### PR TITLE
fix(ci): update live workspace smoke assertion

### DIFF
--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -127,15 +127,17 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     const response = await page.goto(BASE_URL + "/workspace/w/acme-ai?tab=brief");
     expect(response?.status()).toBe(200);
     // Chromeless shell — no cockpit rails, no top nav, no bottom tabbar.
-    // Assert the workspace mounted and kept the no-fixture-fallback contract.
-    await expect(page.getByRole("heading", { name: /Workspace draft/i })).toBeVisible({
+    // Assert the standalone workspace mounted for the requested report id.
+    await expect(page.getByRole("heading", { name: "acme-ai" })).toBeVisible({
       timeout: 15_000,
     });
     // Brand-aware: the product lock docs say "Workspace" should appear in the
     // chromeless header; this also proves the route didn't fall through to
     // the cockpit layout.
     await expect(page.getByText(/Workspace/i).first()).toBeVisible();
-    await expect(page.getByText(/No fixture fallback/i)).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Brief", selected: true })).toBeVisible();
+    await expect(page.getByText(/Live artifact/i)).toBeVisible();
+    await expect(page.getByText(/Report shell loaded/i)).toBeVisible();
   });
 
   test("console has no uncaught errors during landing load", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update the live workspace smoke assertion to match the current deployed workspace shell.
- Keep the scheduled Post-Deploy Verify signal focused on hydration, standalone workspace routing, selected tab state, and live-shell content.

## Root cause
Scheduled Post-Deploy Verify was consistently red because `tests/e2e/live-smoke.spec.ts` still expected obsolete workspace copy: a heading named `Workspace draft` and text `No fixture fallback`. Production now renders the standalone workspace route with the requested report id as the h1 (`acme-ai`) and live shell content (`Live artifact`, `Report shell loaded`). The app route was healthy; the smoke assertion was stale.

## Verification
- `npx playwright test tests/e2e/live-smoke.spec.ts --project=chromium --workers=1 --grep workspace/w --reporter=list`
- `npm run post-deploy:verify:json`

Supersedes draft PR #514, which used the wrong branch/title style.