### PR TITLE
fix(ai-elements): prevent code token cache collisions

### DIFF
--- a/src/components/ai-elements/code-block.test.tsx
+++ b/src/components/ai-elements/code-block.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("shiki", () => ({
+  createHighlighter: vi.fn(async () => ({
+    getLoadedLanguages: () => ["typescript"],
+    codeToTokens: (code: string) => ({
+      bg: "transparent",
+      fg: "inherit",
+      tokens: [[{ color: "inherit", content: code }]],
+    }),
+  })),
+}));
+
+import { highlightCode } from "./code-block";
+
+type HighlightResult = NonNullable<ReturnType<typeof highlightCode>>;
+
+const resolveHighlight = (code: string): Promise<HighlightResult> =>
+  new Promise((resolve) => {
+    const immediate = highlightCode(code, "typescript", resolve);
+    if (immediate) {
+      resolve(immediate);
+    }
+  });
+
+const renderedText = (result: HighlightResult) =>
+  result.tokens.flat().map((token) => token.content).join("");
+
+describe("highlightCode token cache", () => {
+  it("does not reuse tokens for equal-length snippets with matching edges", async () => {
+    const prefix = "p".repeat(100);
+    const suffix = "s".repeat(100);
+    const firstCode = `${prefix}const x = 1;${suffix}`;
+    const secondCode = `${prefix}const y = 2;${suffix}`;
+
+    expect(firstCode).toHaveLength(secondCode.length);
+
+    const first = await resolveHighlight(firstCode);
+    const second = await resolveHighlight(secondCode);
+
+    expect(renderedText(first)).toBe(firstCode);
+    expect(renderedText(second)).toBe(secondCode);
+  });
+});

--- a/src/components/ai-elements/code-block.tsx
+++ b/src/components/ai-elements/code-block.tsx
@@ -142,9 +142,11 @@ const tokensCache = new Map<string, TokenizedCode>();
 const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>();
 
 const getTokensCacheKey = (code: string, language: BundledLanguage) => {
-  const start = code.slice(0, 100);
-  const end = code.length > 100 ? code.slice(-100) : "";
-  return `${language}:${code.length}:${start}:${end}`;
+  // The rendered tokens must be keyed by the complete source. A truncated
+  // prefix/suffix fingerprint can collide for equal-length snippets that only
+  // differ in the middle, which makes the UI display cached code that does not
+  // match the source passed to the Copy action.
+  return `${language}\0${code}`;
 };
 
 const getHighlighter = (


### PR DESCRIPTION
## What changed

- key Shiki token-cache entries by the complete language + source pair
- add a regression for equal-length snippets with identical 100-character edges and different middle content

## Why

The AI Elements code-block cache used language, length, and truncated source edges as its identity. Two distinct snippets could therefore share a cache entry, making the rendered code show stale tokens while Copy used the new source. This is silent content corruption on the live FastAgentPanel Markdown path introduced by PR #516.

## Verification

- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npx vitest run src/features/agents/components/FastAgentPanel/__tests__/` (89 passed)
- `npx vitest run src/components/ai-elements/code-block.test.tsx src/design/designSystem.test.ts` (12 passed)
- `npm run lint:design` (0 high)
- `npm run build`