### PR TITLE
fix(ci): make release verification fail closed

### DIFF
--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -20,16 +20,9 @@ concurrency:
 
 jobs:
   verify:
-    # On deployment_status events, only run when state is success (skip pending,
-    # failure, in_progress). The PRIOR if-clause also tried to skip Preview URLs
-    # without a bypass secret using `vars.VERCEL_AUTOMATION_BYPASS_SECRET_PRESENT`,
-    # but that var drifted out of sync with `secrets.VERCEL_AUTOMATION_BYPASS_SECRET`
-    # and false-failed every dependabot PR's preview deploy with HTTP 401 SSO.
-    #
-    # The robust fix lives in scripts/post-deploy-verify.mjs: when running against
-    # a Vercel preview URL (*.vercel.app) with no bypass secret in env, the script
-    # now skips cleanly (exit 0 with skipped=true) instead of throwing 401. That
-    # safety net works regardless of the var/secret sync state.
+    # On deployment_status events, only run when state is success. Production
+    # events are verified through the canonical public hostname; only known
+    # Preview environments may explicitly skip when SSO has no bypass secret.
     if: |
       github.event_name != 'deployment_status' ||
       github.event.deployment_status.state == 'success'
@@ -51,19 +44,32 @@ jobs:
 
       - name: Resolve URL
         id: url
+        env:
+          DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment }}
+          DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
+          DISPATCH_URL: ${{ github.event.inputs.url }}
         run: |
+          ALLOW_PREVIEW_SKIP=false
           if [ "${{ github.event_name }}" = "deployment_status" ]; then
-            URL="${{ github.event.deployment_status.environment_url }}"
+            if [ "${DEPLOYMENT_ENVIRONMENT,,}" = "production" ]; then
+              URL="https://www.nodebenchai.com"
+            else
+              URL="$DEPLOYMENT_URL"
+              ALLOW_PREVIEW_SKIP=true
+            fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            URL="${{ github.event.inputs.url }}"
+            URL="$DISPATCH_URL"
           else
             URL="https://www.nodebenchai.com"
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "allow_preview_skip=$ALLOW_PREVIEW_SKIP" >> "$GITHUB_OUTPUT"
+          echo "Verifying deployment environment '${DEPLOYMENT_ENVIRONMENT:-scheduled/manual}' at $URL"
 
       - name: Verify deployed app
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          ALLOW_PROTECTED_PREVIEW_SKIP: ${{ steps.url.outputs.allow_preview_skip }}
         run: node scripts/post-deploy-verify.mjs --url=${{ steps.url.outputs.url }} --json > post-deploy-result.json
 
       - name: Upload result

--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -127,8 +127,10 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.event.inputs.head_sha || github.sha }}
-          GITHUB_REF: ${{ github.event.pull_request.head.ref || github.event.inputs.head_ref || github.ref_name }}
+          # GITHUB_SHA and GITHUB_REF are reserved runner variables and cannot be
+          # overridden reliably. Keep the Vercel lookup inputs under distinct names.
+          VERCEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.inputs.head_sha || github.sha }}
+          VERCEL_HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.inputs.head_ref || github.ref_name }}
           OVERRIDE_URL: ${{ github.event.inputs.preview_url }}
         run: |
           if [ -n "$OVERRIDE_URL" ]; then
@@ -144,53 +146,38 @@ jobs:
           # Poll for up to ~10 min for a Vercel preview deployment matching this PR.
           #
           # The query strategy went through two iterations:
-          #   v1 (broken): filter by meta-githubCommitSha=$GITHUB_SHA. After
+          #   v1 (broken): filter by the runner's merge SHA. After
           #     update-branch / merge-commit injection, the SHA Vercel records
           #     can drift from the PR head SHA → false-fail timeouts.
-          #   v2 (this version): filter by meta-githubCommitRef=$GITHUB_REF
-          #     (branch name) which is stable across rebases/merges. Then among
-          #     deployments for the branch, prefer the one matching the exact
-          #     SHA, otherwise fall back to the most recent terminal-state one.
+          #   v2 (this version): filter by meta-githubCommitRef using the explicit
+          #     PR head ref, then require the deployment's metadata to match the
+          #     explicit PR head SHA exactly.
           #
-          # Three terminal states we look for:
-          #   READY    → preview is built, run Tier B against the URL
-          #   CANCELED → Vercel's `vercel-ignore-build.sh` decided this commit
-          #              has no servable change (CRLF-only renormalize PRs are
-          #              byte-equivalent to main on Linux). Skip Tier B — there
-          #              is nothing to test against a preview that doesn't exist
-          #              by design.
-          #   ERROR    → Vercel build failed. Surface as Tier B failure so the
-          #              upstream deploy issue isn't masked.
-          #
-          # If no terminal-state deployment for this branch exists after 10 min,
-          # we treat it as "Vercel never built anything for this branch" → skip
-          # green (matches Vercel's own ignore-build decision).
+          # Only READY for the exact PR head SHA is acceptable here. The changed-
+          # file step already handles proven non-shipping diffs, so CANCELED,
+          # ERROR, API errors, and resolver timeouts fail closed.
           deadline=$(( $(date +%s) + 600 ))
           # URL-encode the branch ref. Branches with "/" in the name (refactor/X,
           # fix/Y, test/Z) require encoding — without it, Vercel's API treats
           # the query as an empty match, returns no deployments, and the loop
-          # below burns the full 10-min deadline to skip-green. With encoding,
+          # below burns the full 10-min deadline before failing. With encoding,
           # the API returns the actual deployment within seconds.
           # (jq is preinstalled on ubuntu-latest GitHub runners.)
-          encoded_ref=$(printf '%s' "$GITHUB_REF" | jq -sRr @uri)
+          encoded_ref=$(printf '%s' "$VERCEL_HEAD_REF" | jq -sRr @uri)
           while [ "$(date +%s)" -lt "$deadline" ]; do
             # Query by branch name (stable) AND limit=20 to catch the latest few
             # deployments on this branch even if Vercel created multiple builds.
-            payload=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+            payload=$(curl -fsS -H "Authorization: Bearer $VERCEL_TOKEN" \
               "https://api.vercel.com/v6/deployments?teamId=$VERCEL_TEAM_ID&projectId=$VERCEL_PROJECT_ID&meta-githubCommitRef=$encoded_ref&limit=20&target=preview")
-            result=$(GITHUB_SHA="$GITHUB_SHA" node -e "
+            result=$(VERCEL_HEAD_SHA="$VERCEL_HEAD_SHA" node -e "
               let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>{
                 try {
                   const j = JSON.parse(s);
-                  const sha = process.env.GITHUB_SHA || '';
-                  const deployments = j.deployments || [];
-                  const isTerminal = (d) => {
-                    const st = d.readyState || d.state;
-                    return st === 'READY' || st === 'CANCELED' || st === 'ERROR';
-                  };
-                  // Prefer the deployment whose meta.githubCommitSha matches.
-                  // Otherwise pick the most-recent terminal deployment for the branch
-                  // (Vercel may have rebuilt with a different SHA after rebase/merge).
+                  const sha = process.env.VERCEL_HEAD_SHA || '';
+                  if (!Array.isArray(j.deployments)) {
+                    throw new Error(j.error?.message || 'deployments array missing');
+                  }
+                  const deployments = j.deployments;
                   const state = (d) => d.readyState || d.state;
                   const exactReady = deployments.find(d => {
                     const m = d.meta || {};
@@ -200,26 +187,23 @@ jobs:
                     const m = d.meta || {};
                     return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'ERROR';
                   });
-                  // If the latest exact SHA was ignored because it is docs-only
-                  // but the branch already has a READY preview from the previous
-                  // app commit, run against that preview instead of skipping.
-                  const branchReady = deployments.find(d => state(d) === 'READY');
                   const exactCanceled = deployments.find(d => {
                     const m = d.meta || {};
                     return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'CANCELED';
                   });
-                  const branchError = deployments.find(d => state(d) === 'ERROR');
-                  const branchCanceled = deployments.find(d => state(d) === 'CANCELED');
-                  const dep = exactReady || exactError || branchReady || exactCanceled || branchError || branchCanceled;
+                  const dep = exactReady || exactError || exactCanceled;
                   if (dep) {
                     const st = state(dep);
                     if (st === 'READY') console.log('READY:https://' + dep.url);
                     else if (st === 'CANCELED') console.log('CANCELED:vercel-marked-ignored');
                     else if (st === 'ERROR') console.log('ERROR:vercel-build-failed');
                   }
-                } catch(e) {}
+                } catch(e) {
+                  console.error('Invalid Vercel deployments response:', e instanceof Error ? e.message : e);
+                  process.exitCode = 2;
+                }
               });
-            ")
+            " <<< "$payload")
             if [[ "$result" == READY:* ]]; then
               url="${result#READY:}"
               echo "Preview ready: $url"
@@ -228,9 +212,8 @@ jobs:
               exit 0
             fi
             if [[ "$result" == CANCELED:* ]]; then
-              echo "::notice::Vercel marked this deploy as Ignored — vercel-ignore-build.sh decided no servable change. Skipping Tier B (no preview to test)."
-              echo "preview_status=skipped" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "::error::Vercel canceled the exact build-relevant head SHA. Tier B cannot verify this shipping change."
+              exit 1
             fi
             if [[ "$result" == ERROR:* ]]; then
               echo "::error::Vercel preview build failed for this branch. Tier B can't run against a failed deploy. Investigate the Vercel build log."
@@ -238,13 +221,9 @@ jobs:
             fi
             sleep 15
           done
-          # No terminal-state deployment found for this branch after 10 min.
-          # Most likely: Vercel never built anything (vercel-ignore-build.sh
-          # filter or rate-limit). Treat as skip-green — same outcome as if
-          # Vercel had explicitly returned CANCELED.
-          echo "::notice::No Vercel preview deployment found for branch '$GITHUB_REF' after 10min. Treating as skip — Vercel did not build a preview (likely vercel-ignore-build.sh decided no servable change, or rate-limited)."
-          echo "preview_status=skipped" >> "$GITHUB_OUTPUT"
-          exit 0
+          # A build-relevant PR without an exact-head deployment is unverifiable.
+          echo "::error::No exact-head preview deployment found for branch '$VERCEL_HEAD_REF' at SHA '$VERCEL_HEAD_SHA' after 10min."
+          exit 1
 
       - name: Install Playwright browsers
         if: steps.preview.outputs.preview_status == 'ready'
@@ -255,6 +234,12 @@ jobs:
         run: |
           echo "preview_status=${{ steps.preview.outputs.preview_status || 'not_resolved' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "preview_url=${{ steps.preview.outputs.url || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require resolved preview for shipping changes
+        if: always() && steps.relevant.outputs.has_relevant == 'true' && steps.preview.outputs.preview_status != 'ready'
+        run: |
+          echo "::error::Build-relevant change did not produce a real READY preview; Tier B fails closed."
+          exit 1
 
       - name: Run Tier B regression + one-flow regression against preview
         if: steps.preview.outputs.preview_status == 'ready'

--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,6 +57,22 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
+- **2026-07-14 · Codex release captain →** `.github/workflows/tier-b-preview.yml`,
+  `.github/workflows/post-deploy-verify.yml`, `scripts/post-deploy-verify.mjs`,
+  `tests/e2e/live-smoke.spec.ts`, release runbooks, and final migration governance/proof ·
+  repair fail-closed release truth and own the serial merge/deploy train · branch
+  `codex/ai-elements-release`.
+- **2026-07-14 · Codex message lane →**
+  `src/features/agents/components/FastAgentPanel/adapters/*`, direct message contract tests,
+  and `FastAgentPanel.UIMessageBubble.tsx` · build the identity-preserving Convex-to-AI-parts
+  adapter and the live bubble wrap · branch `codex/ai-elements-message`.
+- **2026-07-14 · Codex tools lane →** `CollapsibleAgentProgress.tsx`,
+  `ToolCallTransparency.tsx`, `LiveEventCard.tsx`, and their dedicated tests · migrate the
+  reasoning/tool leaves with honest reachability · branch `codex/ai-elements-tools`.
+- **2026-07-14 · Codex composer lane →** `FastAgentPanel.InputBar.tsx`, its direct tests,
+  and the minimal `FastAgentPanel.tsx` send-forwarding seam · preserve every composer
+  callback while wrapping the live input · branch `codex/ai-elements-composer`.
+
 - **2026-06-03 · Claude →** `convex/*#handoff-token`, `src/.../ScratchnodePrivateBridge`,
   `src/App.tsx#events-private-route`, `public/proto/home-v5.html#private-handoff` ·
   shipping the cross-domain private-notes token bridge (opaque stateful token, PR #496) ·

--- a/docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md
+++ b/docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md
@@ -121,8 +121,14 @@ After merge:
 
 ```powershell
 git fetch origin main
-npm run deploy:convex
+$run = gh run list --workflow "Convex Deploy" --branch main --limit 1 --json databaseId,status,conclusion,url | ConvertFrom-Json
+$run
+if ($run.databaseId) { gh run watch $run.databaseId --exit-status }
 ```
+
+Never run `npm run deploy:convex`, `npx convex deploy`, or `deploy:prod`
+out-of-band against the shared production deployment. The reviewed `main` workflow is
+the only release path; monitor it and stop on failure.
 
 Verify production:
 

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "../..");
+const readRepoFile = (path: string) => readFileSync(resolve(root, path), "utf8");
+
+describe("release workflow contracts", () => {
+  it("resolves an exact PR-head Vercel preview and fails closed", () => {
+    const workflow = readRepoFile(".github/workflows/tier-b-preview.yml");
+
+    expect(workflow).toContain("VERCEL_HEAD_REF:");
+    expect(workflow).toContain("VERCEL_HEAD_SHA:");
+    expect(workflow).not.toMatch(/^\s+GITHUB_REF:/m);
+    expect(workflow).not.toMatch(/^\s+GITHUB_SHA:/m);
+    expect(workflow).toContain('<<< "$payload"');
+    expect(workflow).toContain("exactReady || exactError || exactCanceled");
+    expect(workflow).toContain("Require resolved preview for shipping changes");
+    expect(workflow).not.toContain('preview_status=skipped" >> "$GITHUB_OUTPUT"');
+  });
+
+  it("verifies Production through the canonical public hostname", () => {
+    const workflow = readRepoFile(".github/workflows/post-deploy-verify.yml");
+    const script = readRepoFile("scripts/post-deploy-verify.mjs");
+
+    expect(workflow).toContain('${DEPLOYMENT_ENVIRONMENT,,}');
+    expect(workflow).toContain('URL="https://www.nodebenchai.com"');
+    expect(workflow).toContain("ALLOW_PROTECTED_PREVIEW_SKIP:");
+    expect(script).toContain("allowProtectedPreviewSkip");
+    expect(script).toContain(
+      "isVercelPreview && !vercelBypassSecret && allowProtectedPreviewSkip",
+    );
+  });
+});

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -15,6 +15,9 @@ const args = process.argv.slice(2).reduce((acc, arg) => {
 const url = String(args.url ?? process.env.PROD_URL ?? "https://www.nodebenchai.com").replace(/\/$/, "");
 const skips = new Set(String(args.skip ?? "").split(",").filter(Boolean));
 const jsonOut = Boolean(args.json);
+const allowProtectedPreviewSkip =
+  args["allow-protected-preview-skip"] === true ||
+  String(args["allow-protected-preview-skip"] ?? process.env.ALLOW_PROTECTED_PREVIEW_SKIP ?? "") === "true";
 
 function run(cmd, cmdArgs, env = {}) {
   const started = Date.now();
@@ -80,15 +83,14 @@ async function fetchHtml() {
  * Vercel preview deployments are SSO-protected by default. When this script
  * runs against a preview URL without a bypass secret configured, every check
  * will hit HTTP 401 — but that's a misconfiguration of the workflow, not a
- * regression of the deployed app. Treat it as a clean skip (exit 0) so the
- * Post-Deploy Verify check stops false-failing on every dependabot PR.
+ * regression of the deployed app. A known Preview event may explicitly opt in
+ * to a recorded skip; every other invocation fails closed.
  *
- * The workflow's `if:` clause is supposed to gate this, but it depends on
- * `vars.VERCEL_AUTOMATION_BYPASS_SECRET_PRESENT` being kept in sync with the
- * actual secret state. This script-level guard is the safety net — if the var
- * drifts from reality, we skip cleanly instead of failing every CI run.
+ * Skipping must be explicitly authorized for a known Preview deployment. A
+ * generated production *.vercel.app URL must never silently skip all checks.
  */
-const shouldSkipPreviewWithoutBypass = isVercelPreview && !vercelBypassSecret;
+const shouldSkipPreviewWithoutBypass =
+  isVercelPreview && !vercelBypassSecret && allowProtectedPreviewSkip;
 
 function tail(text, lines = 18) {
   return text.split("\n").slice(-lines).join("\n").trim();
@@ -177,7 +179,13 @@ if (shouldSkipPreviewWithoutBypass) {
 }
 
 const failed = results.filter((result) => !result.ok).length;
-const summary = { url, failed, firstFailure, results };
+const summary = {
+  url,
+  failed,
+  firstFailure,
+  explicitPreviewSkipAllowed: allowProtectedPreviewSkip,
+  results,
+};
 
 if (jsonOut) {
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);


### PR DESCRIPTION
## What changed

- resolves Vercel previews with explicit PR-head variables instead of reserved runner `GITHUB_REF` / `GITHUB_SHA`
- requires an exact-head READY preview for build-relevant changes and fails on cancellation, API errors, or timeout
- feeds the Vercel API payload into the resolver (the previous parser read empty stdin)
- verifies Production deployment events through `https://www.nodebenchai.com`
- allows protected-preview skips only when the workflow explicitly identifies a Preview environment
- updates the release runbook to monitor the reviewed Convex Deploy workflow instead of deploying locally
- records the overnight AI Elements lane claims

## Root cause

The Tier B resolver attempted to override reserved GitHub runner variables and never piped its API response into the Node parser, so shipping PRs could wait ten minutes and skip-green. Post-Deploy Verify classified every generated `*.vercel.app` URL as a protected preview, including Production deployment URLs, and could skip every verification step.

## Validation

- `npx vitest run scripts/__tests__/releaseWorkflowContracts.test.ts` (2/2)
- `node --check scripts/post-deploy-verify.mjs`
- Prettier workflow check
- app and Convex typechecks
- FastAgentPanel suite: 89 passed / 19 skipped
- design system: 11/11; `lint:design` High 0
- `npm run build`
- canonical production post-deploy HTML + Tier A verified locally