### PR TITLE
fix(ci): authenticate protected Tier B previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           convex/__tests__/scratchnode.events.test.ts
           server/searchRoute.test.ts
           convex/workflows/ainewsBriefFormat.test.ts
+          scripts/__tests__/releaseWorkflowContracts.test.ts
 
   scratchnode-launch-gates:
     name: ScratchNode launch gates
@@ -109,6 +110,7 @@ jobs:
       - name: Verify demo route gate and live route honesty
         run: >
           npx playwright test
+          tests/e2e/vercel-preview-security.spec.ts
           tests/e2e/scratchnode-demo-route-gate.spec.ts
           tests/e2e/scratchnode-live-route-honesty.spec.ts
           --project=chromium

--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -245,11 +245,16 @@ jobs:
         if: steps.preview.outputs.preview_status == 'ready'
         env:
           BASE_URL: ${{ steps.preview.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           echo "BASE_URL=$BASE_URL"
+          if [ -z "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is required to test the protected READY preview."
+            exit 1
+          fi
           # exact-kit-parity-prod: visual selector parity (per-PR canonical-component check)
           # one-flow-regression: full surface tour + A9 fallback + interactive chip behavior
-          npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts tests/e2e/one-flow-regression.spec.ts --project=chromium --reporter=line
+          npx playwright test tests/e2e/vercel-preview-security.spec.ts tests/e2e/exact-kit-parity-prod.spec.ts tests/e2e/one-flow-regression.spec.ts --project=chromium --reporter=line
 
       - name: Upload Playwright artifacts on failure
         if: failure()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,44 +1,59 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 const htmlReporterOutputFolder = process.env.PLAYWRIGHT_HTML_OUTPUT_FOLDER;
 const jsonReporterOutputFile = process.env.PLAYWRIGHT_JSON_OUTPUT_FILE;
+const baseURL = process.env.BASE_URL || "http://localhost:5173";
+const nonemptyBypassSecret =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
 
 const reporter = [
-  ...(htmlReporterOutputFolder === 'off'
+  ...(htmlReporterOutputFolder === "off"
     ? []
-    : [['html', { outputFolder: htmlReporterOutputFolder || 'playwright-report' }] as const]),
-  ['list'] as const,
-  ...(jsonReporterOutputFile === 'off'
+    : [
+        [
+          "html",
+          { outputFolder: htmlReporterOutputFolder || "playwright-report" },
+        ] as const,
+      ]),
+  ["list"] as const,
+  ...(jsonReporterOutputFile === "off"
     ? []
-    : [['json', { outputFile: jsonReporterOutputFile || 'test-results.json' }] as const]),
+    : [
+        [
+          "json",
+          { outputFile: jsonReporterOutputFile || "test-results.json" },
+        ] as const,
+      ]),
 ];
 
 export default defineConfig({
-  testDir: './tests/e2e',
+  testDir: "./tests/e2e",
   timeout: 30 * 1000,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter,
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:5173',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    baseURL,
+    // Playwright traces include request metadata. Never persist a trace while
+    // the protected-preview secret is attached to origin-scoped requests.
+    trace: nonemptyBypassSecret ? "off" : "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
     actionTimeout: 10000,
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
   // NOTE: Tests expect dev server to be running manually

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -3,7 +3,8 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = resolve(import.meta.dirname, "../..");
-const readRepoFile = (path: string) => readFileSync(resolve(root, path), "utf8");
+const readRepoFile = (path: string) =>
+  readFileSync(resolve(root, path), "utf8");
 
 describe("release workflow contracts", () => {
   it("resolves an exact PR-head Vercel preview and fails closed", () => {
@@ -16,19 +17,63 @@ describe("release workflow contracts", () => {
     expect(workflow).toContain('<<< "$payload"');
     expect(workflow).toContain("exactReady || exactError || exactCanceled");
     expect(workflow).toContain("Require resolved preview for shipping changes");
-    expect(workflow).not.toContain('preview_status=skipped" >> "$GITHUB_OUTPUT"');
+    expect(workflow).not.toContain(
+      'preview_status=skipped" >> "$GITHUB_OUTPUT"',
+    );
   });
 
   it("verifies Production through the canonical public hostname", () => {
     const workflow = readRepoFile(".github/workflows/post-deploy-verify.yml");
     const script = readRepoFile("scripts/post-deploy-verify.mjs");
 
-    expect(workflow).toContain('${DEPLOYMENT_ENVIRONMENT,,}');
+    expect(workflow).toContain("${DEPLOYMENT_ENVIRONMENT,,}");
     expect(workflow).toContain('URL="https://www.nodebenchai.com"');
     expect(workflow).toContain("ALLOW_PROTECTED_PREVIEW_SKIP:");
     expect(script).toContain("allowProtectedPreviewSkip");
     expect(script).toContain(
       "isVercelPreview && !vercelBypassSecret && allowProtectedPreviewSkip",
+    );
+  });
+
+  it("authenticates Tier B to protected previews without tracing the secret", () => {
+    const workflow = readRepoFile(".github/workflows/tier-b-preview.yml");
+    const ci = readRepoFile(".github/workflows/ci.yml");
+    const playwright = readRepoFile("playwright.config.ts");
+    const previewHelper = readRepoFile("tests/e2e/helpers/vercelPreview.ts");
+    const securitySpec = readRepoFile(
+      "tests/e2e/vercel-preview-security.spec.ts",
+    );
+
+    expect(workflow).toContain(
+      "VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
+    );
+    expect(workflow).toContain(
+      "VERCEL_AUTOMATION_BYPASS_SECRET is required to test the protected READY preview",
+    );
+    expect(workflow).toContain("tests/e2e/vercel-preview-security.spec.ts");
+    expect(ci).toContain("scripts/__tests__/releaseWorkflowContracts.test.ts");
+    expect(ci).toContain("tests/e2e/vercel-preview-security.spec.ts");
+    expect(playwright).not.toContain("extraHTTPHeaders");
+    expect(playwright).not.toContain('baseURL.endsWith(".vercel.app")');
+    expect(playwright).toContain(
+      "process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim()",
+    );
+    expect(previewHelper).not.toContain("page.route");
+    expect(previewHelper).not.toContain("route.continue");
+    expect(previewHelper).not.toContain("setExtraHTTPHeaders");
+    expect(previewHelper).not.toContain("Network.setExtraHTTPHeaders");
+    expect(previewHelper).toContain("newCDPSession");
+    expect(previewHelper).toContain('session.on("Fetch.requestPaused"');
+    expect(previewHelper).toContain('session.send("Fetch.continueRequest"');
+    expect(previewHelper).toContain('session.send("Fetch.enable"');
+    expect(previewHelper).toContain("requestOrigin !== scopedOrigin");
+    expect(previewHelper).toContain('"x-vercel-protection-bypass"');
+    expect(previewHelper).toContain('"x-vercel-skip-toolbar"');
+    expect(previewHelper).not.toContain('"x-vercel-set-bypass-cookie"');
+    expect(securitySpec).toContain("installOriginScopedCDPHeaders");
+    expect(securitySpec).toContain("redirects from origin A to origin B");
+    expect(playwright).toContain(
+      'trace: nonemptyBypassSecret ? "off" : "on-first-retry"',
     );
   });
 });

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -5,26 +5,49 @@
  */
 
 import { test, expect } from "@playwright/test";
+import {
+  expectAvatarPulseContract,
+  readAvatarPulseMetrics,
+} from "./helpers/avatarPulse";
+import { installVercelPreviewBypass } from "./helpers/vercelPreview";
 
 const BASE_URL =
   process.env.BASE_URL?.replace(/\/$/, "") ?? "https://www.nodebenchai.com";
 
-async function navigate(page: import("@playwright/test").Page, surface: string) {
-  await page.goto(`${BASE_URL}/?surface=${surface}`, { waitUntil: "networkidle", timeout: 30_000 });
+test.beforeEach(async ({ page }) => {
+  await installVercelPreviewBypass(page, BASE_URL);
+});
+
+async function navigate(
+  page: import("@playwright/test").Page,
+  surface: string,
+) {
+  await page.goto(`${BASE_URL}/?surface=${surface}`, {
+    waitUntil: "networkidle",
+    timeout: 30_000,
+  });
   await page.waitForTimeout(5000);
 }
 
 test("PR A4: Home renders ExactHomeSurface composer hero", async ({ page }) => {
   await navigate(page, "ask");
   const result = await page.evaluate(() => ({
-    composer: !!document.querySelector('[data-testid="exact-web-home-composer"]'),
+    composer: !!document.querySelector(
+      '[data-testid="exact-web-home-composer"]',
+    ),
     kicker: !!Array.from(document.querySelectorAll(".nb-kicker")).find((el) =>
       el.textContent?.toLowerCase().includes("on-the-go intelligence"),
     ),
-    h1: Array.from(document.querySelectorAll(".nb-composer-hero h1")).map((h) => h.textContent?.trim()),
-    lanes: Array.from(document.querySelectorAll(".nb-lane")).map((b) => b.textContent?.trim().slice(0, 20)),
+    h1: Array.from(document.querySelectorAll(".nb-composer-hero h1")).map((h) =>
+      h.textContent?.trim(),
+    ),
+    lanes: Array.from(document.querySelectorAll(".nb-lane")).map((b) =>
+      b.textContent?.trim().slice(0, 20),
+    ),
     asyncProof: !!document.querySelector('[data-testid="home-async-proof"]'),
-    firstImpression: !!document.querySelector('[data-testid="home-first-impression-board"]'),
+    firstImpression: !!document.querySelector(
+      '[data-testid="home-first-impression-board"]',
+    ),
   }));
   console.log("HOME:", JSON.stringify(result, null, 2));
   expect(result.composer).toBe(true);
@@ -38,20 +61,33 @@ test("PR A4: Home renders ExactHomeSurface composer hero", async ({ page }) => {
 test("PR A6: Home renders full kit HomePulse layout", async ({ page }) => {
   await navigate(page, "ask");
   const result = await page.evaluate(() => ({
-    pulseStrip: !!document.querySelector('[data-testid="exact-home-pulse-strip"]'),
+    pulseStrip: !!document.querySelector(
+      '[data-testid="exact-home-pulse-strip"]',
+    ),
     pulseHeroCards: document.querySelectorAll(".nb-pulse-card").length,
     pulseMiniCards: document.querySelectorAll(".nb-pulse-mini").length,
-    todayIntel: !!document.querySelector('[data-testid="exact-home-today-intel"]'),
+    todayIntel: !!document.querySelector(
+      '[data-testid="exact-home-today-intel"]',
+    ),
     todayLanes: document.querySelectorAll(".nb-today-lane").length,
-    activeEvent: !!document.querySelector('[data-testid="exact-home-active-event"]'),
+    activeEvent: !!document.querySelector(
+      '[data-testid="exact-home-active-event"]',
+    ),
     eventStats: document.querySelectorAll(".nb-event-stat").length,
-    recentReports: !!document.querySelector('[data-testid="exact-home-recent-reports"]'),
+    recentReports: !!document.querySelector(
+      '[data-testid="exact-home-recent-reports"]',
+    ),
     recentCards: document.querySelectorAll(".nb-recent-card").length,
   }));
   console.log("HOME PULSE:", JSON.stringify(result, null, 2));
   expect(result.pulseStrip, "PulseStrip section should render").toBe(true);
-  expect(result.pulseHeroCards, "4 hero metric cards").toBeGreaterThanOrEqual(4);
-  expect(result.pulseMiniCards, "6 secondary mini cards").toBeGreaterThanOrEqual(6);
+  expect(result.pulseHeroCards, "4 hero metric cards").toBeGreaterThanOrEqual(
+    4,
+  );
+  expect(
+    result.pulseMiniCards,
+    "6 secondary mini cards",
+  ).toBeGreaterThanOrEqual(6);
   expect(result.todayIntel, "Today's intelligence section").toBe(true);
   expect(result.todayLanes, "4 today lanes").toBeGreaterThanOrEqual(4);
   expect(result.activeEvent, "Active event section").toBe(true);
@@ -60,29 +96,44 @@ test("PR A6: Home renders full kit HomePulse layout", async ({ page }) => {
   expect(result.recentCards, "3 recent report cards").toBeGreaterThanOrEqual(3);
 });
 
-test("PR A8: Chat renders ExactChatSurface ChatStream (full conversation thread)", async ({ page }) => {
+test("PR A8: Chat renders ExactChatSurface ChatStream (full conversation thread)", async ({
+  page,
+}) => {
   await navigate(page, "workspace");
   const result = await page.evaluate(() => ({
-    streamMount: !!document.querySelector('[data-testid="exact-web-chat-stream"]'),
-    liveStatus: document.querySelector('[data-testid="exact-web-chat-stream"]')?.getAttribute("data-chat-live-status"),
-    liveEligible: document.querySelector('[data-testid="exact-web-chat-stream"]')?.getAttribute("data-chat-live-eligible"),
-    noFixtureText: document.body.textContent?.includes("no fixture answer loaded"),
-    contextRuntimeText: document.body.textContent?.includes("Context Runtime") || document.body.textContent?.includes("ContextRuntimePacket"),
+    streamMount: !!document.querySelector(
+      '[data-testid="exact-web-chat-stream"]',
+    ),
+    liveStatus: document
+      .querySelector('[data-testid="exact-web-chat-stream"]')
+      ?.getAttribute("data-chat-live-status"),
+    liveEligible: document
+      .querySelector('[data-testid="exact-web-chat-stream"]')
+      ?.getAttribute("data-chat-live-eligible"),
+    noFixtureText: document.body.textContent?.includes(
+      "no fixture answer loaded",
+    ),
+    contextRuntimeText:
+      document.body.textContent?.includes("Context Runtime") ||
+      document.body.textContent?.includes("ContextRuntimePacket"),
     streamRoot: !!document.querySelector(".nb-stream-root"),
     threadHeader: !!document.querySelector(".nb-stream-header h2"),
     headerTitle: document.querySelector(".nb-stream-header h2")?.textContent,
     saveBar: !!document.querySelector(".nb-stream-savebar"),
-    saveBarReportName: document.querySelector(".nb-stream-savebar strong")?.textContent,
+    saveBarReportName: document.querySelector(".nb-stream-savebar strong")
+      ?.textContent,
     fresh: !!document.querySelector(".nb-stream-fresh"),
     turns: document.querySelectorAll(".nb-turn").length,
-    userTurns: document.querySelectorAll(".nb-turn[data-role=\"user\"]").length,
-    agentTurns: document.querySelectorAll(".nb-turn[data-role=\"agent\"]").length,
+    userTurns: document.querySelectorAll('.nb-turn[data-role="user"]').length,
+    agentTurns: document.querySelectorAll('.nb-turn[data-role="agent"]').length,
     runBars: document.querySelectorAll(".nb-runbar").length,
     runUpdates: document.querySelectorAll(".nb-runup").length,
     entityPills: document.querySelectorAll(".nb-epill").length,
     followupChips: document.querySelectorAll(".nb-followup-chip").length,
     composerCard: !!document.querySelector(".nb-composer-card"),
-    goldenComposer: !!document.querySelector('[data-exact-composer="golden"][data-exact-composer-version="2026-05-02"]'),
+    goldenComposer: !!document.querySelector(
+      '[data-exact-composer="golden"][data-exact-composer-version="2026-05-02"]',
+    ),
     composerPin: !!document.querySelector(".nb-composer-pins .nb-pin"),
     composerInput: !!document.querySelector(".nb-composer-input"),
     composerSendButton: !!document.querySelector(".nb-composer-send"),
@@ -92,14 +143,19 @@ test("PR A8: Chat renders ExactChatSurface ChatStream (full conversation thread)
   console.log("CHAT STREAM:", JSON.stringify(result, null, 2));
   expect(result.streamMount, "ChatStream mount").toBe(true);
   expect(result.liveStatus, "live run status marker").toBeTruthy();
-  expect(result.noFixtureText, "chat starts from honest live-ready state").toBe(true);
+  expect(result.noFixtureText, "chat starts from honest live-ready state").toBe(
+    true,
+  );
   expect(result.contextRuntimeText, "Context Runtime copy").toBe(true);
   expect(result.streamRoot).toBe(true);
   expect(result.threadHeader).toBe(true);
   expect(result.headerTitle).toContain("Live Context Runtime");
   expect(result.saveBar, "Save bar").toBe(true);
   expect(result.saveBarReportName).toContain("NodeBench live runtime");
-  expect(result.turns, "at least the live-ready agent turn").toBeGreaterThanOrEqual(1);
+  expect(
+    result.turns,
+    "at least the live-ready agent turn",
+  ).toBeGreaterThanOrEqual(1);
   expect(result.userTurns).toBeGreaterThanOrEqual(0);
   expect(result.agentTurns).toBeGreaterThanOrEqual(1);
   expect(result.runBars, "agent run bars").toBeGreaterThanOrEqual(1);
@@ -113,51 +169,85 @@ test("PR A8: Chat renders ExactChatSurface ChatStream (full conversation thread)
   expect(result.modelPill, "model route pill").toBe(true);
 });
 
-test("PR A2: Reports renders ExactReportsSurface card grid", async ({ page }) => {
+test("PR A2: Reports renders ExactReportsSurface card grid", async ({
+  page,
+}) => {
   await navigate(page, "reports");
   const result = await page.evaluate(() => ({
     grid: !!document.querySelector(".nb-reports-grid"),
     rcards: document.querySelectorAll(".nb-rcard").length,
-    exactCards: document.querySelectorAll('[data-exact-testid="exact-report-card"]').length,
-    actionRows: document.querySelectorAll('[data-testid="report-card-actions"]').length,
-    launcherGoldenComposer: !!document.querySelector('[data-testid="pipeline-launcher"] [data-exact-composer="golden"]'),
-    launcherModelPill: !!document.querySelector('[data-testid="pipeline-launcher"] .nb-model-trigger'),
+    exactCards: document.querySelectorAll(
+      '[data-exact-testid="exact-report-card"]',
+    ).length,
+    actionRows: document.querySelectorAll('[data-testid="report-card-actions"]')
+      .length,
+    launcherGoldenComposer: !!document.querySelector(
+      '[data-testid="pipeline-launcher"] [data-exact-composer="golden"]',
+    ),
+    launcherModelPill: !!document.querySelector(
+      '[data-testid="pipeline-launcher"] .nb-model-trigger',
+    ),
     launcherModelPillText: document
       .querySelector('[data-testid="pipeline-launcher"] .nb-model-trigger')
       ?.textContent?.trim(),
-    launcherSuggestChips: document.querySelectorAll('[data-testid="pipeline-launcher"] .nb-prompt-chip').length,
+    launcherSuggestChips: document.querySelectorAll(
+      '[data-testid="pipeline-launcher"] .nb-prompt-chip',
+    ).length,
     launcherPlaceholder: document
       .querySelector('[data-testid="pipeline-launcher"] .nb-composer-input')
       ?.getAttribute("placeholder"),
     launcherAddContext: !!Array.from(
-      document.querySelectorAll('[data-testid="pipeline-launcher"] .nb-pin-add'),
+      document.querySelectorAll(
+        '[data-testid="pipeline-launcher"] .nb-pin-add',
+      ),
     ).find((node) => node.textContent?.includes("Add context")),
     launcherFooterMeta: document
       .querySelector('[data-testid="pipeline-launcher"] .nb-composer-meta')
       ?.textContent?.trim(),
     launcherTopModelPins: Array.from(
-      document.querySelectorAll('[data-testid="pipeline-launcher"] .nb-composer-pins .typ'),
-    ).filter((node) => node.textContent?.trim().toLowerCase() === "model").length,
+      document.querySelectorAll(
+        '[data-testid="pipeline-launcher"] .nb-composer-pins .typ',
+      ),
+    ).filter((node) => node.textContent?.trim().toLowerCase() === "model")
+      .length,
   }));
   console.log("REPORTS:", JSON.stringify(result, null, 2));
   expect(result.grid).toBe(true);
   expect(result.rcards).toBeGreaterThan(0);
   expect(result.exactCards).toBeGreaterThan(0);
   expect(result.actionRows).toBeGreaterThan(0);
-  expect(result.launcherGoldenComposer, "Reports uses shared golden composer").toBe(true);
-  expect(result.launcherPlaceholder, "Reports uses golden composer placeholder").toBe(
-    "Ask, capture, paste, upload, or record...",
-  );
-  expect(result.launcherAddContext, "Reports keeps the golden + Add context affordance").toBe(true);
-  expect(result.launcherFooterMeta, "Reports keeps the golden memory/cost footer").toBe(
-    "Memory-first - auto route",
-  );
-  expect(result.launcherModelPill, "Reports model control lives in composer footer").toBe(true);
-  expect(result.launcherModelPillText, "Reports defaults to the route selector").toContain(
-    "Auto balanced",
-  );
-  expect(result.launcherTopModelPins, "Reports does not add a top-row model settings pin").toBe(0);
-  expect(result.launcherSuggestChips, "Reports keeps golden suggestion chips").toBeGreaterThanOrEqual(3);
+  expect(
+    result.launcherGoldenComposer,
+    "Reports uses shared golden composer",
+  ).toBe(true);
+  expect(
+    result.launcherPlaceholder,
+    "Reports uses golden composer placeholder",
+  ).toBe("Ask, capture, paste, upload, or record...");
+  expect(
+    result.launcherAddContext,
+    "Reports keeps the golden + Add context affordance",
+  ).toBe(true);
+  expect(
+    result.launcherFooterMeta,
+    "Reports keeps the golden memory/cost footer",
+  ).toBe("Memory-first - auto route");
+  expect(
+    result.launcherModelPill,
+    "Reports model control lives in composer footer",
+  ).toBe(true);
+  expect(
+    result.launcherModelPillText,
+    "Reports defaults to the route selector",
+  ).toContain("Auto balanced");
+  expect(
+    result.launcherTopModelPins,
+    "Reports does not add a top-row model settings pin",
+  ).toBe(0);
+  expect(
+    result.launcherSuggestChips,
+    "Reports keeps golden suggestion chips",
+  ).toBeGreaterThanOrEqual(3);
   const launcherModelSelect = page
     .locator('[data-testid="pipeline-launcher-model"]')
     .filter({ visible: true });
@@ -169,20 +259,27 @@ test("PR A2: Reports renders ExactReportsSurface card grid", async ({ page }) =>
   ).toContainText("Memory-first - free route");
 });
 
-test("PR A1: Inbox renders ExactInboxSurface single-column rows", async ({ page }) => {
+test("PR A1: Inbox renders ExactInboxSurface single-column rows", async ({
+  page,
+}) => {
   await navigate(page, "nudges");
   const result = await page.evaluate(() => ({
     head: !!document.querySelector(".nb-inbox-head"),
-    filterPills: Array.from(document.querySelectorAll(".nb-inbox-filter button")).map((b) =>
-      (b.textContent ?? "").trim().split(/\s+/)[0],
-    ),
+    filterPills: Array.from(
+      document.querySelectorAll(".nb-inbox-filter button"),
+    ).map((b) => (b.textContent ?? "").trim().split(/\s+/)[0]),
     h1: document.querySelector(".nb-inbox-head h1")?.textContent?.trim(),
     rows: document.querySelectorAll(".nb-ibx-row, .nb-panel").length,
   }));
   console.log("INBOX:", JSON.stringify(result, null, 2));
   expect(result.head).toBe(true);
   expect(result.h1).toBe("Inbox");
-  expect(result.filterPills.slice(0, 4)).toEqual(["All", "Act", "Auto", "Watching"]);
+  expect(result.filterPills.slice(0, 4)).toEqual([
+    "All",
+    "Act",
+    "Auto",
+    "Watching",
+  ]);
 });
 
 test("PR A3: Me renders ExactMeSurface 2-pane sidenav", async ({ page }) => {
@@ -191,9 +288,9 @@ test("PR A3: Me renders ExactMeSurface 2-pane sidenav", async ({ page }) => {
     grid: !!document.querySelector(".nb-me-grid"),
     sidenav: !!document.querySelector(".nb-me-sidenav"),
     profileAvatar: !!document.querySelector(".nb-me-sidenav .av"),
-    sectionGroups: Array.from(document.querySelectorAll(".nb-me-sidenav .section-title")).map((el) =>
-      el.textContent?.trim(),
-    ),
+    sectionGroups: Array.from(
+      document.querySelectorAll(".nb-me-sidenav .section-title"),
+    ).map((el) => el.textContent?.trim()),
   }));
   console.log("ME:", JSON.stringify(result, null, 2));
   expect(result.grid).toBe(true);
@@ -202,22 +299,35 @@ test("PR A3: Me renders ExactMeSurface 2-pane sidenav", async ({ page }) => {
   expect(result.sectionGroups).toEqual(["Account", "Preferences", "Workspace"]);
 });
 
-test("PR A7: Reports card click renders inline detail (no workspace redirect)", async ({ page }) => {
+test("PR A7: Reports card click renders inline detail (no workspace redirect)", async ({
+  page,
+}) => {
   // Direct navigation: ?surface=packets&report=disco should render inline detail
-  await page.goto(`${BASE_URL}/?surface=packets&report=disco`, { waitUntil: "networkidle", timeout: 30_000 });
+  await page.goto(`${BASE_URL}/?surface=packets&report=disco`, {
+    waitUntil: "networkidle",
+    timeout: 30_000,
+  });
   await page.waitForTimeout(5000);
 
   // 1. Confirm we're STILL on the cockpit host, NOT redirected to workspace.nodebenchai.com
   const url1 = page.url();
-  expect(url1, "card-click should NOT redirect to workspace subdomain").not.toContain("workspace.nodebenchai.com");
+  expect(
+    url1,
+    "card-click should NOT redirect to workspace subdomain",
+  ).not.toContain("workspace.nodebenchai.com");
   expect(url1).toContain("surface=packets");
   expect(url1).toContain("report=disco");
 
   // 2. Confirm inline detail shell rendered
   const detail = await page.evaluate(() => ({
-    detailMount: !!document.querySelector('[data-testid="exact-web-report-detail"]'),
-    reportId: document.querySelector('[data-testid="exact-web-report-detail"]')?.getAttribute("data-report-id"),
-    breadcrumbCurrent: document.querySelector(".nb-rdetail-crumb-current")?.textContent,
+    detailMount: !!document.querySelector(
+      '[data-testid="exact-web-report-detail"]',
+    ),
+    reportId: document
+      .querySelector('[data-testid="exact-web-report-detail"]')
+      ?.getAttribute("data-report-id"),
+    breadcrumbCurrent: document.querySelector(".nb-rdetail-crumb-current")
+      ?.textContent,
     title: document.querySelector(".nb-rdetail-title")?.textContent,
     eyebrow: document.querySelector(".nb-rdetail-eyebrow")?.textContent,
     sectionCount: document.querySelectorAll(".nb-rdetail-section").length,
@@ -225,8 +335,8 @@ test("PR A7: Reports card click renders inline detail (no workspace redirect)", 
     quote: !!document.querySelector(".nb-rdetail-quote"),
     backButton: !!document.querySelector(".nb-rdetail-back"),
     liveBadge: !!document.querySelector(".nb-rdetail-live"),
-    askAgentButton: !!Array.from(document.querySelectorAll(".nb-btn")).find((el) =>
-      el.textContent?.toLowerCase().includes("ask agent"),
+    askAgentButton: !!Array.from(document.querySelectorAll(".nb-btn")).find(
+      (el) => el.textContent?.toLowerCase().includes("ask agent"),
     ),
   }));
   console.log("INLINE DETAIL:", JSON.stringify(detail, null, 2));
@@ -234,7 +344,9 @@ test("PR A7: Reports card click renders inline detail (no workspace redirect)", 
   expect(detail.reportId).toBe("disco");
   expect(detail.title).toContain("DISCO");
   expect(detail.sectionCount, "DISCO has 5 sections").toBeGreaterThanOrEqual(5);
-  expect(detail.embeddedCard, "Product & moat embedded company card").toBe(true);
+  expect(detail.embeddedCard, "Product & moat embedded company card").toBe(
+    true,
+  );
   expect(detail.quote, "investment thesis quote").toBe(true);
   expect(detail.backButton).toBe(true);
   expect(detail.liveBadge).toBe(true);
@@ -271,49 +383,68 @@ test("PR A9: Avatar HS button opens kit status panel", async ({ page }) => {
 
   // Click the trigger
   await page.click(".nb-avm-trigger");
-  await page.waitForSelector('[data-testid="exact-avatar-menu"]', { timeout: 10_000 });
+  await page.waitForSelector('[data-testid="exact-avatar-menu"]', {
+    timeout: 10_000,
+  });
   await page.waitForTimeout(500);
 
   const open = await page.evaluate(() => ({
     panel: !!document.querySelector('[data-testid="exact-avatar-menu"]'),
     name: document.querySelector(".nb-avm-name")?.textContent,
     proBadge: document.querySelector(".nb-avm-pro")?.textContent,
-    sectionLabels: Array.from(document.querySelectorAll(".nb-avm-section-label")).map((el) => el.textContent),
+    sectionLabels: Array.from(
+      document.querySelectorAll(".nb-avm-section-label"),
+    ).map((el) => el.textContent),
     pulseTiles: document.querySelectorAll(".nb-avm-pulse").length,
-    pulseValues: Array.from(document.querySelectorAll(".nb-avm-pulse-v")).map((el) => el.textContent),
     watchRows: document.querySelectorAll(".nb-avm-watch-row").length,
     usageBars: document.querySelectorAll(".nb-avm-usage").length,
     upgradeBtn: !!document.querySelector(".nb-avm-upgrade"),
     sessionRows: document.querySelectorAll(".nb-avm-session").length,
     thisMarker: !!document.querySelector(".nb-avm-session-this"),
-    themeOpts: Array.from(document.querySelectorAll(".nb-avm-theme-opt")).map((el) => el.textContent?.trim()),
-    links: Array.from(document.querySelectorAll(".nb-avm-link span:first-of-type")).map((el) => el.textContent),
+    themeOpts: Array.from(document.querySelectorAll(".nb-avm-theme-opt")).map(
+      (el) => el.textContent?.trim(),
+    ),
+    links: Array.from(
+      document.querySelectorAll(".nb-avm-link span:first-of-type"),
+    ).map((el) => el.textContent),
   }));
   console.log("AVATAR (open):", JSON.stringify(open, null, 2));
   expect(open.panel).toBe(true);
   expect(open.name).toBe("Hannah Sato");
   expect(open.proBadge).toBe("PRO");
   expect(open.sectionLabels).toEqual(
-    expect.arrayContaining(["Today's pulse", "Watching · 12 entities", "This month · Pro", "Recent sessions", "Theme"]),
+    expect.arrayContaining([
+      "Today's pulse",
+      "Watching · 12 entities",
+      "This month · Pro",
+      "Recent sessions",
+      "Theme",
+    ]),
   );
-  expect(open.pulseTiles, "3 pulse tiles").toBeGreaterThanOrEqual(3);
-  expect(open.pulseValues).toEqual(expect.arrayContaining(["74%", "38", "91%"]));
+  expect(open.pulseTiles, "3 pulse tiles").toBe(3);
+  expectAvatarPulseContract(await readAvatarPulseMetrics(page));
   expect(open.watchRows, "3 watch rows").toBeGreaterThanOrEqual(3);
   expect(open.usageBars, "3 usage bars").toBeGreaterThanOrEqual(3);
   expect(open.upgradeBtn).toBe(true);
   expect(open.sessionRows, "3 recent sessions").toBeGreaterThanOrEqual(3);
   expect(open.thisMarker).toBe(true);
   expect(open.themeOpts).toEqual(["Light", "Dark"]);
-  expect(open.links).toEqual(expect.arrayContaining(["Settings", "Shortcuts", "Help", "Sign out"]));
+  expect(open.links).toEqual(
+    expect.arrayContaining(["Settings", "Shortcuts", "Help", "Sign out"]),
+  );
 
   // Esc closes
   await page.keyboard.press("Escape");
   await page.waitForTimeout(500);
-  const closed = await page.evaluate(() => !document.querySelector('[data-testid="exact-avatar-menu"]'));
+  const closed = await page.evaluate(
+    () => !document.querySelector('[data-testid="exact-avatar-menu"]'),
+  );
   expect(closed, "Esc closes panel").toBe(true);
 });
 
-test("PR A10: Tier A live wiring graceful fallback when unauthenticated", async ({ page }) => {
+test("PR A10: Tier A live wiring graceful fallback when unauthenticated", async ({
+  page,
+}) => {
   // Anonymous visitor: entities.listEntities returns []. The wired surfaces
   // (PulseStrip, TodayIntel reports-updated lane, RecentReports, Avatar
   // Watching) MUST fall back to seed data so the demo experience is preserved.
@@ -345,7 +476,8 @@ test("PR A10: Tier A live wiring graceful fallback when unauthenticated", async 
   await page.waitForTimeout(500);
   const watching = await page.evaluate(() => ({
     rows: document.querySelectorAll(".nb-avm-watch-row").length,
-    label: document.querySelector(".nb-avm-section-label:not([data-skip])")?.textContent,
+    label: document.querySelector(".nb-avm-section-label:not([data-skip])")
+      ?.textContent,
     names: Array.from(document.querySelectorAll(".nb-avm-watch-name")).map(
       (el) => el.textContent,
     ),

--- a/tests/e2e/helpers/avatarPulse.ts
+++ b/tests/e2e/helpers/avatarPulse.ts
@@ -1,0 +1,67 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface AvatarPulseMetric {
+  label: string;
+  value: string;
+  trend: string;
+}
+
+export async function readAvatarPulseMetrics(
+  page: Page,
+): Promise<AvatarPulseMetric[]> {
+  return page.locator(".nb-avm-pulse").evaluateAll((tiles) =>
+    tiles.map((tile) => ({
+      label: tile.querySelector(".nb-avm-pulse-l")?.textContent?.trim() ?? "",
+      value: tile.querySelector(".nb-avm-pulse-v")?.textContent?.trim() ?? "",
+      trend: tile.querySelector(".nb-avm-pulse-t")?.textContent?.trim() ?? "",
+    })),
+  );
+}
+
+function expectPercent(value: string, label: string): void {
+  expect(value, `${label} renders as an integer percentage`).toMatch(/^\d+%$/);
+  const numericValue = Number.parseInt(value, 10);
+  expect(numericValue, `${label} is at least 0%`).toBeGreaterThanOrEqual(0);
+  expect(numericValue, `${label} does not exceed 100%`).toBeLessThanOrEqual(
+    100,
+  );
+}
+
+/**
+ * Convex metrics replace the kit seed as soon as live aggregates are ready.
+ * Assert the semantic shape of either honest state instead of pinning this
+ * release gate to one deployment's numeric snapshot.
+ */
+export function expectAvatarPulseContract(metrics: AvatarPulseMetric[]): void {
+  expect(
+    metrics,
+    "Today's pulse keeps exactly three named metrics",
+  ).toHaveLength(3);
+  expect(
+    metrics.map(({ label }) => label),
+    "pulse metric order and meaning",
+  ).toEqual(["Memory hits", "Searches saved", "Sources fresh"]);
+  expect(
+    metrics.map(({ value }) => value).every(Boolean),
+    "all pulse values are nonempty",
+  ).toBe(true);
+  expect(
+    metrics.map(({ trend }) => trend).every(Boolean),
+    "all pulse trends are nonempty",
+  ).toBe(true);
+
+  const memoryHits = metrics[0]!;
+  const searchesSaved = metrics[1]!;
+  const sourcesFresh = metrics[2]!;
+  expectPercent(memoryHits.value, memoryHits.label);
+
+  expect(searchesSaved.value, "search count is a non-negative integer").toMatch(
+    /^\d+$/,
+  );
+  expect(
+    Number.parseInt(searchesSaved.value, 10),
+    "search count is non-negative",
+  ).toBeGreaterThanOrEqual(0);
+
+  expectPercent(sourcesFresh.value, sourcesFresh.label);
+}

--- a/tests/e2e/helpers/vercelPreview.ts
+++ b/tests/e2e/helpers/vercelPreview.ts
@@ -1,0 +1,67 @@
+import type { CDPSession, Page } from "@playwright/test";
+
+type HeaderOverrides = Readonly<Record<string, string>>;
+
+function mergeHeaders(
+  requestHeaders: Readonly<Record<string, string>>,
+  overrides: HeaderOverrides,
+): Array<{ name: string; value: string }> {
+  const overriddenNames = new Set(
+    Object.keys(overrides).map((name) => name.toLowerCase()),
+  );
+
+  return [
+    ...Object.entries(requestHeaders)
+      .filter(([name]) => !overriddenNames.has(name.toLowerCase()))
+      .map(([name, value]) => ({ name, value })),
+    ...Object.entries(overrides).map(([name, value]) => ({ name, value })),
+  ];
+}
+
+/**
+ * CDP Fetch header overrides apply to one request only. Redirect requests are
+ * paused again with a new request id, so a hop to another origin receives no
+ * override. Playwright Route overrides cannot provide that guarantee.
+ */
+export async function installOriginScopedCDPHeaders(
+  page: Page,
+  origin: string,
+  headers: HeaderOverrides,
+): Promise<CDPSession> {
+  const scopedOrigin = new URL(origin).origin;
+  const session = await page.context().newCDPSession(page);
+
+  session.on("Fetch.requestPaused", async ({ requestId, request }) => {
+    const requestOrigin = new URL(request.url).origin;
+    if (requestOrigin !== scopedOrigin) {
+      await session.send("Fetch.continueRequest", { requestId });
+      return;
+    }
+
+    await session.send("Fetch.continueRequest", {
+      requestId,
+      headers: mergeHeaders(request.headers, headers),
+    });
+  });
+
+  await session.send("Fetch.enable", {
+    patterns: [{ urlPattern: "*", requestStage: "Request" }],
+  });
+  return session;
+}
+
+export async function installVercelPreviewBypass(
+  page: Page,
+  baseURL: string,
+): Promise<void> {
+  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+  if (!secret) return;
+
+  const previewURL = new URL(baseURL);
+  if (!previewURL.hostname.endsWith(".vercel.app")) return;
+
+  await installOriginScopedCDPHeaders(page, previewURL.origin, {
+    "x-vercel-protection-bypass": secret,
+    "x-vercel-skip-toolbar": "1",
+  });
+}

--- a/tests/e2e/one-flow-regression.spec.ts
+++ b/tests/e2e/one-flow-regression.spec.ts
@@ -6,7 +6,7 @@
  * the sources, explore relationships, and export?"
  *
  * Flow under test:
- *   1. Anonymous visitor lands on Home (?surface=home)
+ *   1. Anonymous visitor lands on canonical Home (?surface=home -> /redesign)
  *   2. Switches to Chat (?surface=chat) — sees seeded thread
  *   3. Source chips render with cached/live badges
  *   4. Switches to Reports (?surface=reports) — sees seeded report grid
@@ -27,20 +27,36 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
+import {
+  expectAvatarPulseContract,
+  readAvatarPulseMetrics,
+} from "./helpers/avatarPulse";
+import { installVercelPreviewBypass } from "./helpers/vercelPreview";
 
 const BASE_URL = process.env.BASE_URL ?? "http://127.0.0.1:4173";
 
-// Surface URL templates
+test.beforeEach(async ({ page }) => {
+  await installVercelPreviewBypass(page, BASE_URL);
+});
+
+// Public surface URLs plus the exact-cockpit compatibility route used by A9.
 const SURFACES = {
   home: "/?surface=home",
   chat: "/?surface=chat",
   reports: "/?surface=reports",
   inbox: "/?surface=inbox",
   me: "/?surface=me",
+  exactHome: "/?surface=ask",
 } as const;
 
-async function goSurface(page: Page, surface: keyof typeof SURFACES): Promise<void> {
-  await page.goto(`${BASE_URL}${SURFACES[surface]}`, { waitUntil: "networkidle", timeout: 30_000 });
+async function goSurface(
+  page: Page,
+  surface: keyof typeof SURFACES,
+): Promise<void> {
+  await page.goto(`${BASE_URL}${SURFACES[surface]}`, {
+    waitUntil: "networkidle",
+    timeout: 30_000,
+  });
   await page.waitForTimeout(800); // settle for staggered animations
 }
 
@@ -60,41 +76,126 @@ async function collectErrors(page: Page): Promise<string[]> {
 }
 
 test.describe("ONE-FLOW REGRESSION", () => {
-  test("anonymous visitor: full surface tour with no console errors + seed fallback intact", async ({ page }) => {
+  test("anonymous visitor: full surface tour with no console errors + seed fallback intact", async ({
+    page,
+  }) => {
     const errors = await collectErrors(page);
 
     // 1. Home
     await goSurface(page, "home");
-    const homeReady = await page.evaluate(() => ({
-      composer: !!document.querySelector(".nb-composer-card, .nb-stream-composer"),
-      pulseTiles: document.querySelectorAll(".nb-pulse-tile, .nb-avm-pulse").length,
-    }));
-    expect(homeReady.composer || homeReady.pulseTiles > 0, "Home surface renders kit elements").toBeTruthy();
+    await expect(
+      page,
+      "canonical Home redirects to the current redesign",
+    ).toHaveURL(/\/redesign(?:[/?#]|$)/);
+    await expect(
+      page.getByTestId("home-v3-chat-first-frontpage"),
+      "chat-first Home front page",
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("home-v3-report-halo"),
+      "report-memory halo",
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Ask once. Turn it into reusable intelligence.",
+      }),
+      "Home intent heading",
+    ).toBeVisible();
+    await expect(
+      page.getByPlaceholder(
+        "Ask about a company, person, event, market, report, or source packet...",
+      ),
+      "Home universal composer",
+    ).toBeVisible();
 
-    // 2. Chat — seeded thread + source chips visible
+    // 2. Chat — honest live-ready state, with no fixture answer substituted
     await goSurface(page, "chat");
     const chatReady = await page.evaluate(() => ({
+      streamMount: !!document.querySelector(
+        '[data-testid="exact-web-chat-stream"]',
+      ),
+      liveStatus: document
+        .querySelector('[data-testid="exact-web-chat-stream"]')
+        ?.getAttribute("data-chat-live-status"),
+      noFixtureText: document.body.textContent?.includes(
+        "no fixture answer loaded",
+      ),
+      contextRuntimeText:
+        document.body.textContent?.includes("Context Runtime") ||
+        document.body.textContent?.includes("ContextRuntimePacket"),
       turns: document.querySelectorAll(".nb-turn").length,
-      sourceChips: document.querySelectorAll(".nb-src-chip").length,
+      agentTurns: document.querySelectorAll('.nb-turn[data-role="agent"]')
+        .length,
+      runBars: document.querySelectorAll(".nb-runbar").length,
       followups: document.querySelectorAll(".nb-followup-chip").length,
+      goldenComposer: !!document.querySelector(
+        '[data-exact-composer="golden"][data-exact-composer-version="2026-05-02"]',
+      ),
     }));
-    expect(chatReady.turns, "Chat seed thread has turns").toBeGreaterThanOrEqual(4);
-    expect(chatReady.sourceChips, "Chat seed thread has source chips").toBeGreaterThanOrEqual(1);
-    expect(chatReady.followups, "Chat seed thread has follow-up chips").toBeGreaterThanOrEqual(1);
+    expect(chatReady.streamMount, "ChatStream mount").toBe(true);
+    expect(
+      chatReady.liveStatus,
+      "Chat exposes its live run status",
+    ).toBeTruthy();
+    expect(
+      chatReady.noFixtureText,
+      "Chat discloses the fixture-free live-ready state",
+    ).toBe(true);
+    expect(
+      chatReady.contextRuntimeText,
+      "Chat names the Context Runtime contract",
+    ).toBe(true);
+    expect(
+      chatReady.turns,
+      "Chat has at least the live-ready turn",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      chatReady.agentTurns,
+      "Chat has a live-ready agent turn",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      chatReady.runBars,
+      "Chat exposes agent run status",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      chatReady.followups,
+      "Chat has actionable follow-up chips",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      chatReady.goldenComposer,
+      "Chat keeps the shared golden composer",
+    ).toBe(true);
 
     // 3. Reports list
     await goSurface(page, "reports");
     const reportsReady = await page.evaluate(() => ({
       cards: document.querySelectorAll(".nb-rcard, .nb-report-card").length,
     }));
-    expect(reportsReady.cards, "Reports list shows seeded cards").toBeGreaterThanOrEqual(1);
+    expect(
+      reportsReady.cards,
+      "Reports list shows seeded cards",
+    ).toBeGreaterThanOrEqual(1);
 
     // 4. Inbox
     await goSurface(page, "inbox");
     const inboxReady = await page.evaluate(() => ({
-      items: document.querySelectorAll(".nb-inbox-item, .nb-inbox-row, [data-inbox-row]").length,
+      head: !!document.querySelector(".nb-inbox-head"),
+      heading: document.querySelector(".nb-inbox-head h1")?.textContent?.trim(),
+      filters: Array.from(
+        document.querySelectorAll(".nb-inbox-filter button"),
+      ).map((button) => (button.textContent ?? "").trim().split(/\s+/)[0]),
+      rows: document.querySelectorAll(".nb-ibx-row, .nb-panel").length,
     }));
-    expect(inboxReady.items, "Inbox shows seeded items").toBeGreaterThanOrEqual(1);
+    expect(inboxReady.head, "Inbox renders its current header").toBe(true);
+    expect(inboxReady.heading, "Inbox heading").toBe("Inbox");
+    expect(
+      inboxReady.filters.slice(0, 4),
+      "Inbox keeps the locked primary filters",
+    ).toEqual(["All", "Act", "Auto", "Watching"]);
+    expect(
+      inboxReady.rows,
+      "Inbox renders actionable rows",
+    ).toBeGreaterThanOrEqual(1);
 
     // 5. Me
     await goSurface(page, "me");
@@ -104,56 +205,86 @@ test.describe("ONE-FLOW REGRESSION", () => {
     expect(meReady.sidenav, "Me surface renders kit shell").toBeTruthy();
 
     // 6. Avatar status panel — A9 regression coverage
-    await goSurface(page, "home");
+    await goSurface(page, "exactHome");
     await page.click(".nb-avm-trigger", { timeout: 10_000 });
-    await page.waitForSelector('[data-testid="exact-avatar-menu"]', { timeout: 10_000 });
+    await page.waitForSelector('[data-testid="exact-avatar-menu"]', {
+      timeout: 10_000,
+    });
     await page.waitForTimeout(400);
     const avatarReady = await page.evaluate(() => ({
       pulseTiles: document.querySelectorAll(".nb-avm-pulse").length,
-      pulseValues: Array.from(document.querySelectorAll(".nb-avm-pulse-v")).map((el) => el.textContent),
-      sectionLabels: Array.from(document.querySelectorAll(".nb-avm-section-label")).map((el) => el.textContent),
+      sectionLabels: Array.from(
+        document.querySelectorAll(".nb-avm-section-label"),
+      ).map((el) => el.textContent),
       watchRows: document.querySelectorAll(".nb-avm-watch-row").length,
       sessionRows: document.querySelectorAll(".nb-avm-session").length,
     }));
     expect(avatarReady.pulseTiles, "3 pulse tiles").toBe(3);
-    expect(avatarReady.pulseValues, "pulse values match kit seed (A9 fix)").toEqual(
-      expect.arrayContaining(["74%", "38", "91%"]),
-    );
-    expect(avatarReady.sectionLabels, "Watching reads 12 entities (A9 fix)").toEqual(
-      expect.arrayContaining(["Watching · 12 entities"]),
-    );
+    expectAvatarPulseContract(await readAvatarPulseMetrics(page));
+    expect(
+      avatarReady.sectionLabels,
+      "Watching reads 12 entities (A9 fix)",
+    ).toEqual(expect.arrayContaining(["Watching · 12 entities"]));
     expect(avatarReady.watchRows, "3 watch rows").toBeGreaterThanOrEqual(3);
-    expect(avatarReady.sessionRows, "3 session rows (sessionRows ≥3 fix)").toBe(3);
+    expect(
+      avatarReady.sessionRows,
+      "at least 3 recent sessions",
+    ).toBeGreaterThanOrEqual(3);
 
     // 7. No console errors throughout
-    expect(errors, `console errors during flow: ${errors.join(" | ")}`).toEqual([]);
+    expect(errors, `console errors during flow: ${errors.join(" | ")}`).toEqual(
+      [],
+    );
   });
 
-  test("source chip click opens domain in new tab (interactive behavior)", async ({ page, context }) => {
+  test("source chip click opens domain in new tab (interactive behavior)", async ({
+    page,
+    context,
+  }) => {
     await goSurface(page, "chat");
-    const chipExists = await page.evaluate(() => !!document.querySelector(".nb-src-chip"));
-    test.skip(!chipExists, "no source chip rendered — skipping interactive test");
+    const chipExists = await page.evaluate(
+      () => !!document.querySelector(".nb-src-chip"),
+    );
+    test.skip(
+      !chipExists,
+      "no source chip rendered — skipping interactive test",
+    );
 
     // Wait for new-tab popup when chip is clicked
     const popupPromise = context.waitForEvent("page", { timeout: 5_000 });
     await page.click(".nb-src-chip");
     const popup = await popupPromise.catch(() => null);
     if (popup) {
-      expect(popup.url(), "source chip opens external URL").toMatch(/^https?:\/\//);
+      expect(popup.url(), "source chip opens external URL").toMatch(
+        /^https?:\/\//,
+      );
       await popup.close();
     }
     // If browser blocked the popup, the click should still register without error.
   });
 
-  test("follow-up chip sends as new prompt (interactive behavior)", async ({ page }) => {
+  test("follow-up chip sends as new prompt (interactive behavior)", async ({
+    page,
+  }) => {
     await goSurface(page, "chat");
-    const followupExists = await page.evaluate(() => !!document.querySelector(".nb-followup-chip"));
-    test.skip(!followupExists, "no followup chip rendered — skipping interactive test");
+    const followupExists = await page.evaluate(
+      () => !!document.querySelector(".nb-followup-chip"),
+    );
+    test.skip(
+      !followupExists,
+      "no followup chip rendered — skipping interactive test",
+    );
 
-    const before = await page.evaluate(() => document.querySelectorAll(".nb-turn").length);
+    const before = await page.evaluate(
+      () => document.querySelectorAll(".nb-turn").length,
+    );
     await page.click(".nb-followup-chip");
     await page.waitForTimeout(800); // wait for streaming start
-    const after = await page.evaluate(() => document.querySelectorAll(".nb-turn").length);
-    expect(after, "follow-up chip appended a new user turn").toBeGreaterThan(before);
+    const after = await page.evaluate(
+      () => document.querySelectorAll(".nb-turn").length,
+    );
+    expect(after, "follow-up chip appended a new user turn").toBeGreaterThan(
+      before,
+    );
   });
 });

--- a/tests/e2e/vercel-preview-security.spec.ts
+++ b/tests/e2e/vercel-preview-security.spec.ts
@@ -1,0 +1,96 @@
+import { createServer, type Server } from "node:http";
+
+import { expect, test } from "@playwright/test";
+
+import { installOriginScopedCDPHeaders } from "./helpers/vercelPreview";
+
+const TEST_HEADER = "x-nodebench-origin-secret";
+const DUMMY_SECRET = "dummy-secret-never-use-for-auth";
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected a TCP address for the local security fixture");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("CDP origin-scoped header does not follow redirects from origin A to origin B", async ({
+  page,
+}) => {
+  const originAHeaders: Array<string | undefined> = [];
+  const originBHeaders: Array<string | undefined> = [];
+  let originB = "";
+
+  const serverB = createServer((request, response) => {
+    if (request.url !== "/landing") {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    const value = request.headers[TEST_HEADER];
+    originBHeaders.push(typeof value === "string" ? value : undefined);
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(
+      "<!doctype html><title>origin B</title><p>redirect landed</p>",
+    );
+  });
+  const serverA = createServer((request, response) => {
+    if (request.url !== "/redirect") {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    const value = request.headers[TEST_HEADER];
+    originAHeaders.push(typeof value === "string" ? value : undefined);
+    response.writeHead(302, { location: `${originB}/landing` });
+    response.end();
+  });
+
+  let session:
+    | Awaited<ReturnType<typeof installOriginScopedCDPHeaders>>
+    | undefined;
+  try {
+    originB = await listen(serverB);
+    const originA = await listen(serverA);
+    session = await installOriginScopedCDPHeaders(page, originA, {
+      [TEST_HEADER]: DUMMY_SECRET,
+    });
+
+    await page.goto(`${originA}/redirect`, { waitUntil: "load" });
+
+    expect(originAHeaders, "origin A receives the scoped dummy header").toEqual(
+      [DUMMY_SECRET],
+    );
+    expect(
+      originBHeaders.length,
+      "origin B receives the redirected request",
+    ).toBe(1);
+    expect(
+      originBHeaders.every((value) => value === undefined),
+      "origin B never receives the scoped dummy header",
+    ).toBe(true);
+  } finally {
+    if (session) {
+      await session.send("Fetch.disable");
+      await session.detach();
+    }
+    await Promise.all([close(serverA), close(serverB)]);
+  }
+});


### PR DESCRIPTION
## Summary

- authenticate Tier B Playwright against protected exact-head Vercel previews
- scope bypass headers to the exact preview origin with Chromium CDP Fetch interception
- add an executable two-origin redirect test proving the bypass never follows a cross-origin 302
- disable Vercel Toolbar injection for automation and suppress traces whenever a bypass secret exists
- align canonical Home, honest live Chat/Inbox, and dynamic avatar pulse assertions with current shipped behavior
- make release contracts and redirect-security coverage run in always-on required CI lanes

## Security

An independent review reproduced Playwright `route.continue({ headers })` propagating a secret across redirect hops. This patch does not use Playwright route/global header APIs. CDP overrides are applied per paused request only when its origin exactly matches the preview origin. A local two-origin test proves origin A receives a dummy header and redirected origin B does not.

## Verification

- protected exact-head preview: 12 passed, 1 honest source-chip skip, 0 failed
- required Runtime smoke exact list: 153 passed, 1 existing skip
- always-run Chromium launch/security gate: 37/37 passed
- release workflow contracts: 3/3 passed
- TypeScript: passed
- production build/PWA: passed
- Prettier and `git diff --check`: passed

No admin bypass; merge remains CI-gated per P0.