### PR TITLE
refactor(ai-elements): wrap fast agent composer

### DIFF
--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -493,6 +493,11 @@ export type PromptInputProps = Omit<
   // e.g., "image/*" or leave undefined for any
   accept?: string;
   multiple?: boolean;
+  /**
+   * Keep the primitive's form/textarea behavior while an existing live composer
+   * continues to own attachment state, validation, paste, and drop handling.
+   */
+  disableFileHandling?: boolean;
   // When true, accepts drops anywhere on document. Default false (opt-in).
   globalDrop?: boolean;
   // Render a hidden input with given name and keep it in sync for native form posts. Default false.
@@ -515,6 +520,7 @@ export const PromptInput = ({
   className,
   accept,
   multiple,
+  disableFileHandling = false,
   globalDrop,
   syncHiddenInput,
   maxFiles,
@@ -551,6 +557,7 @@ export const PromptInput = ({
   const openFileDialogLocal = useCallback(() => {
     inputRef.current?.click();
   }, []);
+  const ignoreFiles = useCallback((_files: File[] | FileList) => undefined, []);
 
   const matchesAccept = useCallback(
     (f: File) => {
@@ -702,7 +709,11 @@ export const PromptInput = ({
     []
   );
 
-  const add = usingProvider ? addWithProviderValidation : addLocal;
+  const add = disableFileHandling
+    ? ignoreFiles
+    : usingProvider
+      ? addWithProviderValidation
+      : addLocal;
   const remove = usingProvider ? controller.attachments.remove : removeLocal;
   const openFileDialog = usingProvider
     ? controller.attachments.openFileDialog
@@ -732,7 +743,7 @@ export const PromptInput = ({
   // Attach drop handlers on nearest form and document (opt-in)
   useEffect(() => {
     const form = formRef.current;
-    if (!form) {
+    if (!form || disableFileHandling) {
       return;
     }
     if (globalDrop) {
@@ -759,10 +770,10 @@ export const PromptInput = ({
       form.removeEventListener("dragover", onDragOver);
       form.removeEventListener("drop", onDrop);
     };
-  }, [add, globalDrop]);
+  }, [add, disableFileHandling, globalDrop]);
 
   useEffect(() => {
-    if (!globalDrop) {
+    if (!globalDrop || disableFileHandling) {
       return;
     }
 
@@ -785,7 +796,7 @@ export const PromptInput = ({
       document.removeEventListener("dragover", onDragOver);
       document.removeEventListener("drop", onDrop);
     };
-  }, [add, globalDrop]);
+  }, [add, disableFileHandling, globalDrop]);
 
   useEffect(
     () => () => {
@@ -905,16 +916,18 @@ export const PromptInput = ({
   // Render with or without local provider
   const inner = (
     <>
-      <input
-        accept={accept}
-        aria-label="Upload files"
-        className="hidden"
-        multiple={multiple}
-        onChange={handleChange}
-        ref={inputRef}
-        title="Upload files"
-        type="file"
-      />
+      {!disableFileHandling && (
+        <input
+          accept={accept}
+          aria-label="Upload files"
+          className="hidden"
+          multiple={multiple}
+          onChange={handleChange}
+          ref={inputRef}
+          title="Upload files"
+          type="file"
+        />
+      )}
       <form
         className={cn("w-full", className)}
         onSubmit={handleSubmit}

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
@@ -11,6 +11,33 @@ import { useSelection } from '@/features/agents/context/SelectionContext';
 import { InlineEnhancer } from './FastAgentPanel.PromptEnhancer';
 import { useAction } from 'convex/react';
 import { api } from '../../../../../convex/_generated/api';
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputButton,
+  PromptInputFooter,
+  PromptInputHeader,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from '@/components/ai-elements/prompt-input';
+import {
+  Context,
+  ContextContent,
+  ContextContentHeader,
+  ContextTrigger,
+} from '@/components/ai-elements/context';
+import {
+  ModelSelector,
+  ModelSelectorContent,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorInput,
+  ModelSelectorItem,
+  ModelSelectorList,
+  ModelSelectorLogo,
+  ModelSelectorName,
+  ModelSelectorTrigger,
+} from '@/components/ai-elements/model-selector';
 
 // ============================================================================
 // Spawn Command Parser (local to InputBar)
@@ -126,6 +153,19 @@ import {
 
 // Get models from shared module
 const APPROVED_MODEL_LIST = getModelUIList();
+
+function parseContextWindow(contextWindow?: string): number {
+  const match = contextWindow?.trim().match(/^(\d+(?:\.\d+)?)([KM])?$/i);
+  if (!match) return 128_000;
+
+  const value = Number.parseFloat(match[1]);
+  const multiplier = match[2]?.toUpperCase() === 'M'
+    ? 1_000_000
+    : match[2]?.toUpperCase() === 'K'
+      ? 1_000
+      : 1;
+  return Math.max(1, Math.round(value * multiplier));
+}
 
 // File size limits
 const MAX_FILE_SIZE_MB = 10;
@@ -600,11 +640,8 @@ export function FastAgentInputBar({
       }
     }
 
-    // Enter to send (Shift+Enter for newline)
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
+    // PromptInputTextarea owns ordinary Enter-to-submit and preserves Shift+Enter.
+    // Slash-command keys above prevent default before the primitive sees them.
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -711,6 +748,9 @@ export function FastAgentInputBar({
   };
 
   const canSend = (input.trim().length > 0 || attachedFiles.length > 0 || contextDocuments.length > 0 || selection !== null || contextCalendarEvents.length > 0) && !isStreaming;
+  const estimatedInputTokens = Math.ceil(input.length / 4);
+  const selectedModelInfo = MODEL_UI_INFO[selectedModel as ApprovedModel];
+  const selectedModelMaxTokens = parseContextWindow(selectedModelInfo?.contextWindow);
   const hasContextPills =
     (selectedDocumentIds?.size ?? 0) > 0 ||
     contextDocuments.length > 0 ||
@@ -801,62 +841,74 @@ export function FastAgentInputBar({
         "focus-within:border-[var(--accent-primary)] focus-within:ring-2 focus-within:ring-[var(--accent-primary)]/15",
         isDragOver && dragFeedback.border
       )}>
-
+        <PromptInput
+          className="[&_[data-slot=input-group]]:!h-auto [&_[data-slot=input-group]]:!flex-col [&_[data-slot=input-group]]:!items-stretch [&_[data-slot=input-group]]:!rounded-none [&_[data-slot=input-group]]:!border-0 [&_[data-slot=input-group]]:!bg-transparent [&_[data-slot=input-group]]:!shadow-none [&_[data-slot=input-group]]:focus-within:!ring-0"
+          data-testid="fast-agent-prompt-input"
+          disableFileHandling
+          id={_id}
+          onSubmit={({ text }) => handleSend(text)}
+        >
         {/* Context Pills Area (Documents, Models, etc.) */}
         {showTopContextRow && (
-          <div className={cn("px-3 pt-3 flex flex-wrap gap-2 items-center", compact && "pt-2.5")}>
+          <PromptInputHeader className={cn("!px-3 !pt-3 !pb-0 flex-wrap gap-2", compact && "!pt-2.5")}>
             {/* Model Selector */}
             {!compact && (
-              <div className="relative">
-            <button
-              type="button"
-              onClick={() => setShowModelSelector(!showModelSelector)}
-              className="flex items-center gap-2 px-2.5 py-1.5 text-xs hover:bg-surface-secondary rounded-lg transition-all duration-200 border border-transparent hover:border-edge"
-            >
-              <span className="text-content-secondary flex items-center gap-1.5 font-medium">
-                {MODEL_UI_INFO[selectedModel as ApprovedModel]?.isFree && <Gift className="w-3 h-3 text-violet-500" />}
-                {MODEL_UI_INFO[selectedModel as ApprovedModel]?.name ?? 'Gemini 3 Flash'}
-              </span>
-              <ChevronUp className={cn("w-3 h-3 text-content-muted transition-transform duration-200", showModelSelector ? "rotate-180" : "")} />
-            </button>
-
-              {/* Model Dropdown */}
-              {showModelSelector && (
-                <>
-                  <div className="fixed inset-0 z-10" onClick={() => setShowModelSelector(false)} />
-                  <div className="absolute bottom-full left-0 mb-2 w-64 bg-surface rounded-lg border border-edge shadow-xl z-20 py-1.5 max-h-80 overflow-y-auto dropdown-enter" style={{ '--dropdown-origin': 'bottom left' } as React.CSSProperties}>
-                    <div className="px-3 py-2 border-b border-edge/50">
-                      <span className="text-xs font-bold text-content-muted">Select Model</span>
-                    </div>
-                    {APPROVED_MODEL_LIST.map((model) => (
-                      <button
-                        type="button"
-                        key={model.id}
-                        onClick={() => {
-                          onSelectModel(model.id);
-                          setShowModelSelector(false);
-                        }}
-                        className={cn(
-                          "w-full px-3 py-2.5 text-left hover:bg-surface-secondary transition-all duration-150",
-                          selectedModel === model.id && "bg-surface-secondary border-l-2 border-l-[rgb(79, 70, 229)]"
-                        )}
-                      >
-                        <div className="flex items-center justify-between">
-                          <span className={cn("text-[12px] flex items-center gap-1.5", selectedModel === model.id ? "font-semibold text-content" : "font-medium text-content-secondary")}>
-                            {model.isFree && <Gift className="w-3 h-3 text-violet-500" />}
-                            {model.name}
-                          </span>
-                          <span className="text-xs text-content-muted font-medium">{model.contextWindow}</span>
-                        </div>
-                        <div className="text-xs text-content-muted mt-1 leading-relaxed">
-                          {model.description}
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                </>
-              )}
-            </div>
+              <ModelSelector
+                modal={false}
+                onOpenChange={setShowModelSelector}
+                open={showModelSelector}
+              >
+                <ModelSelectorTrigger asChild>
+                  <button
+                    aria-label={`Model: ${selectedModelInfo?.name ?? 'Gemini 3 Flash'}`}
+                    className="flex items-center gap-2 rounded-lg border border-transparent px-2.5 py-1.5 text-xs transition-all duration-200 hover:border-edge hover:bg-surface-secondary"
+                    type="button"
+                  >
+                    <span className="flex items-center gap-1.5 font-medium text-content-secondary">
+                      {selectedModelInfo?.isFree && <Gift className="w-3 h-3 text-violet-500" />}
+                      {selectedModelInfo?.name ?? 'Gemini 3 Flash'}
+                    </span>
+                    <ChevronUp className={cn("w-3 h-3 text-content-muted transition-transform duration-200", showModelSelector && "rotate-180")} />
+                  </button>
+                </ModelSelectorTrigger>
+                <ModelSelectorContent
+                  className="z-[1101] max-h-[min(32rem,80vh)] max-w-md overflow-hidden border border-edge bg-surface text-content shadow-2xl"
+                  title="Select model"
+                >
+                  <ModelSelectorInput placeholder="Search approved models..." />
+                  <ModelSelectorList className="max-h-[min(24rem,65vh)]">
+                    <ModelSelectorEmpty>No approved model found.</ModelSelectorEmpty>
+                    <ModelSelectorGroup heading="Approved models">
+                      {APPROVED_MODEL_LIST.map((model) => (
+                        <ModelSelectorItem
+                          className={cn(
+                            "items-start gap-2.5 px-3 py-2.5",
+                            selectedModel === model.id && "bg-surface-secondary",
+                          )}
+                          key={model.id}
+                          onSelect={() => {
+                            onSelectModel(model.id);
+                            setShowModelSelector(false);
+                          }}
+                          value={`${model.name} ${model.id} ${model.description}`}
+                        >
+                          <ModelSelectorLogo provider={model.provider} />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-1.5 text-xs">
+                              {model.isFree && <Gift className="w-3 h-3 text-violet-500" />}
+                              <ModelSelectorName className={cn(selectedModel === model.id ? "font-semibold text-content" : "font-medium text-content-secondary")}>
+                                {model.name}
+                              </ModelSelectorName>
+                              <span className="text-xs font-medium text-content-muted">{model.contextWindow}</span>
+                            </div>
+                            <p className="mt-1 text-xs leading-relaxed text-content-muted">{model.description}</p>
+                          </div>
+                        </ModelSelectorItem>
+                      ))}
+                    </ModelSelectorGroup>
+                  </ModelSelectorList>
+                </ModelSelectorContent>
+              </ModelSelector>
             )}
 
           {/* Document Pills (legacy) */}
@@ -952,7 +1004,7 @@ export function FastAgentInputBar({
               </div>
             );
           })}
-          </div>
+          </PromptInputHeader>
         )}
 
         {/* Attached Files Preview */}
@@ -971,6 +1023,7 @@ export function FastAgentInputBar({
                   )}
                   <span className="max-w-[100px] truncate text-content">{file.name}</span>
                   <button
+                    type="button"
                     onClick={() => onRemoveFile(index)}
                     className="absolute -top-1.5 -right-1.5 bg-surface rounded-full border border-edge p-0.5 opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:text-red-500"
                   >
@@ -1047,9 +1100,9 @@ export function FastAgentInputBar({
         )}
 
         {/* Input Area */}
-        <div className={cn("p-3 flex items-end gap-1.5", compact && "pt-2.5")}>
+        <PromptInputFooter className={cn("!p-3 !flex-row !items-end !justify-start gap-1.5", compact && "!pt-2.5")}>
           {/* Attachment Button */}
-          <button
+          <PromptInputButton
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={isStreaming}
@@ -1058,10 +1111,10 @@ export function FastAgentInputBar({
             aria-label="Attach file"
           >
             <Paperclip className="w-4.5 h-4.5" />
-          </button>
+          </PromptInputButton>
 
           {/* Speech-to-Text / Audio Recording */}
-          <button
+          <PromptInputButton
             type="button"
             onClick={toggleSpeechToText}
             disabled={isStreaming || isRecording}
@@ -1082,9 +1135,9 @@ export function FastAgentInputBar({
             aria-label={isListening ? "Stop listening" : "Voice input using speech recognition"}
           >
             <Mic className="w-4.5 h-4.5" />
-          </button>
+          </PromptInputButton>
           {!compact && (
-            <button
+            <PromptInputButton
               type="button"
               onClick={() => startRecording("video")}
               disabled={isStreaming || isRecording}
@@ -1093,7 +1146,7 @@ export function FastAgentInputBar({
               aria-label="Record video"
             >
               <Video className="w-4.5 h-4.5" />
-            </button>
+            </PromptInputButton>
           )}
           <input
             ref={fileInputRef}
@@ -1105,59 +1158,61 @@ export function FastAgentInputBar({
           />
 
           {/* Textarea */}
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              // Detect @mentions
-              const val = e.target.value;
-              const cursorPos = e.target.selectionStart || 0;
-              const textBefore = val.slice(0, cursorPos);
-              const atMatch = textBefore.match(/@(\w*)$/);
-              if (atMatch) {
-                setShowMentions(true);
-                setMentionQuery(atMatch[1]);
-              } else {
-                setShowMentions(false);
-              }
-            }}
-            onKeyDown={handleKeyDown}
-            onPaste={(e) => {
-              // Image paste handling
-              const items = e.clipboardData?.items;
-              if (items) {
-                const imageFiles: File[] = [];
-                for (const item of Array.from(items)) {
-                  if (item.type.startsWith('image/')) {
-                    const file = item.getAsFile();
-                    if (file) imageFiles.push(file);
+          <PromptInputBody>
+            <PromptInputTextarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value);
+                // Detect @mentions
+                const val = e.target.value;
+                const cursorPos = e.target.selectionStart || 0;
+                const textBefore = val.slice(0, cursorPos);
+                const atMatch = textBefore.match(/@(\w*)$/);
+                if (atMatch) {
+                  setShowMentions(true);
+                  setMentionQuery(atMatch[1]);
+                } else {
+                  setShowMentions(false);
+                }
+              }}
+              onKeyDown={handleKeyDown}
+              onPaste={(e) => {
+                // Image paste handling
+                const items = e.clipboardData?.items;
+                if (items) {
+                  const imageFiles: File[] = [];
+                  for (const item of Array.from(items)) {
+                    if (item.type.startsWith('image/')) {
+                      const file = item.getAsFile();
+                      if (file) imageFiles.push(file);
+                    }
+                  }
+                  if (imageFiles.length > 0) {
+                    e.preventDefault();
+                    onAttachFiles([...attachedFiles, ...imageFiles]);
+                    toast.success(`Pasted ${imageFiles.length} image${imageFiles.length > 1 ? 's' : ''}`);
+                    return;
                   }
                 }
-                if (imageFiles.length > 0) {
-                  e.preventDefault();
-                  onAttachFiles([...attachedFiles, ...imageFiles]);
-                  toast.success(`Pasted ${imageFiles.length} image${imageFiles.length > 1 ? 's' : ''}`);
-                  return;
+                // Smart URL paste: detect URLs and show toast notification
+                const pastedText = e.clipboardData?.getData('text') || '';
+                const urlMatch = pastedText.match(/^https?:\/\/[^\s]+$/);
+                if (urlMatch) {
+                  try {
+                    const url = new URL(pastedText.trim());
+                    const domain = url.hostname.replace('www.', '');
+                    toast.info(`URL detected: ${domain}`, { duration: 2000 });
+                  } catch { /* not a valid URL */ }
                 }
-              }
-              // Smart URL paste: detect URLs and show toast notification
-              const pastedText = e.clipboardData?.getData('text') || '';
-              const urlMatch = pastedText.match(/^https?:\/\/[^\s]+$/);
-              if (urlMatch) {
-                try {
-                  const url = new URL(pastedText.trim());
-                  const domain = url.hostname.replace('www.', '');
-                  toast.info(`URL detected: ${domain}`, { duration: 2000 });
-                } catch { /* not a valid URL */ }
-              }
-            }}
-            placeholder={placeholder}
-            disabled={isStreaming}
-            maxLength={maxLength}
-            className="flex-1 max-h-[200px] py-2 bg-transparent border-none focus:ring-0 p-0 text-sm text-content placeholder:text-content-muted resize-none leading-relaxed"
-            rows={1}
-          />
+              }}
+              placeholder={placeholder}
+              disabled={isStreaming}
+              maxLength={maxLength}
+              className="flex-1 !min-h-0 max-h-[200px] !py-2 bg-transparent border-none focus:ring-0 !px-0 text-sm text-content placeholder:text-content-muted resize-none leading-relaxed"
+              rows={1}
+            />
+          </PromptInputBody>
 
           {/* @Mentions Autocomplete Popup */}
           {showMentions && (
@@ -1229,39 +1284,54 @@ export function FastAgentInputBar({
 
           {/* Input Token Budget Preview */}
           {!compact && input.length > 20 && !isStreaming && (
-            <span className="text-[8px] tabular-nums text-content-muted whitespace-nowrap" title={`Your message: ~${Math.ceil(input.length / 4)} tokens`}>
-              ~{Math.ceil(input.length / 4)}t
-            </span>
+            <Context
+              maxTokens={selectedModelMaxTokens}
+              modelId={selectedModel}
+              usedTokens={estimatedInputTokens}
+            >
+              <ContextTrigger>
+                <button
+                  aria-label={`Prompt context: approximately ${estimatedInputTokens} tokens`}
+                  className="whitespace-nowrap rounded px-1 text-[8px] tabular-nums text-content-muted hover:bg-surface-secondary"
+                  title={`Your message: ~${estimatedInputTokens} tokens`}
+                  type="button"
+                >
+                  ~{estimatedInputTokens}t
+                </button>
+              </ContextTrigger>
+              <ContextContent align="end" side="top">
+                <ContextContentHeader />
+              </ContextContent>
+            </Context>
           )}
 
           {/* Send/Stop Button */}
-          {isStreaming ? (
-            <button
-              onClick={onStop}
-              className="press-scale group relative p-2.5 bg-red-500 text-white hover:bg-red-600 rounded-lg shadow-md shadow-red-500/20 transition-all duration-200"
-              title="Stop generating"
-              aria-label="Stop generating"
-            >
+          <PromptInputSubmit
+            aria-label={isStreaming ? 'Stop generating' : 'Send message'}
+            className={cn(
+              "press-scale relative size-auto rounded-lg p-2.5 transition-all duration-200",
+              isStreaming
+                ? "group bg-red-500 text-white shadow-md shadow-red-500/20 hover:bg-red-600"
+                : canSend
+                  ? "bg-[var(--accent-primary)] text-white shadow-sm hover:bg-[var(--accent-primary-hover)]"
+                  : "cursor-not-allowed bg-surface-secondary text-content-muted",
+            )}
+            disabled={!isStreaming && !canSend}
+            onStop={onStop}
+            status={isStreaming ? 'streaming' : 'ready'}
+            title={isStreaming ? 'Stop generating' : 'Send message'}
+          >
+            {isStreaming ? (
+              <>
               <div className="absolute inset-0 rounded-lg bg-red-400 motion-safe:animate-ping opacity-20" />
               <StopCircle className="w-5 h-5 relative z-10" />
-            </button>
-          ) : (
-            <button
-              onClick={() => handleSend()}
-              disabled={!canSend}
-              className={cn(
-                "press-scale p-2.5 rounded-lg",
-                canSend
-                  ? "bg-[var(--accent-primary)] text-white shadow-sm transition-all hover:bg-[var(--accent-primary-hover)]"
-                  : "bg-surface-secondary text-content-muted cursor-not-allowed"
-              )}
-              title="Send message"
-              aria-label="Send message"
-            >
+              </>
+            ) : (
               <Send className="w-5 h-5" />
-            </button>
-          )}
-        </div>
+            )}
+          </PromptInputSubmit>
+        </PromptInputFooter>
+        </PromptInput>
       </div>
 
       {/* Keyboard shortcut hints */}

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
@@ -877,7 +877,6 @@ export function FastAgentInputBar({
           className="[&_[data-slot=input-group]]:!h-auto [&_[data-slot=input-group]]:!flex-col [&_[data-slot=input-group]]:!items-stretch [&_[data-slot=input-group]]:!rounded-none [&_[data-slot=input-group]]:!border-0 [&_[data-slot=input-group]]:!bg-transparent [&_[data-slot=input-group]]:!shadow-none [&_[data-slot=input-group]]:focus-within:!ring-0"
           data-testid="fast-agent-prompt-input"
           disableFileHandling
-          id={_id}
           onSubmit={({ text }) => handleSend(text)}
         >
         {/* Context Pills Area (Documents, Models, etc.) */}
@@ -1057,7 +1056,7 @@ export function FastAgentInputBar({
                   <button
                     type="button"
                     onClick={() => onRemoveFile(index)}
-                    className="absolute -top-1.5 -right-1.5 bg-surface rounded-full border border-edge p-0.5 opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:text-red-500"
+                    className="absolute -top-1.5 -right-1.5 rounded-full border border-edge bg-surface p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:text-red-500 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-surface motion-reduce:transition-none"
                     aria-label={`Remove ${file.name}`}
                   >
                     <X className="w-3 h-3" />
@@ -1207,6 +1206,7 @@ export function FastAgentInputBar({
           {/* Textarea */}
           <PromptInputBody>
             <PromptInputTextarea
+              id={_id}
               ref={textareaRef}
               value={input}
               onChange={(e) => {

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
@@ -546,11 +546,21 @@ export function FastAgentInputBar({
     }
   }, [isStreaming]);
 
+  const hasDocumentContext =
+    contextDocuments.length > 0 || (selectedDocumentIds?.size ?? 0) > 0;
+
   const handleSend = useCallback((content?: string) => {
     const trimmed = (content ?? input).trim();
     const hasSelection = selection !== null;
     const hasCalendarEvents = contextCalendarEvents.length > 0;
-    if ((!trimmed && attachedFiles.length === 0 && !hasSelection && !hasCalendarEvents) || isStreaming) return;
+    if (
+      (!trimmed &&
+        attachedFiles.length === 0 &&
+        !hasSelection &&
+        !hasCalendarEvents &&
+        !hasDocumentContext) ||
+      isStreaming
+    ) return;
 
     // Voice intent router — intercept UI commands before agent send
     if (trimmed && onVoiceIntent?.(trimmed, 'text')) {
@@ -607,7 +617,7 @@ export function FastAgentInputBar({
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [attachedFiles.length, clearSelection, contextCalendarEvents, contextCalendarEvents.length, flashVoiceConfirmation, input, isStreaming, onSend, onSpawn, onVoiceIntent, selection, setInput]);
+  }, [attachedFiles.length, clearSelection, contextCalendarEvents, contextCalendarEvents.length, flashVoiceConfirmation, hasDocumentContext, input, isStreaming, onSend, onSpawn, onVoiceIntent, selection, setInput]);
 
   sendTextRef.current = handleSend;
 
@@ -747,7 +757,13 @@ export function FastAgentInputBar({
     return objectUrlMapRef.current.get(fileKey(file)) ?? null;
   };
 
-  const canSend = (input.trim().length > 0 || attachedFiles.length > 0 || contextDocuments.length > 0 || selection !== null || contextCalendarEvents.length > 0) && !isStreaming;
+  const canSend = (
+    input.trim().length > 0 ||
+    attachedFiles.length > 0 ||
+    hasDocumentContext ||
+    selection !== null ||
+    contextCalendarEvents.length > 0
+  ) && !isStreaming;
   const estimatedInputTokens = Math.ceil(input.length / 4);
   const selectedModelInfo = MODEL_UI_INFO[selectedModel as ApprovedModel];
   const selectedModelMaxTokens = parseContextWindow(selectedModelInfo?.contextWindow);

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.InputBar.tsx
@@ -2,7 +2,7 @@
 // Enhanced input bar with auto-resize, context pills, drag-and-drop, and floating design
 
 import React, { useState, useRef, useEffect, useCallback, KeyboardEvent, DragEvent } from 'react';
-import { Send, Loader2, Paperclip, X, Mic, Video, Image as ImageIcon, FileText, ChevronUp, StopCircle, FolderOpen, Table2, Calendar, Zap, Gift, AlignLeft, AlignJustify, BookOpen } from 'lucide-react';
+import { Send, Loader2, Paperclip, X, Mic, Video, Image as ImageIcon, FileText, ChevronUp, StopCircle, FolderOpen, Table2, Calendar, Zap, Gift, AlignLeft, AlignJustify, BookOpen, AlertTriangle } from 'lucide-react';
 import { MediaRecorderComponent } from './FastAgentPanel.MediaRecorder';
 import { FileDropOverlay } from '@/shared/components/FileDropOverlay';
 import { cn } from '@/lib/utils';
@@ -383,6 +383,7 @@ export function FastAgentInputBar({
 
   // Selection context for "Chat with Selection" feature
   const { selection, clearSelection } = useSelection();
+  const attachmentsHeld = attachedFiles.length > 0;
 
   // Prompt enhancement action
   const enhancePromptAction = useAction(api.domains.agents.promptEnhancer.enhancePrompt);
@@ -390,14 +391,19 @@ export function FastAgentInputBar({
   // Handle prompt enhancement (Ctrl+P)
   const handleEnhance = useCallback(async () => {
     if (!input.trim() || isStreaming || isEnhancing) return;
+    if (attachmentsHeld) {
+      toast.error('Attachments are held', {
+        description: 'Prompt enhancement cannot read these files. Remove them before enhancing your message.',
+      });
+      return;
+    }
 
     setIsEnhancing(true);
     try {
-      const attachedFileIds = attachedFiles.map((_, i) => `file-${i}`); // Placeholder IDs
       const result = await enhancePromptAction({
         prompt: input,
         threadId,
-        attachedFileIds: attachedFileIds.length > 0 ? attachedFileIds : undefined,
+        attachedFileIds: undefined,
       });
 
       if (result && result.enhanced) {
@@ -412,7 +418,7 @@ export function FastAgentInputBar({
     } finally {
       setIsEnhancing(false);
     }
-  }, [input, threadId, attachedFiles, isStreaming, isEnhancing, enhancePromptAction, setInput]);
+  }, [attachmentsHeld, input, threadId, isStreaming, isEnhancing, enhancePromptAction, setInput]);
 
   // Keyboard shortcut for enhancement (Ctrl+P)
   useEffect(() => {
@@ -546,19 +552,26 @@ export function FastAgentInputBar({
     }
   }, [isStreaming]);
 
-  const hasDocumentContext =
-    contextDocuments.length > 0 || (selectedDocumentIds?.size ?? 0) > 0;
+  const hasReadyDocumentContext =
+    contextDocuments.some((document) => !document.analyzing) ||
+    (selectedDocumentIds?.size ?? 0) > 0;
+  const attachmentHeldStatusId = `${_id ?? 'fast-agent-input'}-attachments-held`;
 
   const handleSend = useCallback((content?: string) => {
     const trimmed = (content ?? input).trim();
     const hasSelection = selection !== null;
     const hasCalendarEvents = contextCalendarEvents.length > 0;
+    if (attachmentsHeld) {
+      toast.error('Attachments are held', {
+        description: 'This chat cannot send files yet. Remove them before sending; the files will stay attached until then.',
+      });
+      return;
+    }
     if (
       (!trimmed &&
-        attachedFiles.length === 0 &&
         !hasSelection &&
         !hasCalendarEvents &&
-        !hasDocumentContext) ||
+        !hasReadyDocumentContext) ||
       isStreaming
     ) return;
 
@@ -617,7 +630,7 @@ export function FastAgentInputBar({
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [attachedFiles.length, clearSelection, contextCalendarEvents, contextCalendarEvents.length, flashVoiceConfirmation, hasDocumentContext, input, isStreaming, onSend, onSpawn, onVoiceIntent, selection, setInput]);
+  }, [attachmentsHeld, clearSelection, contextCalendarEvents, contextCalendarEvents.length, flashVoiceConfirmation, hasReadyDocumentContext, input, isStreaming, onSend, onSpawn, onVoiceIntent, selection, setInput]);
 
   sendTextRef.current = handleSend;
 
@@ -758,12 +771,15 @@ export function FastAgentInputBar({
   };
 
   const canSend = (
-    input.trim().length > 0 ||
-    attachedFiles.length > 0 ||
-    hasDocumentContext ||
-    selection !== null ||
-    contextCalendarEvents.length > 0
-  ) && !isStreaming;
+    !attachmentsHeld &&
+    (
+      input.trim().length > 0 ||
+      hasReadyDocumentContext ||
+      selection !== null ||
+      contextCalendarEvents.length > 0
+    ) &&
+    !isStreaming
+  );
   const estimatedInputTokens = Math.ceil(input.length / 4);
   const selectedModelInfo = MODEL_UI_INFO[selectedModel as ApprovedModel];
   const selectedModelMaxTokens = parseContextWindow(selectedModelInfo?.contextWindow);
@@ -1042,12 +1058,27 @@ export function FastAgentInputBar({
                     type="button"
                     onClick={() => onRemoveFile(index)}
                     className="absolute -top-1.5 -right-1.5 bg-surface rounded-full border border-edge p-0.5 opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:text-red-500"
+                    aria-label={`Remove ${file.name}`}
                   >
                     <X className="w-3 h-3" />
                   </button>
                 </div>
               );
             })}
+          </div>
+        )}
+
+        {attachmentsHeld && (
+          <div
+            aria-live="polite"
+            className="mx-3 mt-2 flex items-start gap-2 rounded-lg border border-[rgba(180,83,9,0.20)] bg-[rgba(180,83,9,0.06)] px-2.5 py-2 text-[11px] leading-relaxed text-[var(--warning,#B45309)]"
+            id={attachmentHeldStatusId}
+            role="alert"
+          >
+            <AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+            <span>
+              <strong>Attachments held.</strong> This chat cannot send files yet. Remove them to send your message; your files remain attached until then.
+            </span>
           </div>
         )}
 
@@ -1294,7 +1325,7 @@ export function FastAgentInputBar({
               value={input}
               onEnhance={handleEnhance}
               isEnhancing={isEnhancing}
-              disabled={isStreaming}
+              disabled={isStreaming || attachmentsHeld}
             />
           )}
 
@@ -1323,6 +1354,7 @@ export function FastAgentInputBar({
 
           {/* Send/Stop Button */}
           <PromptInputSubmit
+            aria-describedby={attachmentsHeld ? attachmentHeldStatusId : undefined}
             aria-label={isStreaming ? 'Stop generating' : 'Send message'}
             className={cn(
               "press-scale relative size-auto rounded-lg p-2.5 transition-all duration-200",

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.PromptEnhancer.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.PromptEnhancer.tsx
@@ -473,6 +473,7 @@ export function InlineEnhancer({
 
   return (
     <button
+      type="button"
       onClick={onEnhance}
       disabled={disabled || isEnhancing}
       className={cn(

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.sendContract.ts
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.sendContract.ts
@@ -1,0 +1,189 @@
+export interface FastAgentContextDocument {
+  id: string;
+  title: string;
+  type?: 'document' | 'dossier' | 'note';
+  analyzing?: boolean;
+}
+
+export type FastAgentSubmissionBlockReason =
+  | 'attachments_unsupported'
+  | 'documents_analyzing'
+  | 'empty';
+
+export type FastAgentPreparedSubmission =
+  | {
+      ok: false;
+      reason: FastAgentSubmissionBlockReason;
+    }
+  | {
+      consumedContextDocumentIds: string[];
+      messageContent: string;
+      ok: true;
+      text: string;
+    };
+
+interface PrepareFastAgentSubmissionArgs {
+  allowAttachments: boolean;
+  attachedFiles: Array<{ name: string }>;
+  content?: string;
+  contextDocuments: FastAgentContextDocument[];
+  dossierPrefix: string;
+  input: string;
+  selectedDocumentIds: Iterable<string>;
+}
+
+/**
+ * Builds the exact text contract consumed by FastAgentPanel's backends.
+ *
+ * File objects never become text-only claims here unless the caller confirms that the
+ * selected backend will receive real file references. This keeps the presentation layer
+ * and both non-product chat modes capability-honest.
+ */
+export function prepareFastAgentSubmission({
+  allowAttachments,
+  attachedFiles,
+  content,
+  contextDocuments,
+  dossierPrefix,
+  input,
+  selectedDocumentIds,
+}: PrepareFastAgentSubmissionArgs): FastAgentPreparedSubmission {
+  if (attachedFiles.length > 0 && !allowAttachments) {
+    return { ok: false, reason: 'attachments_unsupported' };
+  }
+
+  const submittedText = (content ?? input).trim();
+  const readyDocuments = contextDocuments.filter((document) => !document.analyzing);
+  const legacyDocumentIds = Array.from(selectedDocumentIds);
+  const hasReadyDocumentContext =
+    readyDocuments.length > 0 || legacyDocumentIds.length > 0;
+
+  if (
+    !submittedText &&
+    !hasReadyDocumentContext &&
+    contextDocuments.some((document) => document.analyzing)
+  ) {
+    return { ok: false, reason: 'documents_analyzing' };
+  }
+
+  const attachmentPrompt =
+    allowAttachments && attachedFiles.length > 0
+      ? `Please analyze the attached file${attachedFiles.length === 1 ? '' : 's'}: ${attachedFiles
+          .map((file) => file.name)
+          .join(', ')}.`
+      : '';
+  const documentPrompt = hasReadyDocumentContext
+    ? 'Please analyze the selected documents.'
+    : '';
+  const text = submittedText || attachmentPrompt || documentPrompt;
+
+  if (!text) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  let messageContent = dossierPrefix ? `${dossierPrefix}${text}` : text;
+
+  if (readyDocuments.length > 0) {
+    const contextInfo = readyDocuments
+      .map((document) => `${document.title} (ID: ${document.id})`)
+      .join(', ');
+    messageContent = `[CONTEXT: Analyzing documents: ${contextInfo}]\n\n${messageContent}`;
+  }
+
+  if (legacyDocumentIds.length > 0) {
+    messageContent = `[CONTEXT: Analyzing ${legacyDocumentIds.length} document(s): ${legacyDocumentIds.join(', ')}]\n\n${messageContent}`;
+  }
+
+  return {
+    consumedContextDocumentIds: readyDocuments.map((document) => document.id),
+    messageContent,
+    ok: true,
+    text,
+  };
+}
+
+interface FastAgentClientContext {
+  timezone?: string;
+  locale?: string;
+  utcOffsetMinutes?: number;
+  location?: string;
+}
+
+interface DispatchFastAgentSubmissionArgs {
+  activeThreadId: string | null;
+  anonymousSessionId?: string;
+  arbitrageEnabled?: boolean;
+  chatMode: 'agent' | 'agent-streaming';
+  clientContext?: FastAgentClientContext;
+  continueThreadAction: (args: {
+    message: string;
+    threadId: string;
+  }) => Promise<unknown>;
+  createThreadWithMessage: (args: {
+    message: string;
+    model: string;
+  }) => Promise<{ threadId: string }>;
+  entitySlug?: string;
+  messageContent: string;
+  selectedModel: string;
+  sendStreamingMessage: (args: {
+    anonymousSessionId?: string;
+    arbitrageEnabled?: boolean;
+    clientContext?: FastAgentClientContext;
+    entitySlug?: string;
+    model: string;
+    prompt: string;
+    threadId: string;
+    useCoordinator: boolean;
+  }) => Promise<unknown>;
+  streamThreadId: string | null;
+}
+
+export async function dispatchFastAgentSubmission({
+  activeThreadId,
+  anonymousSessionId,
+  arbitrageEnabled,
+  chatMode,
+  clientContext,
+  continueThreadAction,
+  createThreadWithMessage,
+  entitySlug,
+  messageContent,
+  selectedModel,
+  sendStreamingMessage,
+  streamThreadId,
+}: DispatchFastAgentSubmissionArgs): Promise<{
+  createdThreadId?: string;
+}> {
+  if (chatMode === 'agent') {
+    if (activeThreadId) {
+      await continueThreadAction({
+        message: messageContent,
+        threadId: activeThreadId,
+      });
+      return {};
+    }
+
+    const result = await createThreadWithMessage({
+      message: messageContent,
+      model: selectedModel,
+    });
+    return { createdThreadId: result.threadId };
+  }
+
+  if (!streamThreadId) {
+    throw new Error('Thread ID is required');
+  }
+
+  await sendStreamingMessage({
+    anonymousSessionId,
+    arbitrageEnabled,
+    clientContext,
+    entitySlug,
+    model: selectedModel,
+    prompt: messageContent,
+    threadId: streamThreadId,
+    useCoordinator: true,
+  });
+  return {};
+}

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -1856,7 +1856,16 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   }, []);
 
   const handleSendMessage = useCallback(async (content?: string) => {
-    const text = (content ?? input).trim();
+    const submittedText = (content ?? input).trim();
+    // InputBar intentionally keeps `content` optional so attachments and document
+    // context can be submitted without synthetic text inside the presentation layer.
+    const attachmentOnlyPrompt = attachedFiles.length > 0
+      ? `Please analyze the attached file${attachedFiles.length === 1 ? '' : 's'}: ${attachedFiles.map((file) => file.name).join(', ')}.`
+      : '';
+    const documentOnlyPrompt = contextDocuments.length > 0 || selectedDocumentIds.size > 0
+      ? 'Please analyze the selected documents.'
+      : '';
+    const text = submittedText || attachmentOnlyPrompt || documentOnlyPrompt;
     if (!text || isBusy) return;
 
     // Guest/demo mode intercept: play scripted or fallback response
@@ -3666,7 +3675,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                   id="fa-chat-input"
                   input={input}
                   setInput={setInput}
-                  onSend={() => stableSendMessage(input)}
+                  onSend={stableSendMessage}
                   isStreaming={isBusy}
                   onStop={handleStopStreaming}
                   selectedModel={selectedModel}

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -70,6 +70,10 @@ import { useConversationEngine } from '@/features/chat/hooks/useConversationEngi
 import type { LensId } from '@/features/controlPlane/components/searchTypes';
 import { ProductIntakeComposer } from '@/features/product/components/ProductIntakeComposer';
 import { uploadProductDraftFiles } from '@/features/product/lib/uploadDraftFiles';
+import {
+  dispatchFastAgentSubmission,
+  prepareFastAgentSubmission,
+} from './FastAgentPanel.sendContract';
 
 import type {
   Message,
@@ -1856,17 +1860,36 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   }, []);
 
   const handleSendMessage = useCallback(async (content?: string) => {
-    const submittedText = (content ?? input).trim();
-    // InputBar intentionally keeps `content` optional so attachments and document
-    // context can be submitted without synthetic text inside the presentation layer.
-    const attachmentOnlyPrompt = attachedFiles.length > 0
-      ? `Please analyze the attached file${attachedFiles.length === 1 ? '' : 's'}: ${attachedFiles.map((file) => file.name).join(', ')}.`
-      : '';
-    const documentOnlyPrompt = contextDocuments.length > 0 || selectedDocumentIds.size > 0
-      ? 'Please analyze the selected documents.'
-      : '';
-    const text = submittedText || attachmentOnlyPrompt || documentOnlyPrompt;
-    if (!text || isBusy) return;
+    if (isBusy) return;
+
+    const preparedSubmission = prepareFastAgentSubmission({
+      allowAttachments: isProductConversationMode && isAuthenticated,
+      attachedFiles,
+      content,
+      contextDocuments,
+      dossierPrefix: dossierPrefixRef.current,
+      input,
+      selectedDocumentIds,
+    });
+
+    if (!preparedSubmission.ok) {
+      if (preparedSubmission.reason === 'attachments_unsupported') {
+        toast.error('Attachments are held', {
+          description: 'This chat cannot send files yet. Remove them to send your message; your files will stay attached until then.',
+        });
+      } else if (preparedSubmission.reason === 'documents_analyzing') {
+        toast.info('Document analysis is still running', {
+          description: 'Wait for at least one document to finish before sending.',
+        });
+      }
+      return;
+    }
+
+    const {
+      consumedContextDocumentIds,
+      messageContent,
+      text,
+    } = preparedSubmission;
 
     // Guest/demo mode intercept: play scripted or fallback response
     if (!isAuthenticated) {
@@ -1965,39 +1988,19 @@ export const FastAgentPanel = memo(function FastAgentPanel({
       }
     }
 
-    // Build message with document context if documents are selected or dragged
-    let messageContent = text;
-
-    // Include dossier context if present (for act-aware agent interactions)
-    const dossierPrefix = dossierPrefixRef.current;
-    if (dossierPrefix) {
-      messageContent = `${dossierPrefix}${messageContent}`;
-    }
-
-    // Include drag-and-drop context documents
-    if (contextDocuments.length > 0) {
-      const contextInfo = contextDocuments
-        .filter(doc => !doc.analyzing) // Only include analyzed documents
-        .map(doc => `${doc.title} (ID: ${doc.id})`)
-        .join(', ');
-      if (contextInfo) {
-        messageContent = `[CONTEXT: Analyzing documents: ${contextInfo}]\n\n${messageContent}`;
-      }
-    }
-
-    // Also include selected document IDs (legacy)
-    if (selectedDocumentIds.size > 0) {
-      const docIdArray = Array.from(selectedDocumentIds);
-      messageContent = `[CONTEXT: Analyzing ${docIdArray.length} document(s): ${docIdArray.join(', ')}]\n\n${messageContent}`;
-    }
-
     setInput('');
     setLiveTokens("");
     setLiveAgents([]);
     setIsStreaming(true);
 
-    // Clear context documents and calendar events after sending
-    setContextDocuments([]);
+    // Clear only document context that was actually included. Documents still being
+    // analyzed remain visible and cannot be silently dropped by an unrelated send.
+    if (consumedContextDocumentIds.length > 0) {
+      const consumedDocumentIds = new Set(consumedContextDocumentIds);
+      setContextDocuments((current) =>
+        current.filter((document) => !consumedDocumentIds.has(document.id)),
+      );
+    }
     setContextCalendarEvents([]);
 
     // Clear live state
@@ -2024,21 +2027,19 @@ export const FastAgentPanel = memo(function FastAgentPanel({
         setAttachedFiles([]);
         setIsStreaming(false);
       } else if (chatMode === 'agent') {
-        // Agent-based chat flow
-        let result;
-        if (!activeThreadId) {
-          // Create new thread with first message
-          result = await createThreadWithMessage({
-            message: messageContent,
-            model: selectedModel,
-          });
-          setActiveThreadId(result.threadId);
-        } else {
-          // Continue existing thread
-          result = await continueThreadAction({
-            threadId: activeThreadId,
-            message: messageContent,
-          });
+        const result = await dispatchFastAgentSubmission({
+          activeThreadId,
+          chatMode,
+          clientContext: undefined,
+          continueThreadAction,
+          createThreadWithMessage,
+          messageContent,
+          selectedModel,
+          sendStreamingMessage,
+          streamThreadId: null,
+        });
+        if (result.createdThreadId) {
+          setActiveThreadId(result.createdThreadId);
         }
 
         setIsStreaming(false);
@@ -2085,15 +2086,19 @@ export const FastAgentPanel = memo(function FastAgentPanel({
             }
             : undefined;
 
-        await sendStreamingMessage({
-          threadId: threadId as Id<"chatThreadsStream">,
-          prompt: messageContent,
-          model: selectedModel,
-          useCoordinator: true,  // Enable smart routing via coordinator
-          arbitrageEnabled,
+        await dispatchFastAgentSubmission({
+          activeThreadId,
           anonymousSessionId: anonymousSession.sessionId ?? undefined,
+          arbitrageEnabled,
+          chatMode,
           clientContext,
+          continueThreadAction,
+          createThreadWithMessage,
           entitySlug: productEntitySlug ?? undefined,
+          messageContent,
+          selectedModel,
+          sendStreamingMessage,
+          streamThreadId: threadId as Id<"chatThreadsStream">,
         });
 
         setIsStreaming(false);

--- a/src/features/agents/components/FastAgentPanel/__tests__/FastAgentPanel.sendContract.test.ts
+++ b/src/features/agents/components/FastAgentPanel/__tests__/FastAgentPanel.sendContract.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  dispatchFastAgentSubmission,
+  prepareFastAgentSubmission,
+} from '../FastAgentPanel.sendContract';
+
+const createBackends = () => ({
+  continueThreadAction: vi.fn().mockResolvedValue({ success: true }),
+  createThreadWithMessage: vi.fn().mockResolvedValue({
+    success: true,
+    threadId: 'agent-thread-new',
+  }),
+  sendStreamingMessage: vi.fn().mockResolvedValue({ messageId: 'message-1' }),
+});
+
+async function prepareAndDispatch(
+  input: Parameters<typeof prepareFastAgentSubmission>[0],
+  dispatch: Omit<
+    Parameters<typeof dispatchFastAgentSubmission>[0],
+    'messageContent'
+  >,
+) {
+  const prepared = prepareFastAgentSubmission(input);
+  if (prepared.ok) {
+    await dispatchFastAgentSubmission({
+      ...dispatch,
+      messageContent: prepared.messageContent,
+    });
+  }
+  return prepared;
+}
+
+describe('FastAgentPanel send contract', () => {
+  it('holds text plus files and never calls a text-only backend', async () => {
+    const backends = createBackends();
+
+    const result = await prepareAndDispatch(
+      {
+        allowAttachments: false,
+        attachedFiles: [{ name: 'evidence.txt' }],
+        content: 'Use this evidence',
+        contextDocuments: [],
+        dossierPrefix: '',
+        input: '',
+        selectedDocumentIds: [],
+      },
+      {
+        activeThreadId: null,
+        chatMode: 'agent-streaming',
+        clientContext: undefined,
+        selectedModel: 'gpt-5.4-mini',
+        streamThreadId: 'stream-thread-1',
+        ...backends,
+      },
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'attachments_unsupported' });
+    expect(backends.createThreadWithMessage).not.toHaveBeenCalled();
+    expect(backends.continueThreadAction).not.toHaveBeenCalled();
+    expect(backends.sendStreamingMessage).not.toHaveBeenCalled();
+  });
+
+  it('holds file-only sends without synthesizing an attached-file claim', async () => {
+    const backends = createBackends();
+
+    const result = await prepareAndDispatch(
+      {
+        allowAttachments: false,
+        attachedFiles: [{ name: 'board.pdf' }],
+        contextDocuments: [],
+        dossierPrefix: '',
+        input: '',
+        selectedDocumentIds: [],
+      },
+      {
+        activeThreadId: null,
+        chatMode: 'agent',
+        clientContext: undefined,
+        selectedModel: 'gpt-5.4-mini',
+        streamThreadId: null,
+        ...backends,
+      },
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'attachments_unsupported' });
+    expect(JSON.stringify(result)).not.toContain('attached file');
+    expect(backends.createThreadWithMessage).not.toHaveBeenCalled();
+    expect(backends.continueThreadAction).not.toHaveBeenCalled();
+    expect(backends.sendStreamingMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends a ready dragged document through the streaming backend with its real id', async () => {
+    const backends = createBackends();
+
+    const result = await prepareAndDispatch(
+      {
+        allowAttachments: false,
+        attachedFiles: [],
+        contextDocuments: [
+          { id: 'doc-ready', title: 'Board memo', type: 'document' },
+        ],
+        dossierPrefix: '',
+        input: '',
+        selectedDocumentIds: [],
+      },
+      {
+        activeThreadId: null,
+        chatMode: 'agent-streaming',
+        clientContext: { locale: 'en-US' },
+        selectedModel: 'gpt-5.4-mini',
+        streamThreadId: 'stream-thread-1',
+        ...backends,
+      },
+    );
+
+    expect(result).toMatchObject({
+      consumedContextDocumentIds: ['doc-ready'],
+      ok: true,
+      text: 'Please analyze the selected documents.',
+    });
+    expect(backends.sendStreamingMessage).toHaveBeenCalledWith({
+      anonymousSessionId: undefined,
+      arbitrageEnabled: undefined,
+      clientContext: { locale: 'en-US' },
+      entitySlug: undefined,
+      model: 'gpt-5.4-mini',
+      prompt:
+        '[CONTEXT: Analyzing documents: Board memo (ID: doc-ready)]\n\nPlease analyze the selected documents.',
+      threadId: 'stream-thread-1',
+      useCoordinator: true,
+    });
+  });
+
+  it('holds analyzing-only document sends and leaves every backend untouched', async () => {
+    const backends = createBackends();
+
+    const result = await prepareAndDispatch(
+      {
+        allowAttachments: false,
+        attachedFiles: [],
+        contextDocuments: [
+          {
+            analyzing: true,
+            id: 'doc-loading',
+            title: 'Still indexing',
+            type: 'document',
+          },
+        ],
+        dossierPrefix: '',
+        input: '',
+        selectedDocumentIds: [],
+      },
+      {
+        activeThreadId: null,
+        chatMode: 'agent-streaming',
+        clientContext: undefined,
+        selectedModel: 'gpt-5.4-mini',
+        streamThreadId: 'stream-thread-1',
+        ...backends,
+      },
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'documents_analyzing' });
+    expect(backends.createThreadWithMessage).not.toHaveBeenCalled();
+    expect(backends.continueThreadAction).not.toHaveBeenCalled();
+    expect(backends.sendStreamingMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends legacy selected document ids through the existing agent backend', async () => {
+    const backends = createBackends();
+
+    const result = await prepareAndDispatch(
+      {
+        allowAttachments: false,
+        attachedFiles: [],
+        contextDocuments: [],
+        dossierPrefix: '',
+        input: '',
+        selectedDocumentIds: ['legacy-doc-1'],
+      },
+      {
+        activeThreadId: 'agent-thread-existing',
+        chatMode: 'agent',
+        clientContext: undefined,
+        selectedModel: 'gpt-5.4-mini',
+        streamThreadId: null,
+        ...backends,
+      },
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    expect(backends.continueThreadAction).toHaveBeenCalledWith({
+      message:
+        '[CONTEXT: Analyzing 1 document(s): legacy-doc-1]\n\nPlease analyze the selected documents.',
+      threadId: 'agent-thread-existing',
+    });
+    expect(backends.createThreadWithMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
@@ -28,14 +28,6 @@ vi.mock('../FastAgentPanel.MediaRecorder', () => ({
   ),
 }));
 
-vi.mock('../FastAgentPanel.PromptEnhancer', () => ({
-  InlineEnhancer: ({ onEnhance }: { onEnhance: () => void }) => (
-    <button aria-label="Enhance prompt" onClick={onEnhance} type="button">
-      Enhance
-    </button>
-  ),
-}));
-
 vi.mock('@/shared/components/FileDropOverlay', () => ({
   FileDropOverlay: () => null,
 }));
@@ -154,6 +146,50 @@ describe('FastAgentInputBar parity', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith(undefined);
+  });
+
+  it('allows dragged-document-only submission through the parent fallback', async () => {
+    const onSend = vi.fn();
+
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          contextDocuments={[
+            {
+              id: 'doc-1',
+              title: 'Board memo',
+              type: 'document',
+            },
+          ]}
+          onSend={onSend}
+        />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith(undefined);
+  });
+
+  it('allows legacy selected-document-only submission through the parent fallback', async () => {
+    const onSend = vi.fn();
+
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          onSend={onSend}
+          selectedDocumentIds={new Set(['doc-legacy-1'])}
+        />
+      </SelectionProvider>,
+    );
+
+    const submit = screen.getByRole('button', { name: 'Send message' });
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+
     await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
     expect(onSend).toHaveBeenCalledWith(undefined);
   });
@@ -425,5 +461,27 @@ describe('FastAgentInputBar parity', () => {
     expect(screen.getByRole('textbox')).toHaveValue(
       'Enhanced prompt with memory',
     );
+  });
+
+  it('keeps the real inline enhancer outside the form submit path', async () => {
+    const onSend = vi.fn();
+    enhancePrompt.mockResolvedValue({
+      enhanced: 'Enhanced without sending',
+      injectedContext: { memory: [], suggestedTools: [] },
+    });
+    render(
+      <SelectionProvider>
+        <ControlledInputBar initialInput="Improve this" onSend={onSend} />
+      </SelectionProvider>,
+    );
+
+    const enhanceButton = screen.getByTitle(
+      'Enhance prompt with context (Ctrl+P)',
+    );
+    expect(enhanceButton).toHaveAttribute('type', 'button');
+    fireEvent.click(enhanceButton);
+
+    await waitFor(() => expect(enhancePrompt).toHaveBeenCalledTimes(1));
+    expect(onSend).not.toHaveBeenCalled();
   });
 });

--- a/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
@@ -1,0 +1,429 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SelectionProvider,
+  useSelection,
+} from '@/features/agents/context/SelectionContext';
+import { FastAgentInputBar } from '../FastAgentPanel.InputBar';
+
+const enhancePrompt = vi.fn();
+
+vi.mock('convex/react', () => ({
+  useAction: () => enhancePrompt,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('../FastAgentPanel.MediaRecorder', () => ({
+  MediaRecorderComponent: ({ mode }: { mode: string }) => (
+    <div data-mode={mode} data-testid="media-recorder" />
+  ),
+}));
+
+vi.mock('../FastAgentPanel.PromptEnhancer', () => ({
+  InlineEnhancer: ({ onEnhance }: { onEnhance: () => void }) => (
+    <button aria-label="Enhance prompt" onClick={onEnhance} type="button">
+      Enhance
+    </button>
+  ),
+}));
+
+vi.mock('@/shared/components/FileDropOverlay', () => ({
+  FileDropOverlay: () => null,
+}));
+
+type InputBarProps = React.ComponentProps<typeof FastAgentInputBar>;
+
+const defaultProps = (): InputBarProps => ({
+  attachedFiles: [],
+  id: 'fa-chat-input',
+  input: '',
+  isStreaming: false,
+  onAttachFiles: vi.fn(),
+  onRemoveFile: vi.fn(),
+  onSelectModel: vi.fn(),
+  onSend: vi.fn(),
+  onStop: vi.fn(),
+  selectedModel: 'gemini-3-flash-preview',
+  setInput: vi.fn(),
+});
+
+function ControlledInputBar({
+  initialInput = '',
+  ...overrides
+}: Partial<InputBarProps> & { initialInput?: string }) {
+  const [input, setInput] = useState(initialInput);
+  const props = { ...defaultProps(), ...overrides, input, setInput };
+
+  return <FastAgentInputBar {...props} />;
+}
+
+function ActiveSelection() {
+  const { setSelection } = useSelection();
+
+  useEffect(() => {
+    setSelection('Revenue,42', {
+      filename: 'forecast.csv',
+      rangeDescription: 'A1:B2',
+      sourceType: 'spreadsheet',
+    });
+  }, [setSelection]);
+
+  return null;
+}
+
+class SpeechRecognitionMock {
+  static instances: SpeechRecognitionMock[] = [];
+
+  continuous = false;
+  interimResults = false;
+  lang = '';
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onresult: ((event: unknown) => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn(() => this.onend?.());
+
+  constructor() {
+    SpeechRecognitionMock.instances.push(this);
+  }
+}
+
+describe('FastAgentInputBar parity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    SpeechRecognitionMock.instances = [];
+    class ResizeObserverMock {
+      disconnect = vi.fn();
+      observe = vi.fn();
+      unobserve = vi.fn();
+    }
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window, 'SpeechRecognition', {
+      configurable: true,
+      value: SpeechRecognitionMock,
+    });
+  });
+
+  it('submits with Enter and preserves Shift+Enter for a newline', async () => {
+    const onSend = vi.fn();
+    render(
+      <SelectionProvider>
+        <ControlledInputBar initialInput="Ship the composer" onSend={onSend} />
+      </SelectionProvider>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    expect(screen.getByTestId('fast-agent-prompt-input')).toHaveAttribute(
+      'id',
+      'fa-chat-input',
+    );
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith('Ship the composer');
+  });
+
+  it('allows attachment-only submission through the existing optional content API', async () => {
+    const onSend = vi.fn();
+    const attachment = new File(['evidence'], 'evidence.txt', {
+      type: 'text/plain',
+    });
+
+    render(
+      <SelectionProvider>
+        <ControlledInputBar attachedFiles={[attachment]} onSend={onSend} />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith(undefined);
+  });
+
+  it('intercepts a completed voice command before agent submission', () => {
+    const onSend = vi.fn();
+    const onVoiceIntent = vi.fn(() => true);
+    render(
+      <SelectionProvider>
+        <ControlledInputBar onSend={onSend} onVoiceIntent={onVoiceIntent} />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Voice input using speech recognition',
+      }),
+    );
+
+    const recognition = SpeechRecognitionMock.instances[0];
+    expect(recognition).toBeDefined();
+    expect(recognition.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [
+          {
+            0: { transcript: 'open reports' },
+            isFinal: true,
+          },
+        ],
+      });
+      recognition.onend?.();
+    });
+
+    expect(onVoiceIntent).toHaveBeenCalledWith('open reports', 'voice');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('routes /spawn commands to the swarm callback without sending a chat message', async () => {
+    const onSend = vi.fn();
+    const onSpawn = vi.fn();
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          initialInput={'/spawn "Tesla analysis" --agents=doc,media'}
+          onSend={onSend}
+          onSpawn={onSpawn}
+        />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => {
+      expect(onSpawn).toHaveBeenCalledWith('Tesla analysis', [
+        'DocumentAgent',
+        'MediaAgent',
+      ]);
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('forwards the constructed selection and calendar context as the send argument', async () => {
+    const onSend = vi.fn();
+    render(
+      <SelectionProvider>
+        <ActiveSelection />
+        <ControlledInputBar
+          contextCalendarEvents={[
+            {
+              allDay: true,
+              id: 'event-1',
+              startTime: Date.UTC(2026, 6, 14),
+              title: 'Board review',
+            },
+          ]}
+          initialInput="Summarize the implications"
+          onSend={onSend}
+        />
+      </SelectionProvider>,
+    );
+
+    await screen.findByText(/Cells A1:B2 from forecast.csv/);
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    const content = onSend.mock.calls[0][0] as string;
+    expect(content).toContain('**Calendar Events for Context:**');
+    expect(content).toContain('**Board review**');
+    expect(content).toContain(
+      '**Analyzing spreadsheet selection from "forecast.csv" (A1:B2):**',
+    );
+    expect(content).toContain('Revenue,42');
+    expect(content.endsWith('Summarize the implications')).toBe(true);
+  });
+
+  it('stops the active stream instead of submitting', () => {
+    const onSend = vi.fn();
+    const onStop = vi.fn();
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          initialInput="Do not resubmit"
+          isStreaming
+          onSend={onSend}
+          onStop={onStop}
+        />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop generating' }));
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('keeps model selection delegated to the parent', async () => {
+    const onSelectModel = vi.fn();
+    render(
+      <SelectionProvider>
+        <ControlledInputBar onSelectModel={onSelectModel} />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Gemini 3 Flash Preview/i }),
+    );
+    fireEvent.click(await screen.findByText('GPT-5.4 Mini'));
+
+    expect(onSelectModel).toHaveBeenCalledWith('gpt-5.4-mini');
+  });
+
+  it('keeps @mention completion on the controlled live input', async () => {
+    render(
+      <SelectionProvider>
+        <ControlledInputBar />
+      </SelectionProvider>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, {
+      target: { selectionStart: 3, value: '@do' },
+    });
+    fireEvent.click(await screen.findByText('@docs'));
+
+    expect(textarea).toHaveValue('@docs ');
+  });
+
+  it('keeps slash-command completion on the controlled live input', async () => {
+    render(
+      <SelectionProvider>
+        <ControlledInputBar />
+      </SelectionProvider>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: '/' } });
+    fireEvent.click(await screen.findByText('Start Team'));
+
+    expect(textarea).toHaveValue('/spawn "Tesla analysis" --agents=doc,media,sec');
+  });
+
+  it('keeps file-picker and pasted-image attachments on the parent-owned state path', () => {
+    const onAttachFiles = vi.fn();
+    const pickedFile = new File(['video'], 'clip.mp4', { type: 'video/mp4' });
+    const pastedFile = new File(['image'], 'chart.png', { type: 'image/png' });
+    const { container } = render(
+      <SelectionProvider>
+        <ControlledInputBar onAttachFiles={onAttachFiles} />
+      </SelectionProvider>,
+    );
+
+    const fileInputs = container.querySelectorAll('input[type="file"]');
+    expect(fileInputs).toHaveLength(1);
+    const fileInput = fileInputs.item(0);
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, { target: { files: [pickedFile] } });
+    expect(onAttachFiles).toHaveBeenNthCalledWith(1, [pickedFile]);
+
+    fireEvent.paste(screen.getByRole('textbox'), {
+      clipboardData: {
+        getData: () => '',
+        items: [
+          {
+            getAsFile: () => pastedFile,
+            kind: 'file',
+            type: 'image/png',
+          },
+        ],
+      },
+    });
+    expect(onAttachFiles).toHaveBeenNthCalledWith(2, [pastedFile]);
+  });
+
+  it('keeps media drag-and-drop on the parent-owned attachment state path', () => {
+    const onAttachFiles = vi.fn();
+    const droppedFile = new File(['image'], 'drop.png', { type: 'image/png' });
+    const { container } = render(
+      <SelectionProvider>
+        <ControlledInputBar onAttachFiles={onAttachFiles} />
+      </SelectionProvider>,
+    );
+
+    const dropTarget = container.querySelector('.fa-input-bar-wrapper');
+    expect(dropTarget).not.toBeNull();
+    fireEvent.drop(dropTarget!, {
+      dataTransfer: {
+        files: [droppedFile],
+        getData: () => '',
+        types: ['Files'],
+      },
+    });
+
+    expect(onAttachFiles).toHaveBeenCalledTimes(1);
+    expect(onAttachFiles).toHaveBeenCalledWith([droppedFile]);
+  });
+
+  it('keeps the custom media recorder entry point', () => {
+    render(
+      <SelectionProvider>
+        <ControlledInputBar />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record video' }));
+    expect(screen.getByTestId('media-recorder')).toHaveAttribute(
+      'data-mode',
+      'video',
+    );
+  });
+
+  it('keeps response-length control delegated to the parent', () => {
+    const onResponseLengthChange = vi.fn();
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          onResponseLengthChange={onResponseLengthChange}
+          responseLength="detailed"
+        />
+      </SelectionProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Response length: detailed' }),
+    );
+    expect(onResponseLengthChange).toHaveBeenCalledWith('exhaustive');
+  });
+
+  it('keeps Ctrl+P enhancement on the Convex action and controlled input', async () => {
+    enhancePrompt.mockResolvedValue({
+      enhanced: 'Enhanced prompt with memory',
+      injectedContext: { memory: ['memory'], suggestedTools: ['search'] },
+    });
+    render(
+      <SelectionProvider>
+        <ControlledInputBar initialInput="Improve this" threadId="thread-1" />
+      </SelectionProvider>,
+    );
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'p' });
+
+    await waitFor(() => {
+      expect(enhancePrompt).toHaveBeenCalledWith({
+        attachedFileIds: undefined,
+        prompt: 'Improve this',
+        threadId: 'thread-1',
+      });
+    });
+    expect(screen.getByRole('textbox')).toHaveValue(
+      'Enhanced prompt with memory',
+    );
+  });
+});

--- a/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
@@ -133,7 +133,7 @@ describe('FastAgentInputBar parity', () => {
     expect(onSend).toHaveBeenCalledWith('Ship the composer');
   });
 
-  it('allows attachment-only submission through the existing optional content API', async () => {
+  it('holds attachment-only submission with an explicit capability warning', () => {
     const onSend = vi.fn();
     const attachment = new File(['evidence'], 'evidence.txt', {
       type: 'text/plain',
@@ -145,9 +145,18 @@ describe('FastAgentInputBar parity', () => {
       </SelectionProvider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
-    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
-    expect(onSend).toHaveBeenCalledWith(undefined);
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Attachments held. This chat cannot send files yet.',
+    );
+    const submit = screen.getByRole('button', { name: 'Send message' });
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute(
+      'aria-describedby',
+      'fa-chat-input-attachments-held',
+    );
+    fireEvent.click(submit);
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByText('evidence.txt')).toBeInTheDocument();
   });
 
   it('allows dragged-document-only submission through the parent fallback', async () => {
@@ -192,6 +201,32 @@ describe('FastAgentInputBar parity', () => {
 
     await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
     expect(onSend).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps analyzing-only document submission disabled until a document is ready', () => {
+    const onSend = vi.fn();
+
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          contextDocuments={[
+            {
+              analyzing: true,
+              id: 'doc-loading',
+              title: 'Board memo',
+              type: 'document',
+            },
+          ]}
+          onSend={onSend}
+        />
+      </SelectionProvider>,
+    );
+
+    expect(screen.getByText('Analyzing Board memo...')).toBeInTheDocument();
+    const submit = screen.getByRole('button', { name: 'Send message' });
+    expect(submit).toBeDisabled();
+    fireEvent.click(submit);
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it('intercepts a completed voice command before agent submission', () => {
@@ -461,6 +496,27 @@ describe('FastAgentInputBar parity', () => {
     expect(screen.getByRole('textbox')).toHaveValue(
       'Enhanced prompt with memory',
     );
+  });
+
+  it('does not pass placeholder file ids into prompt enhancement', () => {
+    const attachment = new File(['evidence'], 'evidence.txt', {
+      type: 'text/plain',
+    });
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          attachedFiles={[attachment]}
+          initialInput="Improve this with the file"
+        />
+      </SelectionProvider>,
+    );
+
+    const enhanceButton = screen.getByTitle(
+      'Enhance prompt with context (Ctrl+P)',
+    );
+    expect(enhanceButton).toBeDisabled();
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'p' });
+    expect(enhancePrompt).not.toHaveBeenCalled();
   });
 
   it('keeps the real inline enhancer outside the form submit path', async () => {

--- a/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/__tests__/InputBar.parity.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useEffect, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -112,6 +113,23 @@ describe('FastAgentInputBar parity', () => {
     });
   });
 
+  it('puts the skip-link target on the focusable chat textbox', () => {
+    render(
+      <SelectionProvider>
+        <ControlledInputBar />
+      </SelectionProvider>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    expect(screen.getByTestId('fast-agent-prompt-input')).not.toHaveAttribute(
+      'id',
+    );
+    expect(textarea).toHaveAttribute('id', 'fa-chat-input');
+    expect(document.querySelector('#fa-chat-input')).toBe(textarea);
+    textarea.focus();
+    expect(textarea).toHaveFocus();
+  });
+
   it('submits with Enter and preserves Shift+Enter for a newline', async () => {
     const onSend = vi.fn();
     render(
@@ -121,10 +139,6 @@ describe('FastAgentInputBar parity', () => {
     );
 
     const textarea = screen.getByRole('textbox');
-    expect(screen.getByTestId('fast-agent-prompt-input')).toHaveAttribute(
-      'id',
-      'fa-chat-input',
-    );
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
     expect(onSend).not.toHaveBeenCalled();
 
@@ -157,6 +171,39 @@ describe('FastAgentInputBar parity', () => {
     fireEvent.click(submit);
     expect(onSend).not.toHaveBeenCalled();
     expect(screen.getByText('evidence.txt')).toBeInTheDocument();
+  });
+
+  it('keeps attachment removal visible and operable from the keyboard', async () => {
+    const user = userEvent.setup();
+    const onRemoveFile = vi.fn();
+    const attachment = new File(['evidence'], 'evidence.txt', {
+      type: 'text/plain',
+    });
+
+    render(
+      <SelectionProvider>
+        <ControlledInputBar
+          attachedFiles={[attachment]}
+          onRemoveFile={onRemoveFile}
+        />
+      </SelectionProvider>,
+    );
+
+    const removeButton = screen.getByRole('button', {
+      name: 'Remove evidence.txt',
+    });
+    removeButton.focus();
+
+    expect(removeButton).toHaveFocus();
+    expect(removeButton).toHaveClass(
+      'focus-visible:opacity-100',
+      'focus-visible:ring-2',
+      'focus-visible:ring-[var(--accent-primary)]',
+    );
+
+    await user.keyboard('{Enter}');
+    expect(onRemoveFile).toHaveBeenCalledOnce();
+    expect(onRemoveFile).toHaveBeenCalledWith(0);
   });
 
   it('allows dragged-document-only submission through the parent fallback', async () => {


### PR DESCRIPTION
## What changed

- Wraps the FastAgentPanel composer with AI Elements PromptInput primitives while preserving NodeBench send, stop, prompt-enhancement, and product-intake behavior.
- Adds a deterministic parent send contract so attachments and documents are either delivered to a capable backend or held fail-closed.
- Keeps analyzing documents attached and unsent, passes real ready/legacy document IDs, and uploads real product files before `beginRun`.
- Restores keyboard recovery: the panel skip link targets the actual textarea, and attachment removal is visible and operable on focus.
- Adds parity, send-contract, Enter-key, document, attachment, product-mode, and accessibility regressions.

## Why

The previous composer could not adopt the shared primitive safely without an explicit boundary between text-only and attachment/document-capable backends. Independent review caught two additional P1 accessibility defects: a non-focusable skip-link target and a mouse-hover-only attachment recovery control. Both were reproduced failing-first and are fixed.

## Validation

- Focused InputBar/send contracts: 26 passed
- Full FastAgentPanel: 173 passed, 19 environment-gated skipped
- Explicit streaming guard: 1 passed
- `npx tsc --noEmit --pretty false`
- Design system: 11 passed; `npm run lint:design` has 0 high findings
- `npm run build`
- Bundle guard: FastAgentPanel 1,550,259 B; separate code block 73,341 B; separate Streamdown 163,187 B; 0 Shiki/oniguruma/wasm markers in panel; 0 `assets/shiki/` service-worker precache entries
- QA memory: `f904f7c63d19` and `a7aaecb7821b` fixed, 0 open/regressed

## Release

Ready for required checks and CI-gated squash auto-merge. No admin bypass.