### PR TITLE
refactor(ai-elements): migrate live event cards

### DIFF
--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PanelHeader, type PanelHeaderProps } from './FastAgentPanel.PanelHeader';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn: vi.fn() }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/features/agents/components/DossierModeIndicator', () => ({
+  DossierModeIndicator: () => null,
+}));
+
+function compactHeaderProps(
+  overrides: Partial<PanelHeaderProps> = {}
+): PanelHeaderProps {
+  return {
+    activePersona: 'general',
+    activeThreadId: null,
+    anonymousSession: {
+      canSendMessage: true,
+      isAnonymous: false,
+      isLoading: false,
+      limit: 5,
+      remaining: 5,
+    },
+    appendToSignalsLog: vi.fn(async () => undefined),
+    handleCopyAsMarkdown: vi.fn(async () => undefined),
+    handleDownloadMarkdown: vi.fn(),
+    isAuthenticated: false,
+    isCompactSidebar: true,
+    isFocusMode: false,
+    isStreaming: true,
+    isSwarmActive: false,
+    isWideMode: false,
+    liveEvents: [
+      {
+        id: 'search-1-unified',
+        status: 'running',
+        title: 'webSearch',
+      },
+    ],
+    messagesToRender: [],
+    onClose: vi.fn(),
+    personas: [{ icon: 'N', id: 'general', name: 'General' }],
+    selectedModel: 'default',
+    setActivePersona: vi.fn(),
+    setActiveThreadId: vi.fn(),
+    setAttachedFiles: vi.fn(),
+    setInput: vi.fn(),
+    setIsFocusMode: vi.fn(),
+    setIsMinimized: vi.fn(),
+    setIsWideMode: vi.fn(),
+    setShowAnalytics: vi.fn(),
+    setShowEventsPanel: vi.fn(),
+    setShowOverflowMenu: vi.fn(),
+    setShowPersonaPicker: vi.fn(),
+    setShowSkillsPanel: vi.fn(),
+    setShowSystemPrompt: vi.fn(),
+    setShowTimeline: vi.fn(),
+    showOverflowMenu: false,
+    showPersonaPicker: false,
+    swarmTasks: [],
+    systemPrompt: '',
+    threads: [],
+    ...overrides,
+  };
+}
+
+describe('PanelHeader live event reachability', () => {
+  it('opens Live Events from the compact sidebar variant used by Cockpit', () => {
+    const setShowEventsPanel = vi.fn();
+
+    render(
+      <PanelHeader
+        {...compactHeaderProps({ setShowEventsPanel })}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /open live events/i });
+    expect(button).toHaveAttribute('aria-label', 'Open live events (1 running)');
+
+    fireEvent.click(button);
+
+    expect(setShowEventsPanel).toHaveBeenCalledTimes(1);
+    expect(setShowEventsPanel).toHaveBeenCalledWith(expect.any(Function));
+    const toggle = setShowEventsPanel.mock.calls[0]?.[0] as (
+      previous: boolean
+    ) => boolean;
+    expect(toggle(false)).toBe(true);
+  });
+
+  it('does not add a dead compact control when no live events exist', () => {
+    render(<PanelHeader {...compactHeaderProps({ liveEvents: [] })} />);
+
+    expect(
+      screen.queryByRole('button', { name: /open live events/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.tsx
@@ -184,6 +184,37 @@ export const PanelHeader = memo(function PanelHeader({
 
       {/* Primary Actions */}
       <div className="flex items-center gap-1">
+        {isCompactSidebar && liveEvents.length > 0 && (() => {
+          const runningCount = liveEvents.filter(
+            (event) => event.status === 'running'
+          ).length;
+          return (
+            <button
+              type="button"
+              onClick={() => setShowEventsPanel(previous => !previous)}
+              className="inline-flex items-center gap-1 rounded-md p-1.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content"
+              aria-label={`Open live events (${runningCount} running)`}
+              title="Live Events"
+            >
+              <Activity
+                aria-hidden="true"
+                className={cn(
+                  'h-4 w-4',
+                  runningCount > 0 && 'text-violet-500'
+                )}
+              />
+              {runningCount > 0 && (
+                <span
+                  aria-hidden="true"
+                  className="min-w-4 rounded-full bg-violet-500 px-1 text-center text-[10px] font-semibold leading-4 text-white"
+                >
+                  {runningCount}
+                </span>
+              )}
+            </button>
+          );
+        })()}
+
         {/* Persona Switcher */}
         {!isCompactSidebar && <div className="relative">
           <button

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -43,6 +43,7 @@ const TaskManagerView = React.lazy(() => import('../TaskManager').then(m => ({ d
 const SwarmLanesView = React.lazy(() => import('./SwarmLanesView').then(m => ({ default: m.SwarmLanesView })));
 const LiveAgentLanes = React.lazy(() => import('@/features/agents/views/LiveAgentLanes').then(m => ({ default: m.LiveAgentLanes })));
 import { LiveEventCard, type LiveEvent } from './LiveEventCard';
+import { extractLiveEventsFromUIMessages } from './liveEvents';
 import { RichMediaSection } from './RichMediaSection';
 import { DocumentActionGrid, extractDocumentActions, type DocumentAction } from './DocumentActionCard';
 import { extractMediaFromText, type ExtractedMedia } from './utils/mediaExtractor';
@@ -1604,78 +1605,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     if (chatMode !== "agent-streaming") return [];
     if (!streamingMessages || streamingMessages.length === 0) return [];
 
-    const events: LiveEvent[] = [];
-    let eventCounter = 0;
-
-    const toToolName = (part: any): string => {
-      if (typeof part?.toolName === "string" && part.toolName.trim()) return part.toolName.trim();
-      if (typeof part?.name === "string" && part.name.trim()) return part.name.trim();
-
-      const type = typeof part?.type === "string" ? part.type : "";
-      const typed = type.match(/^tool-(?:call|result|error)-(.+)$/);
-      if (typed?.[1]) return typed[1];
-
-      const generic = type.match(/^tool-(.+)$/);
-      if (generic?.[1]) return generic[1];
-      return "unknown";
-    };
-
-    for (const raw of streamingMessages as any[]) {
-      const msg = raw?.message ?? raw;
-      const role = msg?.role ?? raw?.role;
-      const parts = Array.isArray(msg?.parts) ? msg.parts : Array.isArray(raw?.parts) ? raw.parts : [];
-      if (role !== "assistant" || parts.length === 0) continue;
-
-      const baseTimestamp =
-        typeof raw?._creationTime === "number"
-          ? raw._creationTime
-          : typeof msg?._creationTime === "number"
-            ? msg._creationTime
-            : Date.now();
-
-      for (const part of parts) {
-        const partType = typeof part?.type === "string" ? part.type : "";
-        const isResult = partType === "tool-result" || partType.startsWith("tool-result");
-        const isError = partType === "tool-error" || partType.startsWith("tool-error");
-        const isCall =
-          !isResult &&
-          !isError &&
-          (partType === "tool-call" || partType.startsWith("tool-"));
-        if (!isCall && !isResult && !isError) continue;
-
-        const toolName = toToolName(part);
-        const title = toolName;
-        const toolCallId =
-          typeof part?.toolCallId === "string" && part.toolCallId.trim() ? part.toolCallId.trim() : null;
-        const idBase = toolCallId ?? raw?._id ?? raw?.id ?? msg?._id ?? msg?.id ?? "msg";
-        const timestamp = baseTimestamp + eventCounter;
-        eventCounter += 1;
-
-        const resultText = part?.output ?? part?.result;
-        const errorText = part?.error ?? part?.output ?? part?.result;
-
-        events.push({
-          id: `${idBase}-${eventCounter}`,
-          type: isError ? "tool_error" : isResult ? "tool_end" : "tool_start",
-          status: isError ? "error" : isResult ? "success" : "running",
-          title,
-          toolName,
-          details:
-            isResult && resultText
-              ? typeof resultText === "string"
-                ? String(resultText).slice(0, 160)
-                : "Completed"
-              : isError && errorText
-                ? String(errorText).slice(0, 160)
-                : isCall
-                  ? "Executing..."
-                  : undefined,
-          timestamp,
-        });
-      }
-    }
-
-    return events;
+    return extractLiveEventsFromUIMessages(streamingMessages);
   }, [chatMode, isProductConversationMode, productConversation.streaming.stages, streamingMessages]);
 
   const createStreamingThread = useAction(api.domains.agents.fastAgentPanelStreaming.createThread);

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -42,7 +42,7 @@ const BriefTab = React.lazy(() => import('./FastAgentPanel.BriefTab').then(m => 
 const TaskManagerView = React.lazy(() => import('../TaskManager').then(m => ({ default: m.TaskManagerView })));
 const SwarmLanesView = React.lazy(() => import('./SwarmLanesView').then(m => ({ default: m.SwarmLanesView })));
 const LiveAgentLanes = React.lazy(() => import('@/features/agents/views/LiveAgentLanes').then(m => ({ default: m.LiveAgentLanes })));
-import type { LiveEvent } from './LiveEventCard';
+import { LiveEventCard, type LiveEvent } from './LiveEventCard';
 import { RichMediaSection } from './RichMediaSection';
 import { DocumentActionGrid, extractDocumentActions, type DocumentAction } from './DocumentActionCard';
 import { extractMediaFromText, type ExtractedMedia } from './utils/mediaExtractor';
@@ -2889,26 +2889,12 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                         </button>
                       </div>
                       <div className="space-y-1">
-                        {liveEvents.slice(-5).map((event) => (
-                          <div key={event.id} className="flex items-center gap-2 py-1 text-xs">
-                            {event.status === 'running' ? (
-                              <Loader2 className="w-3 h-3 motion-safe:animate-spin text-violet-500" />
-                            ) : event.status === 'success' ? (
-                              <div className="w-3 h-3 rounded-full bg-indigo-100 flex items-center justify-center">
-                                <div className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
-                              </div>
-                            ) : (
-                              <div className="w-3 h-3 rounded-full bg-amber-100 flex items-center justify-center">
-                                <div className="w-1.5 h-1.5 rounded-full bg-amber-500" />
-                              </div>
-                            )}
-                            <span className="text-content-secondary truncate flex-1">
-                              {event.title || event.toolName || event.type.replace(/_/g, ' ')}
-                            </span>
-                            {event.duration && (
-                              <span className="text-xs text-content-muted">{event.duration}ms</span>
-                            )}
-                          </div>
+                        {liveEvents.slice(-5).map((event, index, visibleEvents) => (
+                          <LiveEventCard
+                            key={event.id}
+                            event={event}
+                            isLast={index === visibleEvents.length - 1}
+                          />
                         ))}
                       </div>
                     </div>

--- a/src/features/agents/components/FastAgentPanel/LiveEventCard.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/LiveEventCard.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  LiveEventCard,
+  type LiveEvent,
+  type LiveEventStatus,
+  type LiveEventType,
+} from './LiveEventCard';
+
+const motionState = vi.hoisted(() => ({ reduced: false }));
+
+vi.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => motionState.reduced,
+}));
+
+const makeEvent = (overrides: Partial<LiveEvent> = {}): LiveEvent => ({
+  details: 'Fetched three grounded sources.',
+  duration: 1250,
+  id: 'event-1',
+  status: 'running',
+  timestamp: new Date('2026-07-14T12:34:56Z').getTime(),
+  title: 'Search primary sources',
+  toolName: 'web_search',
+  type: 'tool_start',
+  ...overrides,
+});
+
+const stateCases: Array<{
+  status: LiveEventStatus;
+  primitiveState: string;
+  label: string;
+}> = [
+  { status: 'running', primitiveState: 'input-available', label: 'Running' },
+  { status: 'success', primitiveState: 'output-available', label: 'Completed' },
+  { status: 'error', primitiveState: 'output-error', label: 'Error' },
+  { status: 'pending', primitiveState: 'input-streaming', label: 'Pending' },
+];
+
+const iconCases: Array<{
+  type: LiveEventType;
+  toolName?: string;
+  iconKind: string;
+}> = [
+  { type: 'tool_start', toolName: 'web_search', iconKind: 'search' },
+  { type: 'tool_end', toolName: 'create_document', iconKind: 'document' },
+  { type: 'tool_error', toolName: 'memory_lookup', iconKind: 'memory' },
+  { type: 'agent_spawn', iconKind: 'agent' },
+  { type: 'agent_complete', iconKind: 'agent' },
+  { type: 'thinking', iconKind: 'thinking' },
+  { type: 'memory_read', iconKind: 'memory' },
+  { type: 'memory_write', iconKind: 'memory' },
+  { type: 'step_complete', iconKind: 'step' },
+];
+
+describe('LiveEventCard', () => {
+  beforeEach(() => {
+    motionState.reduced = false;
+  });
+
+  it.each(stateCases)(
+    'maps $status to the live Tool state $primitiveState',
+    ({ label, primitiveState, status }) => {
+      const { container } = render(<LiveEventCard event={makeEvent({ status })} />);
+
+      expect(container.querySelector(`[data-tool-state="${primitiveState}"]`)).toBeInTheDocument();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  );
+
+  it.each(iconCases)(
+    'keeps the $type domain renderer as $iconKind',
+    ({ iconKind, toolName, type }) => {
+      const { container } = render(
+        <LiveEventCard event={makeEvent({ toolName, type })} showTimeline={false} />
+      );
+
+      expect(container.querySelector(`[data-event-icon="${iconKind}"]`)).toBeInTheDocument();
+    }
+  );
+
+  it('is expanded by default and preserves metadata while details are disclosed', () => {
+    render(
+      <LiveEventCard
+        event={makeEvent({
+          agentName: 'Research Agent',
+          status: 'success',
+        })}
+      />
+    );
+
+    const trigger = screen.getByRole('button', { name: /search primary sources/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Fetched three grounded sources.')).toBeInTheDocument();
+    expect(screen.getByText('web_search')).toBeInTheDocument();
+    expect(screen.getByText('Research Agent')).toBeInTheDocument();
+    expect(screen.getByText('1.3s')).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Fetched three grounded sources.')).not.toBeInTheDocument();
+    expect(screen.getByText('web_search')).toBeInTheDocument();
+    expect(screen.getByText('Research Agent')).toBeInTheDocument();
+    expect(screen.getByText('1.3s')).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Fetched three grounded sources.')).toBeInTheDocument();
+  });
+
+  it('preserves timeline connector and last-item behavior', () => {
+    const { container, rerender } = render(
+      <LiveEventCard event={makeEvent()} isLast={false} showTimeline />
+    );
+
+    expect(container.querySelector('[data-live-event-connector]')).toBeInTheDocument();
+    expect(container.querySelector('[data-live-event-dot]')).toBeInTheDocument();
+
+    rerender(<LiveEventCard event={makeEvent()} isLast showTimeline />);
+
+    expect(container.querySelector('[data-live-event-connector]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-live-event-dot]')).toBeInTheDocument();
+
+    rerender(<LiveEventCard event={makeEvent()} isLast showTimeline={false} />);
+
+    expect(container.querySelector('[data-live-event-connector]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-live-event-dot]')).not.toBeInTheDocument();
+  });
+
+  it('removes primitive and card motion when reduced motion is preferred', () => {
+    motionState.reduced = true;
+
+    const { container } = render(<LiveEventCard event={makeEvent()} />);
+
+    const reducedMotionSurfaces = container.querySelectorAll('[data-reduced-motion="true"]');
+    expect(reducedMotionSurfaces).toHaveLength(2);
+    for (const surface of reducedMotionSurfaces) {
+      expect(surface).toHaveClass('!animate-none', '!transform-none', '!transition-none');
+    }
+  });
+});

--- a/src/features/agents/components/FastAgentPanel/LiveEventCard.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/LiveEventCard.test.tsx
@@ -34,6 +34,7 @@ const stateCases: Array<{
   { status: 'running', primitiveState: 'input-available', label: 'Running' },
   { status: 'success', primitiveState: 'output-available', label: 'Completed' },
   { status: 'error', primitiveState: 'output-error', label: 'Error' },
+  { status: 'denied', primitiveState: 'output-denied', label: 'Denied' },
   { status: 'pending', primitiveState: 'input-streaming', label: 'Pending' },
 ];
 

--- a/src/features/agents/components/FastAgentPanel/LiveEventCard.tsx
+++ b/src/features/agents/components/FastAgentPanel/LiveEventCard.tsx
@@ -34,7 +34,12 @@ export type LiveEventType =
   | 'memory_read'
   | 'memory_write';
 
-export type LiveEventStatus = 'running' | 'success' | 'error' | 'pending';
+export type LiveEventStatus =
+  | 'running'
+  | 'success'
+  | 'error'
+  | 'denied'
+  | 'pending';
 
 export interface LiveEvent {
   id: string;
@@ -59,6 +64,7 @@ type EventIconKind =
   | 'web';
 
 const TOOL_STATE_BY_STATUS: Record<LiveEventStatus, ToolPart['state']> = {
+  denied: 'output-denied',
   error: 'output-error',
   pending: 'input-streaming',
   running: 'input-available',
@@ -132,6 +138,13 @@ function getStatusStyles(status: LiveEventStatus) {
         dot: 'bg-red-500',
         icon: 'text-red-500',
       };
+    case 'denied':
+      return {
+        bg: 'bg-accent-primary/[0.06]',
+        border: 'border-accent-primary/20',
+        dot: 'bg-accent-primary',
+        icon: 'text-accent-primary',
+      };
     case 'pending':
     default:
       return {
@@ -190,6 +203,7 @@ export function LiveEventCard({
                 'border-violet-500 motion-safe:animate-pulse',
               event.status === 'success' && 'border-green-500',
               event.status === 'error' && 'border-red-500',
+              event.status === 'denied' && 'border-accent-primary',
               event.status === 'pending' && 'border-content-muted',
               reducedMotion && '!animate-none !transition-none'
             )}

--- a/src/features/agents/components/FastAgentPanel/LiveEventCard.tsx
+++ b/src/features/agents/components/FastAgentPanel/LiveEventCard.tsx
@@ -1,31 +1,33 @@
 // src/components/FastAgentPanel/LiveEventCard.tsx
-// Modern AG-UI card component for displaying live agent events
+// Disclosure card for live agent events backed by AI Elements primitives.
 
-import React from 'react';
-import { 
-  Wrench, 
-  CheckCircle2, 
-  XCircle, 
-  Bot, 
-  Loader2, 
-  Zap,
-  Search,
-  FileText,
+import type { ReactNode } from 'react';
+import {
+  Bot,
+  Brain,
+  Clock,
   Database,
+  FileText,
   Globe,
-  Brain
+  Search,
+  Wrench,
+  Zap,
 } from 'lucide-react';
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  type ToolPart,
+} from '@/components/ai-elements/tool';
+import { TaskItem } from '@/components/ai-elements/task';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 
-// ═══════════════════════════════════════════════════════════════════════════
-// TYPES
-// ═══════════════════════════════════════════════════════════════════════════
-
-export type LiveEventType = 
-  | 'tool_start' 
-  | 'tool_end' 
+export type LiveEventType =
+  | 'tool_start'
+  | 'tool_end'
   | 'tool_error'
-  | 'agent_spawn' 
+  | 'agent_spawn'
   | 'agent_complete'
   | 'step_complete'
   | 'thinking'
@@ -46,48 +48,64 @@ export interface LiveEvent {
   duration?: number; // ms
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// HELPERS
-// ═══════════════════════════════════════════════════════════════════════════
+type EventIconKind =
+  | 'agent'
+  | 'document'
+  | 'memory'
+  | 'search'
+  | 'step'
+  | 'thinking'
+  | 'tool'
+  | 'web';
 
-function getEventIcon(event: LiveEvent) {
-  const iconClass = "w-3.5 h-3.5";
-  
+const TOOL_STATE_BY_STATUS: Record<LiveEventStatus, ToolPart['state']> = {
+  error: 'output-error',
+  pending: 'input-streaming',
+  running: 'input-available',
+  success: 'output-available',
+};
+
+function getEventVisual(event: LiveEvent): {
+  icon: ReactNode;
+  kind: EventIconKind;
+} {
+  const iconClass = 'h-3.5 w-3.5';
+
   switch (event.type) {
     case 'tool_start':
     case 'tool_end':
-    case 'tool_error':
-      // Try to guess icon based on tool name
-      if (event.toolName?.toLowerCase().includes('search')) {
-        return <Search className={iconClass} />;
+    case 'tool_error': {
+      const toolName = event.toolName?.toLowerCase() ?? '';
+
+      if (toolName.includes('search')) {
+        return { icon: <Search className={iconClass} />, kind: 'search' };
       }
-      if (event.toolName?.toLowerCase().includes('document')) {
-        return <FileText className={iconClass} />;
+      if (toolName.includes('document')) {
+        return { icon: <FileText className={iconClass} />, kind: 'document' };
       }
-      if (event.toolName?.toLowerCase().includes('memory')) {
-        return <Database className={iconClass} />;
+      if (toolName.includes('memory')) {
+        return { icon: <Database className={iconClass} />, kind: 'memory' };
       }
-      if (event.toolName?.toLowerCase().includes('web') || event.toolName?.toLowerCase().includes('linkup')) {
-        return <Globe className={iconClass} />;
+      if (toolName.includes('web') || toolName.includes('linkup')) {
+        return { icon: <Globe className={iconClass} />, kind: 'web' };
       }
-      return <Wrench className={iconClass} />;
-    
+      return { icon: <Wrench className={iconClass} />, kind: 'tool' };
+    }
+
     case 'agent_spawn':
     case 'agent_complete':
-      return <Bot className={iconClass} />;
-    
+      return { icon: <Bot className={iconClass} />, kind: 'agent' };
+
     case 'thinking':
-      return <Brain className={iconClass} />;
-    
+      return { icon: <Brain className={iconClass} />, kind: 'thinking' };
+
     case 'memory_read':
     case 'memory_write':
-      return <Database className={iconClass} />;
-    
+      return { icon: <Database className={iconClass} />, kind: 'memory' };
+
     case 'step_complete':
-      return <Zap className={iconClass} />;
-    
     default:
-      return <Zap className={iconClass} />;
+      return { icon: <Zap className={iconClass} />, kind: 'step' };
   }
 }
 
@@ -97,34 +115,30 @@ function getStatusStyles(status: LiveEventStatus) {
       return {
         bg: 'bg-blue-50 dark:bg-blue-900/20',
         border: 'border-blue-200 dark:border-blue-800',
-        text: 'text-violet-700 dark:text-violet-400',
-        icon: 'text-violet-500',
         dot: 'bg-violet-500',
+        icon: 'text-violet-500',
       };
     case 'success':
       return {
         bg: 'bg-green-50 dark:bg-green-900/20',
         border: 'border-green-200 dark:border-green-800',
-        text: 'text-green-700 dark:text-green-400',
-        icon: 'text-green-500',
         dot: 'bg-green-500',
+        icon: 'text-green-500',
       };
     case 'error':
       return {
         bg: 'bg-red-50 dark:bg-red-900/20',
         border: 'border-red-200 dark:border-red-800',
-        text: 'text-red-700 dark:text-red-400',
-        icon: 'text-red-500',
         dot: 'bg-red-500',
+        icon: 'text-red-500',
       };
     case 'pending':
     default:
       return {
         bg: 'bg-surface-secondary dark:bg-gray-800/50',
         border: 'border-edge dark:border-edge',
-        text: 'text-content-secondary dark:text-content-secondary',
-        icon: 'text-content-muted',
         dot: 'bg-content-muted',
+        icon: 'text-content-muted',
       };
   }
 }
@@ -136,13 +150,12 @@ function formatDuration(ms: number): string {
 }
 
 function formatTimestamp(ts: number): string {
-  const date = new Date(ts);
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  return new Date(ts).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 }
-
-// ═══════════════════════════════════════════════════════════════════════════
-// COMPONENT
-// ═══════════════════════════════════════════════════════════════════════════
 
 interface LiveEventCardProps {
   event: LiveEvent;
@@ -150,104 +163,112 @@ interface LiveEventCardProps {
   isLast?: boolean;
 }
 
-export function LiveEventCard({ event, showTimeline = true, isLast = false }: LiveEventCardProps) {
+export function LiveEventCard({
+  event,
+  showTimeline = true,
+  isLast = false,
+}: LiveEventCardProps) {
+  const reducedMotion = useReducedMotion();
   const styles = getStatusStyles(event.status);
-  const icon = getEventIcon(event);
+  const eventVisual = getEventVisual(event);
+  const toolState = TOOL_STATE_BY_STATUS[event.status];
 
   return (
-    <div className={cn(
-      "relative",
-      showTimeline && "pl-6"
-    )}>
-      {/* Timeline connector */}
+    <div className={cn('relative', showTimeline && 'pl-6')}>
       {showTimeline && (
         <>
-          {/* Vertical line */}
           {!isLast && (
-            <div className="absolute left-[9px] top-5 bottom-0 w-0.5 bg-[var(--border-color)] dark:bg-[var(--border-color)]" />
+            <div
+              className="absolute bottom-0 left-[9px] top-5 w-0.5 bg-[var(--border-color)]"
+              data-live-event-connector
+            />
           )}
-          {/* Status dot */}
-          <div className={cn(
-            "absolute left-1 top-2 w-4 h-4 rounded-full border-2 flex items-center justify-center bg-surface dark:bg-gray-900 z-10",
-            event.status === 'running' && "border-violet-500 motion-safe:animate-pulse",
-            event.status === 'success' && "border-green-500",
-            event.status === 'error' && "border-red-500",
-            event.status === 'pending' && "border-content-muted"
-          )}>
-            <div className={cn("w-1.5 h-1.5 rounded-full", styles.dot)} />
+          <div
+            className={cn(
+              'absolute left-1 top-2 z-10 flex h-4 w-4 items-center justify-center rounded-full border-2 bg-surface',
+              event.status === 'running' &&
+                'border-violet-500 motion-safe:animate-pulse',
+              event.status === 'success' && 'border-green-500',
+              event.status === 'error' && 'border-red-500',
+              event.status === 'pending' && 'border-content-muted',
+              reducedMotion && '!animate-none !transition-none'
+            )}
+            data-live-event-dot
+          >
+            <div className={cn('h-1.5 w-1.5 rounded-full', styles.dot)} />
           </div>
         </>
       )}
 
-      {/* Card */}
-      <div className={cn(
-        "mb-2 rounded-lg border p-2.5 transition-all duration-200",
-        "hover:shadow-sm",
-        styles.bg,
-        styles.border,
-        event.status === 'running' && "animate-in fade-in slide-in-from-left-2 duration-300"
-      )}>
-        {/* Header row */}
-        <div className="flex items-center gap-2">
-          {/* Icon */}
-          <div className={cn(
-            "flex-shrink-0 p-1 rounded",
-            styles.bg,
-            styles.icon
-          )}>
-            {event.status === 'running' ? (
-              <Loader2 className="w-3.5 h-3.5 motion-safe:animate-spin" />
-            ) : event.status === 'success' ? (
-              <CheckCircle2 className="w-3.5 h-3.5" />
-            ) : event.status === 'error' ? (
-              <XCircle className="w-3.5 h-3.5" />
-            ) : (
-              icon
+      <Tool
+        className={cn(
+          'mb-2 overflow-hidden rounded-lg border transition-all duration-200 hover:shadow-sm',
+          styles.bg,
+          styles.border,
+          event.status === 'running' &&
+            'animate-in fade-in slide-in-from-left-2 duration-300',
+          reducedMotion && '!animate-none !transform-none !transition-none'
+        )}
+        data-event-status={event.status}
+        data-reduced-motion={reducedMotion ? 'true' : undefined}
+        data-tool-state={toolState}
+        defaultOpen
+      >
+        <div className="relative">
+          <span
+            className={cn(
+              'pointer-events-none absolute left-3 top-3 z-10 flex h-4 w-4 items-center justify-center',
+              styles.icon
             )}
-          </div>
-
-          {/* Title */}
-          <div className="flex-1 min-w-0">
-            <div className={cn(
-              "text-xs font-medium truncate",
-              styles.text
-            )}>
-              {event.title}
-            </div>
-            {event.toolName && (
-              <div className="text-xs font-mono text-content-secondary dark:text-content-secondary truncate">
-                {event.toolName}
-              </div>
+            data-event-icon={eventVisual.kind}
+          >
+            {eventVisual.icon}
+          </span>
+          <ToolHeader
+            className={cn(
+              'gap-2 py-2.5 pl-9 pr-3 text-left [&>div]:min-w-0 [&>div]:flex-1 [&>div>span]:truncate [&>div>svg:first-child]:hidden',
+              reducedMotion &&
+                '[&_.animate-pulse]:!animate-none [&>svg]:!transition-none'
             )}
-          </div>
-
-          {/* Status badge / Duration */}
-          <div className="flex-shrink-0 flex items-center gap-1.5">
-            {event.duration !== undefined && event.status === 'success' && (
-              <span className="text-xs text-content-secondary dark:text-content-secondary">
-                {formatDuration(event.duration)}
-              </span>
-            )}
-            {event.status === 'running' && (
-              <span className="text-xs px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 font-medium">
-                Running
-              </span>
-            )}
-          </div>
+            state={toolState}
+            title={event.title}
+            toolName={event.toolName ?? event.type}
+            type="dynamic-tool"
+          />
         </div>
 
-        {/* Details (if any) */}
-        {event.details && (
-          <div className="mt-1.5 text-xs text-content-secondary dark:text-content-secondary line-clamp-2">
-            {event.details}
+        {(event.toolName ||
+          event.agentName ||
+          (event.duration !== undefined && event.status === 'success')) && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-current/10 px-3 py-1.5 text-xs text-content-secondary">
+            {event.toolName && (
+              <span className="truncate font-mono">{event.toolName}</span>
+            )}
+            {event.agentName && <span>{event.agentName}</span>}
+            {event.duration !== undefined && event.status === 'success' && (
+              <span className="ml-auto">{formatDuration(event.duration)}</span>
+            )}
           </div>
         )}
 
-        {/* Timestamp */}
-        <div className="mt-1 text-xs text-content-muted dark:text-content-muted">
-          {formatTimestamp(event.timestamp)}
-        </div>
-      </div>
+        <ToolContent
+          className={cn(
+            'space-y-1 border-t border-current/10 px-3 pb-2.5 pt-2',
+            reducedMotion && '!animate-none !transform-none !transition-none'
+          )}
+          data-reduced-motion={reducedMotion ? 'true' : undefined}
+        >
+          {event.details && (
+            <TaskItem className="line-clamp-2 text-xs text-content-secondary">
+              {event.details}
+            </TaskItem>
+          )}
+          <TaskItem className="flex items-center gap-1 text-xs text-content-muted">
+            <Clock aria-hidden="true" className="h-3 w-3" />
+            {formatTimestamp(event.timestamp)}
+          </TaskItem>
+        </ToolContent>
+      </Tool>
     </div>
   );
 }

--- a/src/features/agents/components/FastAgentPanel/liveEvents.test.ts
+++ b/src/features/agents/components/FastAgentPanel/liveEvents.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractLiveEventsFromUIMessages } from './liveEvents';
+
+type TestPart = Record<string, unknown> & { type: string };
+
+function streamingMessages(parts: TestPart[]) {
+  return [
+    {
+      _creationTime: 1_000,
+      _id: 'stored-message-1',
+      message: {
+        id: 'message-1',
+        parts,
+        role: 'assistant',
+      },
+    },
+  ];
+}
+
+describe('extractLiveEventsFromUIMessages', () => {
+  it('maps a unified output-available tool to one successful terminal event', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          input: { query: 'NodeBench' },
+          output: { results: 3 },
+          state: 'output-available',
+          toolCallId: 'search-1',
+          type: 'tool-fusionSearch',
+        },
+      ])
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      details: 'Completed',
+      id: 'search-1-1',
+      status: 'success',
+      title: 'fusionSearch',
+      toolName: 'fusionSearch',
+      type: 'tool_end',
+    });
+  });
+
+  it('uses unified errorText and treats output-denied as an error terminal', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          errorText: 'Provider failed safely',
+          input: { url: 'https://example.com' },
+          state: 'output-error',
+          toolCallId: 'fetch-1',
+          type: 'tool-fetchUrl',
+        },
+        {
+          errorText: 'Approval denied',
+          input: { id: 'doc-1' },
+          state: 'output-denied',
+          toolCallId: 'write-1',
+          type: 'tool-writeDocument',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Provider failed safely',
+        status: 'error',
+        type: 'tool_error',
+      },
+      {
+        details: 'Approval denied',
+        status: 'error',
+        type: 'tool_error',
+      },
+    ]);
+  });
+
+  it('distinguishes unified input-streaming pending from input-available running', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          input: '',
+          state: 'input-streaming',
+          toolCallId: 'pending-1',
+          type: 'tool-webSearch',
+        },
+        {
+          input: { query: 'NodeBench' },
+          state: 'input-available',
+          toolCallId: 'running-1',
+          type: 'tool-webSearch',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Preparing...',
+        status: 'pending',
+        type: 'tool_start',
+      },
+      {
+        details: 'Executing...',
+        status: 'running',
+        type: 'tool_start',
+      },
+    ]);
+  });
+
+  it('keeps a dynamic tool name and unified terminal state', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          input: { company: 'NodeBench' },
+          output: 'Saved',
+          state: 'output-available',
+          toolCallId: 'dynamic-1',
+          toolName: 'customerTool',
+          type: 'dynamic-tool',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Saved',
+        status: 'success',
+        title: 'customerTool',
+        toolName: 'customerTool',
+        type: 'tool_end',
+      },
+    ]);
+  });
+
+  it('preserves legacy call, result, and error compatibility', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          args: { query: 'NodeBench' },
+          toolCallId: 'legacy-call',
+          toolName: 'legacySearch',
+          type: 'tool-call',
+        },
+        {
+          output: 'Found three results',
+          toolCallId: 'legacy-result',
+          toolName: 'legacySearch',
+          type: 'tool-result',
+        },
+        {
+          error: 'Legacy provider failed',
+          toolCallId: 'legacy-error',
+          toolName: 'legacySearch',
+          type: 'tool-error',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Executing...',
+        status: 'running',
+        type: 'tool_start',
+      },
+      {
+        details: 'Found three results',
+        status: 'success',
+        type: 'tool_end',
+      },
+      {
+        details: 'Legacy provider failed',
+        status: 'error',
+        type: 'tool_error',
+      },
+    ]);
+  });
+});

--- a/src/features/agents/components/FastAgentPanel/liveEvents.test.ts
+++ b/src/features/agents/components/FastAgentPanel/liveEvents.test.ts
@@ -35,7 +35,7 @@ describe('extractLiveEventsFromUIMessages', () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       details: 'Completed',
-      id: 'search-1-1',
+      id: 'search-1-unified',
       status: 'success',
       title: 'fusionSearch',
       toolName: 'fusionSearch',
@@ -43,7 +43,7 @@ describe('extractLiveEventsFromUIMessages', () => {
     });
   });
 
-  it('uses unified errorText and treats output-denied as an error terminal', () => {
+  it('uses unified errorText and preserves output-denied as a denied terminal', () => {
     const events = extractLiveEventsFromUIMessages(
       streamingMessages([
         {
@@ -71,7 +71,67 @@ describe('extractLiveEventsFromUIMessages', () => {
       },
       {
         details: 'Approval denied',
+        status: 'denied',
+        type: 'tool_error',
+      },
+    ]);
+  });
+
+  it('forces a terminal error when unified errorText arrives before state catches up', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          errorText: 'Provider failed safely',
+          input: { url: 'https://example.com' },
+          state: 'input-available',
+          toolCallId: 'fetch-lagging-state',
+          type: 'tool-fetchUrl',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Provider failed safely',
+        id: 'fetch-lagging-state-unified',
         status: 'error',
+        type: 'tool_error',
+      },
+    ]);
+  });
+
+  it('fails closed by skipping an unrecognized unified state without error evidence', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          input: { query: 'NodeBench' },
+          state: 'mystery-state',
+          toolCallId: 'unknown-state-1',
+          type: 'tool-webSearch',
+        },
+      ])
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it('uses honest denial fallback copy when the provider omits a denial reason', () => {
+    const events = extractLiveEventsFromUIMessages(
+      streamingMessages([
+        {
+          input: { id: 'doc-1' },
+          state: 'output-denied',
+          toolCallId: 'write-denied',
+          type: 'tool-writeDocument',
+        },
+      ])
+    );
+
+    expect(events).toMatchObject([
+      {
+        details: 'Tool execution denied',
+        id: 'write-denied-unified',
+        status: 'denied',
         type: 'tool_error',
       },
     ]);
@@ -175,5 +235,87 @@ describe('extractLiveEventsFromUIMessages', () => {
         type: 'tool_error',
       },
     ]);
+  });
+
+  it('keeps a tool event id stable when an unrelated earlier part is prepended', () => {
+    const targetPart: TestPart = {
+      input: { query: 'NodeBench' },
+      state: 'input-available',
+      toolCallId: 'stable-target',
+      type: 'tool-webSearch',
+    };
+    const unrelatedPart: TestPart = {
+      input: { id: 'doc-1' },
+      state: 'output-available',
+      toolCallId: 'unrelated-earlier',
+      type: 'tool-readDocument',
+    };
+
+    const beforeId = extractLiveEventsFromUIMessages(
+      streamingMessages([targetPart])
+    )[0]?.id;
+    const afterId = extractLiveEventsFromUIMessages(
+      streamingMessages([unrelatedPart, targetPart])
+    ).find((event) => event.toolName === 'webSearch')?.id;
+
+    expect(beforeId).toBe('stable-target-unified');
+    expect(afterId).toBe(beforeId);
+  });
+
+  it('creates deterministic collision-safe ids for legacy events sharing a tool call id', () => {
+    const parts: TestPart[] = [
+      {
+        args: { query: 'NodeBench' },
+        toolCallId: 'shared-call',
+        toolName: 'legacySearch',
+        type: 'tool-call',
+      },
+      {
+        output: 'Found three results',
+        toolCallId: 'shared-call',
+        toolName: 'legacySearch',
+        type: 'tool-result',
+      },
+      {
+        error: 'Legacy provider failed',
+        toolCallId: 'shared-call',
+        toolName: 'legacySearch',
+        type: 'tool-error',
+      },
+    ];
+
+    const firstIds = extractLiveEventsFromUIMessages(streamingMessages(parts)).map(
+      (event) => event.id
+    );
+    const secondIds = extractLiveEventsFromUIMessages(streamingMessages(parts)).map(
+      (event) => event.id
+    );
+
+    expect(firstIds).toEqual([
+      'shared-call-call',
+      'shared-call-result',
+      'shared-call-error',
+    ]);
+    expect(new Set(firstIds).size).toBe(firstIds.length);
+    expect(secondIds).toEqual(firstIds);
+  });
+
+  it('uses a deterministic suffix when fallback source fingerprints collide', () => {
+    const part: TestPart = {
+      input: { query: 'NodeBench' },
+      state: 'input-available',
+      type: 'tool-webSearch',
+    };
+
+    const firstIds = extractLiveEventsFromUIMessages(
+      streamingMessages([part, { ...part }])
+    ).map((event) => event.id);
+    const secondIds = extractLiveEventsFromUIMessages(
+      streamingMessages([part, { ...part }])
+    ).map((event) => event.id);
+
+    expect(firstIds[0]).toMatch(/^stored-message-1-unified-[a-z0-9]+$/);
+    expect(firstIds[1]).toBe(`${firstIds[0]}-2`);
+    expect(secondIds).toEqual(firstIds);
   });
 });

--- a/src/features/agents/components/FastAgentPanel/liveEvents.ts
+++ b/src/features/agents/components/FastAgentPanel/liveEvents.ts
@@ -1,0 +1,213 @@
+import type { LiveEvent } from './LiveEventCard';
+
+type MessagePart = Record<string, unknown> & { type?: unknown };
+type MessageRecord = Record<string, unknown> & {
+  message?: unknown;
+  parts?: unknown;
+  role?: unknown;
+};
+
+type UnifiedToolState =
+  | 'input-streaming'
+  | 'input-available'
+  | 'output-available'
+  | 'output-error'
+  | 'output-denied';
+
+const UNIFIED_EVENT_BY_STATE: Record<
+  UnifiedToolState,
+  Pick<LiveEvent, 'status' | 'type'>
+> = {
+  'input-streaming': { status: 'pending', type: 'tool_start' },
+  'input-available': { status: 'running', type: 'tool_start' },
+  'output-available': { status: 'success', type: 'tool_end' },
+  'output-error': { status: 'error', type: 'tool_error' },
+  'output-denied': { status: 'error', type: 'tool_error' },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function firstPresent(...values: unknown[]): unknown {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
+function hasOwn(record: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function toToolName(part: MessagePart): string {
+  const explicit = nonEmptyString(part.toolName) ?? nonEmptyString(part.name);
+  if (explicit) return explicit;
+
+  const type = typeof part.type === 'string' ? part.type : '';
+  const typed = type.match(/^tool-(?:call|result|error)-(.+)$/);
+  if (typed?.[1]) return typed[1];
+
+  const unified = type.match(/^tool-(.+)$/);
+  if (unified?.[1]) return unified[1];
+  return 'unknown';
+}
+
+function terminalOutputDetails(part: MessagePart): string | undefined {
+  const output = firstPresent(part.output, part.result);
+  if (typeof output === 'string') {
+    return output.length > 0 ? output.slice(0, 160) : undefined;
+  }
+  return output === undefined ? undefined : 'Completed';
+}
+
+function unifiedErrorDetails(part: MessagePart): string {
+  const error = nonEmptyString(part.errorText) ?? firstPresent(part.error);
+  return error === undefined
+    ? 'Tool execution failed'
+    : String(error).slice(0, 160);
+}
+
+function unifiedToolEvent(part: MessagePart): {
+  details?: string;
+  status: LiveEvent['status'];
+  type: LiveEvent['type'];
+} {
+  const state =
+    typeof part.state === 'string' && hasOwn(UNIFIED_EVENT_BY_STATE, part.state)
+      ? (part.state as UnifiedToolState)
+      : undefined;
+  const eventState = state
+    ? UNIFIED_EVENT_BY_STATE[state]
+    : UNIFIED_EVENT_BY_STATE['input-available'];
+
+  if (eventState.type === 'tool_end') {
+    return { ...eventState, details: terminalOutputDetails(part) };
+  }
+  if (eventState.type === 'tool_error') {
+    return { ...eventState, details: unifiedErrorDetails(part) };
+  }
+  return {
+    ...eventState,
+    details: eventState.status === 'pending' ? 'Preparing...' : 'Executing...',
+  };
+}
+
+/**
+ * Translate the actual `useUIMessages` payload into the live-activity contract.
+ * Convex Agent emits unified AI SDK tool parts and updates their `state` in
+ * place; older stored messages can still contain split call/result/error parts.
+ */
+export function extractLiveEventsFromUIMessages(
+  streamingMessages: readonly unknown[]
+): LiveEvent[] {
+  const events: LiveEvent[] = [];
+  let eventCounter = 0;
+
+  for (const rawValue of streamingMessages) {
+    if (!isRecord(rawValue)) continue;
+    const raw = rawValue as MessageRecord;
+    const nestedMessage = isRecord(raw.message)
+      ? (raw.message as MessageRecord)
+      : undefined;
+    const message = nestedMessage ?? raw;
+    const role = message.role ?? raw.role;
+    const rawParts = Array.isArray(message.parts)
+      ? message.parts
+      : Array.isArray(raw.parts)
+        ? raw.parts
+        : [];
+    if (role !== 'assistant' || rawParts.length === 0) continue;
+
+    const baseTimestamp =
+      typeof raw._creationTime === 'number'
+        ? raw._creationTime
+        : typeof message._creationTime === 'number'
+          ? message._creationTime
+          : Date.now();
+
+    for (const rawPart of rawParts) {
+      if (!isRecord(rawPart)) continue;
+      const part = rawPart as MessagePart;
+      const partType = typeof part.type === 'string' ? part.type : '';
+      const isLegacyResult =
+        partType === 'tool-result' || partType.startsWith('tool-result-');
+      const isLegacyError =
+        partType === 'tool-error' || partType.startsWith('tool-error-');
+      const isLegacyCall =
+        partType === 'tool-call' || partType.startsWith('tool-call-');
+      const isUnifiedTool =
+        partType === 'dynamic-tool' ||
+        (partType.startsWith('tool-') &&
+          !isLegacyCall &&
+          !isLegacyResult &&
+          !isLegacyError);
+      if (
+        !isLegacyCall &&
+        !isLegacyResult &&
+        !isLegacyError &&
+        !isUnifiedTool
+      ) {
+        continue;
+      }
+
+      const toolName = toToolName(part);
+      const toolCallId = nonEmptyString(part.toolCallId);
+      const idBase =
+        toolCallId ??
+        nonEmptyString(raw._id) ??
+        nonEmptyString(raw.id) ??
+        nonEmptyString(message._id) ??
+        nonEmptyString(message.id) ??
+        'msg';
+      const timestamp = baseTimestamp + eventCounter;
+      eventCounter += 1;
+
+      if (isUnifiedTool) {
+        const unifiedEvent = unifiedToolEvent(part);
+        events.push({
+          id: `${idBase}-${eventCounter}`,
+          title: toolName,
+          toolName,
+          timestamp,
+          ...unifiedEvent,
+        });
+        continue;
+      }
+
+      const result = firstPresent(part.output, part.result);
+      const error = firstPresent(part.error, part.output, part.result);
+      events.push({
+        id: `${idBase}-${eventCounter}`,
+        type: isLegacyError
+          ? 'tool_error'
+          : isLegacyResult
+            ? 'tool_end'
+            : 'tool_start',
+        status: isLegacyError
+          ? 'error'
+          : isLegacyResult
+            ? 'success'
+            : 'running',
+        title: toolName,
+        toolName,
+        details:
+          isLegacyResult && result
+            ? typeof result === 'string'
+              ? result.slice(0, 160)
+              : 'Completed'
+            : isLegacyError && error
+              ? String(error).slice(0, 160)
+              : isLegacyCall
+                ? 'Executing...'
+                : undefined,
+        timestamp,
+      });
+    }
+  }
+
+  return events;
+}

--- a/src/features/agents/components/FastAgentPanel/liveEvents.ts
+++ b/src/features/agents/components/FastAgentPanel/liveEvents.ts
@@ -22,7 +22,7 @@ const UNIFIED_EVENT_BY_STATE: Record<
   'input-available': { status: 'running', type: 'tool_start' },
   'output-available': { status: 'success', type: 'tool_end' },
   'output-error': { status: 'error', type: 'tool_error' },
-  'output-denied': { status: 'error', type: 'tool_error' },
+  'output-denied': { status: 'denied', type: 'tool_error' },
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -71,18 +71,114 @@ function unifiedErrorDetails(part: MessagePart): string {
     : String(error).slice(0, 160);
 }
 
+function unifiedDeniedDetails(part: MessagePart): string {
+  const reason =
+    nonEmptyString(part.errorText) ??
+    nonEmptyString(part.denialReason) ??
+    nonEmptyString(part.reason) ??
+    nonEmptyString(part.error);
+  return reason?.slice(0, 160) ?? 'Tool execution denied';
+}
+
+function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (typeof value === 'bigint') return `${value.toString()}n`;
+  if (typeof value !== 'object') return String(value);
+  if (seen.has(value)) return '"[Circular]"';
+
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const serialized = `[${value
+      .map((entry) => stableSerialize(entry, seen))
+      .join(',')}]`;
+    seen.delete(value);
+    return serialized;
+  }
+
+  const serialized = `{${Object.keys(value)
+    .sort()
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stableSerialize(
+          (value as Record<string, unknown>)[key],
+          seen
+        )}`
+    )
+    .join(',')}}`;
+  seen.delete(value);
+  return serialized;
+}
+
+function stableHash(value: unknown): string {
+  const serialized = stableSerialize(value);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < serialized.length; index += 1) {
+    hash ^= serialized.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function eventIdBase(
+  part: MessagePart,
+  semantic: 'call' | 'error' | 'result' | 'unified',
+  sourceIdentity?: string
+): string {
+  const toolCallId = nonEmptyString(part.toolCallId);
+  if (toolCallId) return `${toolCallId}-${semantic}`;
+
+  const fingerprint = stableHash(part);
+  return sourceIdentity
+    ? `${sourceIdentity}-${semantic}-${fingerprint}`
+    : `part-${semantic}-${fingerprint}`;
+}
+
+function allocateEventId(
+  base: string,
+  occurrences: Map<string, number>
+): string {
+  const occurrence = (occurrences.get(base) ?? 0) + 1;
+  occurrences.set(base, occurrence);
+  return occurrence === 1 ? base : `${base}-${occurrence}`;
+}
+
 function unifiedToolEvent(part: MessagePart): {
   details?: string;
   status: LiveEvent['status'];
   type: LiveEvent['type'];
-} {
+} | null {
   const state =
     typeof part.state === 'string' && hasOwn(UNIFIED_EVENT_BY_STATE, part.state)
       ? (part.state as UnifiedToolState)
       : undefined;
-  const eventState = state
-    ? UNIFIED_EVENT_BY_STATE[state]
-    : UNIFIED_EVENT_BY_STATE['input-available'];
+  const errorText = nonEmptyString(part.errorText);
+
+  if (state === 'output-denied') {
+    return {
+      ...UNIFIED_EVENT_BY_STATE[state],
+      details: unifiedDeniedDetails(part),
+    };
+  }
+
+  // Convex Agent can attach tool-error delta text before advancing the part's
+  // state. Error evidence must win over a stale running/success state.
+  if (errorText) {
+    return {
+      ...UNIFIED_EVENT_BY_STATE['output-error'],
+      details: unifiedErrorDetails(part),
+    };
+  }
+
+  // Unknown future states must not be presented as work that is definitely
+  // running. Skip them until the adapter knows their honest semantics.
+  if (!state) return null;
+
+  const eventState = UNIFIED_EVENT_BY_STATE[state];
 
   if (eventState.type === 'tool_end') {
     return { ...eventState, details: terminalOutputDetails(part) };
@@ -106,6 +202,7 @@ export function extractLiveEventsFromUIMessages(
 ): LiveEvent[] {
   const events: LiveEvent[] = [];
   let eventCounter = 0;
+  const idOccurrences = new Map<string, number>();
 
   for (const rawValue of streamingMessages) {
     if (!isRecord(rawValue)) continue;
@@ -128,6 +225,11 @@ export function extractLiveEventsFromUIMessages(
         : typeof message._creationTime === 'number'
           ? message._creationTime
           : Date.now();
+    const sourceIdentity =
+      nonEmptyString(raw._id) ??
+      nonEmptyString(raw.id) ??
+      nonEmptyString(message._id) ??
+      nonEmptyString(message.id);
 
     for (const rawPart of rawParts) {
       if (!isRecord(rawPart)) continue;
@@ -155,21 +257,17 @@ export function extractLiveEventsFromUIMessages(
       }
 
       const toolName = toToolName(part);
-      const toolCallId = nonEmptyString(part.toolCallId);
-      const idBase =
-        toolCallId ??
-        nonEmptyString(raw._id) ??
-        nonEmptyString(raw.id) ??
-        nonEmptyString(message._id) ??
-        nonEmptyString(message.id) ??
-        'msg';
-      const timestamp = baseTimestamp + eventCounter;
-      eventCounter += 1;
 
       if (isUnifiedTool) {
         const unifiedEvent = unifiedToolEvent(part);
+        if (!unifiedEvent) continue;
+        const timestamp = baseTimestamp + eventCounter;
+        eventCounter += 1;
         events.push({
-          id: `${idBase}-${eventCounter}`,
+          id: allocateEventId(
+            eventIdBase(part, 'unified', sourceIdentity),
+            idOccurrences
+          ),
           title: toolName,
           toolName,
           timestamp,
@@ -180,8 +278,18 @@ export function extractLiveEventsFromUIMessages(
 
       const result = firstPresent(part.output, part.result);
       const error = firstPresent(part.error, part.output, part.result);
+      const semantic = isLegacyError
+        ? 'error'
+        : isLegacyResult
+          ? 'result'
+          : 'call';
+      const timestamp = baseTimestamp + eventCounter;
+      eventCounter += 1;
       events.push({
-        id: `${idBase}-${eventCounter}`,
+        id: allocateEventId(
+          eventIdBase(part, semantic, sourceIdentity),
+          idOccurrences
+        ),
         type: isLegacyError
           ? 'tool_error'
           : isLegacyResult


### PR DESCRIPTION
## What changed

- Migrates FastAgentPanel live tool activity onto the shared AI Elements Tool primitive.
- Adds a single typed projection from unified and legacy event streams with stable semantic IDs and deterministic collision suffixes.
- Preserves honest Pending/Running/Completed/Error/Denied states, including `output-denied` and lagging nonempty `errorText` precedence.
- Fails closed for unknown future unified states instead of falsely presenting them as running.
- Adds an accessible compact-sidebar Live Events opener on the canonical Cockpit path without duplicating the global overlay or streaming hook.
- Adds focused projection, card, denied/error, ID-stability, collision, and header reachability coverage.

## Why

The previous custom card could not safely adopt the primitive while unified event states, legacy events, and compact sidebar reachability were mixed in the parent. Two rounds of independent review found and then verified fixes for stale error state, unstable IDs, lost denial semantics, and an unreachable canonical opener.

## Validation

- Focused Live/Header/Tool/Input/UIMessage contracts: 77 passed
- Full FastAgentPanel: 203 passed, 19 environment-gated skipped
- Explicit streaming guard: 1 passed
- `npx tsc --noEmit --pretty false`
- Design system: 11 passed; `npm run lint:design` has 0 high findings
- `npm run build`
- Bundle guard: FastAgentPanel 1,558,184 B; separate code block 73,341 B; separate Streamdown 163,187 B; 0 Shiki/oniguruma/wasm markers in panel; 0 `assets/shiki/` service-worker precache entries; no asset over 10 MiB
- Independent final P0/P1 audit: GO, no findings

## Release

Ready for required checks and CI-gated squash auto-merge. No admin bypass.