### PR TITLE
docs(agents): seal FastAgent production handoff

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,13 +57,6 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-07-14 · Codex release captain →**
-  `convex/domains/agents/fastAgentPanelStreaming.ts#provider-message-adapter`,
-  `src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx#terminal-run-error`,
-  and focused tests · production dogfood after #529 selected the correct
-  tier-eligible model but exposed an empty provider-message list plus an internal
-  error type in the terminal alert · branch `fix/fast-agent-empty-messages`.
-
 - **2026-06-03 · Claude →** `convex/*#handoff-token`, `src/.../ScratchnodePrivateBridge`,
   `src/App.tsx#events-private-route`, `public/proto/home-v5.html#private-handoff` ·
   shipping the cross-domain private-notes token bridge (opaque stateful token, PR #496) ·
@@ -75,7 +68,8 @@ Server Error) for an unknown slug.
 
 ## Hand-offs (built + ready for the other agent to call)
 
-- **2026-07-14 - Codex P0 runtime safety (pending branch merge)** - authenticated
+- **2026-07-14 - Codex P0 runtime safety (#529 and #531 merged; canonical main
+  `c4035256` / `fa397589`)** - authenticated
   FastAgent runs reserve budget atomically through internal
   `domains/billing/rateLimiting:reserveLlmRequestInternal({ reservationKey,
   attemptKey, userId, model, estimatedInputTokens, estimatedOutputTokens,
@@ -100,8 +94,11 @@ Server Error) for an unknown slug.
   bounded Linkup search plus static ground-truth tools, has no secondary embedding or
   nested model calls, permits one Linkup call per logical run, propagates durable
   cancellation into the Linkup fetch, and plans every provider step against one
-  cumulative input-plus-output token ceiling. Do not call these internal functions
-  from UI code.
+  cumulative input-plus-output token ceiling. The queued provider adapter now
+  validates the exact persisted user row before routing or reservation and passes
+  that prompt explicitly with `recentMessages: 0`, so bounded context cannot become
+  an empty provider request or duplicate the user message. Do not call these
+  internal functions from UI code.
 
 - **2026-06-03 - Codex -> Claude/Codex next builder** - Public wiki payoff shipped
   in PR #490 and verified live on `scratchnode.live`:
@@ -163,6 +160,21 @@ Server Error) for an unknown slug.
   actually enters a room. The live counter + share moment both honor this.
 
 ## Recently shipped (this ScratchNode session)
+
+- **#531 Codex** - exact queued-prompt validation, explicit bounded-context
+  provider input, and safe internal-error redaction. Canonical main commit
+  `fa397589`. Signed-in production run `j9742r0yg3zkfsdqvgpx9he8k98ahv8t`
+  completed on `gemini-2.5-flash` with exactly `TIER_OK`; usage reconciled at
+  741 input / 4 output tokens, daily counters moved +1 request / +1 success /
+  0 errors, and search runs remained zero. The #531 production Vercel deployment
+  `dpl_Ci4RreLinimCumhwLmrJXykiAJAK` reached READY and CI Convex deploy run
+  `29351246820` succeeded.
+
+- **#529 Codex** - tier-safe FastAgent routing, atomic reservation/reconciliation,
+  queue and cancellation fences, bounded Linkup, and honest terminal state.
+  Canonical main commit `c4035256`. Its first production dogfood safely stopped
+  before provider execution, released the zero-token reservation, and exposed the
+  empty-provider-message adapter gap closed by #531.
 
 - **#528 Codex** - exact public projections for agent plans, memory, and episodic memory;
   removed unused ambient FastAgentPanel subscriptions; fixed the authenticated

--- a/docs/architecture/AI_ELEMENTS_MIGRATION_HANDOFF.md
+++ b/docs/architecture/AI_ELEMENTS_MIGRATION_HANDOFF.md
@@ -1,7 +1,7 @@
 # AI Elements Migration — Codex Handoff
 
-**Date:** 2026-07-14. **Canonical source:** `origin/main` through PR #527,
-commit `28d704b2`. **Program state:** **11/26 component decisions complete**;
+**Date:** 2026-07-14. **Canonical runtime source:** `origin/main` through PR #531,
+commit `fa397589`. **Program state:** **11/26 component decisions complete**;
 the broader 56-file migrate/wrap/keep-custom migration remains ongoing.
 
 > Goal: retire hand-rolled generic AI UI behind thin Vercel AI Elements
@@ -25,6 +25,9 @@ These are squash commits on `origin/main`, not pre-merge branch SHAs.
 | #525 | `165ecec2` | Live `UIMessageBubble` wrapper |
 | #526 | `3cc7cd06` | Live `InputBar` / send-contract wrapper |
 | #527 | `28d704b2` | `LiveEventCard` migration plus shared live-event derivation and panel header extraction |
+| #528 | `849ff3e5` | Owner-safe agent plan/memory projections and authenticated query-validator fix |
+| #529 | `c4035256` | Tier-safe FastAgent routing, atomic reservation/reconciliation, queue/cancellation fences, bounded Linkup, and honest terminal state |
+| #531 | `fa397589` | Exact queued-prompt validation and explicit bounded-context provider input, with safe internal-error redaction |
 
 ## Read first
 
@@ -71,8 +74,51 @@ These states are independent and must never be collapsed:
   were checked directly after the merge.
 
 A green build does not prove preview or production state. A screenshot does not
-prove production state. This handoff creates no screenshot, Agentic UI Bar
-score, Gemini receipt, or production-live claim.
+prove production state. The runtime evidence below applies only to the exact
+signed-in FastAgent path; it does not create visual-proof, Agentic UI Bar,
+Gemini-receipt, or reachability claims for other migration candidates.
+
+## FastAgent P0 production evidence (#529 → #531)
+
+- **#529 bounded failure (2026-07-14):** production run
+  `j97cew6c6cd3h3ygsh861xn3s98ah7m7` selected tier-eligible
+  `gemini-2.5-flash`, but the Agent SDK received an empty provider-message list
+  because history was zero and only `promptMessageId` crossed the provider
+  boundary. Reservation
+  `fast-agent:j97cew6c6cd3h3ygsh861xn3s98ah7m7:500651aa` was released
+  with zero input/output tokens and `Run ended before provider execution`.
+  This is safety evidence, not a successful product-path claim.
+- **#531 source and checks:** merged at `2026-07-14T16:49:41Z` as
+  `fa397589fbdd1c3333a59756a04e19013c49289c` from final head
+  `9a6de10493feffefcf5a5b4ba8d8cd98d4995175`. Typecheck, Runtime smoke,
+  Build, and Tier B vs preview URL passed. CI-managed
+  [Convex Deploy run 29351246820](https://github.com/HomenShum/NodeBenchAI/actions/runs/29351246820)
+  succeeded; no manual or out-of-band Convex deployment was used.
+- **Production deployment:** Vercel deployment
+  `dpl_Ci4RreLinimCumhwLmrJXykiAJAK` at
+  `https://nodebench-aqqg2g65l-hshum2018-gmailcoms-projects.vercel.app`
+  reached READY at `2026-07-14T16:54:50.338Z`. During #531 post-deploy
+  verification, the canonical aliases resolved to it;
+  `https://www.nodebenchai.com/agents` returned HTTP 200 with main asset
+  `/assets/index-DwH5Fcl7.js`. Post-deploy verification run `29351596286` and
+  Attrition QA run `29351596158` passed.
+- **Signed-in dogfood PASS (`2026-07-14T17:01:06.366Z`):** a fresh canonical
+  `/agents` thread sent `Reply with exactly TIER_OK and nothing else.` once.
+  One user message and one assistant response exactly `TIER_OK` rendered; busy
+  state stopped; no tool/search/source cards appeared; no raw or internal error
+  was shown. Thread `sd7dnv6hx0waskwyk8kps9wbjs8ahnn8`, Agent thread
+  `m57ea0mvgp4cbm87hbanake4n58ah0ay`, run
+  `j9742r0yg3zkfsdqvgpx9he8k98ahv8t`, prompt message
+  `ks7as6sgypb77cwm8qbk04en7x8ag49j`, assistant message
+  `ks7deyjjf3v7vqyj1bsqcsptk18agvn2`.
+- **Accounting proof:** effective model `gemini-2.5-flash`; usage row
+  `gd7sgkt10mv5ybhkjtby1x0x6h8agfy6`; reservation
+  `fast-agent:j9742r0yg3zkfsdqvgpx9he8k98ahv8t:063e0069`; one attempt,
+  `reservationStatus=reconciled`, terminal audit state `provider_ended`,
+  `success=true`, 741 input and 4 output tokens, and no active reserved fields.
+  Daily counters changed requests `0 → 1`, successes `0 → 1`, errors `0 → 0`,
+  and tokens `0 → 745`; active reservations and dogfood search runs were both
+  zero after reconciliation.
 
 ## Verification floor
 
@@ -80,6 +126,8 @@ Run from a clean worktree based on current `origin/main`:
 
 ```powershell
 npx tsc --noEmit --pretty false
+npx tsc -p convex/tsconfig.json --noEmit --pretty false
+npx vitest run convex/__tests__/agentRuntimeTierFallback.test.ts
 npx vitest run src/features/agents/components/FastAgentPanel
 npx vitest run src/design/designSystem.test.ts
 npm run lint:design


### PR DESCRIPTION
## Summary
- close the #529/#531 FastAgent P0 coordination claim with canonical merge SHAs
- preserve exact signed-in production dogfood, deployment, and accounting evidence
- extend the handoff verification floor without changing the honest 11/26 migration score

## Verification
- `git diff --check`
- independent read-only evidence review: approved
- docs-only change; no runtime code changed

## Release policy
CI-gated squash auto-merge only; no admin merge and no out-of-band Convex deployment.