### PR TITLE
fix(agents): declutter UI and restore plain prompts

### DIFF
--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -10,6 +10,7 @@ This directory contains append-only per-surface changelog lanes. Each lane recor
 - [`pages/convex-events.md`](pages/convex-events.md) — ScratchNode live-event backend surface.
 - [`pages/linkedin-daily-brief.md`](pages/linkedin-daily-brief.md) — LinkedIn daily-brief pipeline.
 - [`pages/scratchnode-nodebench-bridge.md`](pages/scratchnode-nodebench-bridge.md) — ScratchNode-to-NodeBench bridge.
+- [`pages/agents.md`](pages/agents.md) — Agents hub prompt routing, topic presentation, and responsive hub navigation.
 
 ### Components
 

--- a/CHANGELOG/components/fast-agent-panel.md
+++ b/CHANGELOG/components/fast-agent-panel.md
@@ -3,6 +3,22 @@
 Append-only lane for behavior-preserving AI Elements adoption inside
 `src/features/agents/components/FastAgentPanel/`. Newest entries first.
 
+## 2026-07-14 — Remove ungrounded chat chrome
+
+The unopened panel now keeps the composer and four real starter actions as its primary surface. Empty tabs, duplicate command rails, decorative progress/minimap UI, placebo Focus/Tone controls, and text-inferred confidence/citation/media projections are removed while canonical streaming, approvals, structured sources, tool/domain cards, model/token provenance, Markdown, and exports remain.
+
+**PR / canonical main commit**: `PENDING #TBD MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: pending.
+- Checks: local current-tree FastAgent, streaming, typecheck, design, and build gates passed; required PR checks pending.
+- Visual proof: private local responsive/theme captures independently reviewed; public-safe preview captures pending.
+- Preview: pending.
+- Production live: pending.
+
+**Author**: Homen Shum + Codex.
+**Touches**: [`../pages/agents.md`](../pages/agents.md).
+
 ## 2026-07-14 — Migrate LiveEventCard onto the shared tool shell
 
 LiveEventCard now composes the tool/task vocabulary, while live-event derivation

--- a/CHANGELOG/components/fast-agent-panel.md
+++ b/CHANGELOG/components/fast-agent-panel.md
@@ -7,7 +7,7 @@ Append-only lane for behavior-preserving AI Elements adoption inside
 
 The unopened panel now keeps the composer and four real starter actions as its primary surface. Empty tabs, duplicate command rails, decorative progress/minimap UI, placebo Focus/Tone controls, and text-inferred confidence/citation/media projections are removed while canonical streaming, approvals, structured sources, tool/domain cards, model/token provenance, Markdown, and exports remain.
 
-**PR / canonical main commit**: `PENDING #TBD MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: `PENDING #533 MAIN SHA / FINAL QA`.
 
 **Evidence state**:
 - Source: pending.

--- a/CHANGELOG/pages/agents.md
+++ b/CHANGELOG/pages/agents.md
@@ -6,7 +6,7 @@ Append-only lane for the `/agents` hub, its primary command path, topic list, an
 
 Ordinary prompts now open the canonical FastAgent chat while `/spawn` remains the explicit swarm path. The hub shows recorded topic fields instead of fabricated narrative metrics, defers suggestions, removes dead controls, and uses a reachable native selector for the mobile hub rail.
 
-**PR / canonical main commit**: `PENDING #TBD MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: `PENDING #533 MAIN SHA / FINAL QA`.
 
 **Evidence state**:
 - Source: pending.

--- a/CHANGELOG/pages/agents.md
+++ b/CHANGELOG/pages/agents.md
@@ -1,0 +1,19 @@
+# Agents Hub
+
+Append-only lane for the `/agents` hub, its primary command path, topic list, and responsive hub navigation. Newest entries first.
+
+## 2026-07-14 — Make the Agents hub action-first
+
+Ordinary prompts now open the canonical FastAgent chat while `/spawn` remains the explicit swarm path. The hub shows recorded topic fields instead of fabricated narrative metrics, defers suggestions, removes dead controls, and uses a reachable native selector for the mobile hub rail.
+
+**PR / canonical main commit**: `PENDING #TBD MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: pending.
+- Checks: local current-tree typechecks, focused tests, design gates, runtime guards, and production build passed; required PR checks pending.
+- Visual proof: private local responsive/theme captures independently reviewed; public-safe preview captures pending.
+- Preview: pending.
+- Production live: pending.
+
+**Author**: Homen Shum + Codex.
+**Touches**: [`../components/fast-agent-panel.md`](../components/fast-agent-panel.md).

--- a/src/features/agents/components/AgentCommandBar.test.tsx
+++ b/src/features/agents/components/AgentCommandBar.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentCommandBar } from "./AgentCommandBar";
+
+describe("AgentCommandBar", () => {
+  it("submits a plain question through the single-agent path", () => {
+    const onSubmit = vi.fn();
+    render(<AgentCommandBar onSubmit={onSubmit} />);
+
+    expect(screen.queryByText(/Swarm:/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Suggestions").closest("details"),
+    ).not.toHaveAttribute("open");
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Message input" }), {
+      target: { value: "What changed in the latest filing?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit.mock.calls[0]?.[0]).toBe(
+      "What changed in the latest filing?",
+    );
+    expect(onSubmit.mock.calls[0]?.[1].agents).toBeUndefined();
+  });
+
+  it("keeps swarm suggestions secondary and exposes controls only for /spawn", () => {
+    const onSubmit = vi.fn();
+    render(<AgentCommandBar onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByText("Suggestions"));
+    fireEvent.click(screen.getByRole("button", { name: "Research" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Message input" }), {
+      target: { value: '/spawn "Compare chips" --agents=doc,media,sec' },
+    });
+
+    expect(screen.getByText("Swarm: 3 agents")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Compare chips",
+      expect.objectContaining({
+        agents: ["DocumentAgent", "MediaAgent", "SECAgent"],
+      }),
+    );
+  });
+
+  it("does not submit an empty question", () => {
+    const onSubmit = vi.fn();
+    render(<AgentCommandBar onSubmit={onSubmit} />);
+
+    const send = screen.getByRole("button", { name: "Send message" });
+    expect(send).toBeDisabled();
+    fireEvent.click(send);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/agents/components/AgentCommandBar.tsx
+++ b/src/features/agents/components/AgentCommandBar.tsx
@@ -15,7 +15,6 @@ import {
   Building,
   TrendingUp,
   Search,
-  Sparkles,
   Command,
   Gift,
 } from "lucide-react";
@@ -34,26 +33,7 @@ import {
 // Types & Constants
 // ============================================================================
 
-export type AgentMode = "quick" | "research" | "deep";
 export type { ApprovedModel };
-
-const MODE_CONFIG: Record<AgentMode, { label: string; description: string; icon: React.ElementType }> = {
-  quick: {
-    label: "Quick",
-    description: "Fast single-agent response",
-    icon: Zap,
-  },
-  research: {
-    label: "Research",
-    description: "Multi-source parallel search",
-    icon: Search,
-  },
-  deep: {
-    label: "Deep",
-    description: "Thorough analysis with planning",
-    icon: Sparkles,
-  },
-};
 
 // Build MODEL_OPTIONS from shared APPROVED_MODELS (SINGLE SOURCE OF TRUTH)
 const MODEL_OPTIONS = APPROVED_MODELS.map((modelId) => {
@@ -83,7 +63,6 @@ const AGENT_SHORTCUTS = [
 
 interface AgentCommandBarProps {
   onSubmit: (query: string, options: {
-    mode: AgentMode;
     model: ApprovedModel;
     agents?: string[];
   }) => void;
@@ -95,69 +74,6 @@ interface AgentCommandBarProps {
 // ============================================================================
 // Sub-components
 // ============================================================================
-
-const ModeSelector = memo(function ModeSelector({
-  mode,
-  onModeChange,
-  isOpen,
-  onToggle,
-}: {
-  mode: AgentMode;
-  onModeChange: (mode: AgentMode) => void;
-  isOpen: boolean;
-  onToggle: () => void;
-}) {
-  const config = MODE_CONFIG[mode];
-  const Icon = config.icon;
-
-  return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={onToggle}
-        className={cn(
-          "flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg",
-          "text-xs font-medium border border-edge",
-          "hover:bg-surface-hover transition-colors",
-          isOpen && "bg-surface-hover"
-        )}
-      >
-        <Icon className="w-3.5 h-3.5 text-indigo-600 dark:text-indigo-400" />
-        <span>{config.label}</span>
-        <ChevronDown className={cn("w-3 h-3 transition-transform", isOpen && "rotate-180")} />
-      </button>
-
-      {isOpen && (
-        <div className="absolute top-full left-0 mt-1 z-50 min-w-[180px] bg-surface border border-edge rounded-lg shadow-lg overflow-hidden">
-          {(Object.entries(MODE_CONFIG) as [AgentMode, typeof MODE_CONFIG["quick"]][]).map(([key, cfg]) => {
-            const ModeIcon = cfg.icon;
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => {
-                  onModeChange(key);
-                  onToggle();
-                }}
-                className={cn(
-                  "w-full flex items-start gap-2 px-3 py-2 text-left",
-                  "hover:bg-surface-hover transition-colors",
-                  mode === key && "bg-indigo-500/10"
-                )}
-              >
-                <ModeIcon className="w-4 h-4 mt-0.5 text-indigo-600 dark:text-indigo-400" />
-                <div>
-                  <div className="text-xs font-medium text-content">{cfg.label}</div>
-                  <div className="text-xs text-content-muted">{cfg.description}</div>
-                </div>
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-});
 
 const ModelSelector = memo(function ModelSelector({
   model,
@@ -225,13 +141,11 @@ const ModelSelector = memo(function ModelSelector({
 export const AgentCommandBar = memo(function AgentCommandBar({
   onSubmit,
   isLoading = false,
-  placeholder = "Ask anything or use /spawn for parallel agents...",
+  placeholder = "Ask NodeBench...",
   className,
 }: AgentCommandBarProps) {
   const [input, setInput] = useState("");
-  const [mode, setMode] = useState<AgentMode>("quick");
   const [model, setModel] = useState<ApprovedModel>(DEFAULT_MODEL);
-  const [modeDropdownOpen, setModeDropdownOpen] = useState(false);
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [showHint, setShowHint] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -257,16 +171,16 @@ export const AgentCommandBar = memo(function AgentCommandBar({
     if (!input.trim() || isLoading) return;
 
     if (parsedSpawn) {
-      onSubmit(parsedSpawn.query, { mode: "research", model, agents: parsedSpawn.agents });
+      onSubmit(parsedSpawn.query, { model, agents: parsedSpawn.agents });
     } else {
-      onSubmit(input.trim(), { mode, model });
+      onSubmit(input.trim(), { model });
     }
 
     setInput("");
     if (inputRef.current) {
       inputRef.current.style.height = "auto";
     }
-  }, [input, isLoading, parsedSpawn, mode, model, onSubmit]);
+  }, [input, isLoading, parsedSpawn, model, onSubmit]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -289,37 +203,14 @@ export const AgentCommandBar = memo(function AgentCommandBar({
   }, []);
 
   return (
-    <div className={cn("space-y-3", className)}>
-      {/* Quick Action Chips */}
-      <div className="flex items-center gap-2 flex-wrap">
-        {QUICK_ACTIONS.map((action) => {
-          const Icon = action.icon;
-          return (
-            <button
-              key={action.label}
-              type="button"
-              onClick={() => handleQuickAction(action)}
-              className={cn(
-                "flex items-center gap-1.5 px-2.5 py-1.5 rounded-full",
-                "text-xs font-medium border border-edge",
-                "bg-surface hover:bg-surface-hover",
-                "transition-colors"
-              )}
-            >
-              <Icon className="w-3 h-3 text-indigo-600 dark:text-indigo-400" />
-              {action.label}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Command Input Area */}
+    <div className={cn("space-y-2", className)}>
+      {/* Command Input Area — the only primary action on first view. */}
       <div className="relative">
         <div
           className={cn(
             "flex flex-col bg-surface rounded-lg border border-edge",
             "focus-within:ring-2 focus-within:ring-ring",
-            "focus-within:border-indigo-500/30/50 transition-all"
+            "focus-within:border-indigo-500/30/50 transition-all",
           )}
         >
           {/* Input Row */}
@@ -335,7 +226,7 @@ export const AgentCommandBar = memo(function AgentCommandBar({
               className={cn(
                 "flex-1 resize-none bg-transparent text-sm",
                 "text-content placeholder:text-content-muted",
-                "outline-none min-h-[24px] max-h-[120px]"
+                "outline-none min-h-[24px] max-h-[120px]",
               )}
             />
             <button
@@ -347,44 +238,28 @@ export const AgentCommandBar = memo(function AgentCommandBar({
                 "flex items-center justify-center w-8 h-8 rounded-lg",
                 "bg-[var(--accent-primary)] text-white",
                 "hover:opacity-90 transition-opacity",
-                "disabled:opacity-50 disabled:cursor-not-allowed"
+                "disabled:opacity-50 disabled:cursor-not-allowed",
               )}
             >
               <Send className="w-4 h-4" aria-hidden="true" />
             </button>
           </div>
 
-          {/* Controls Row */}
-          <div className="flex items-center justify-between px-3 pb-3 pt-0">
-            <div className="flex items-center gap-2">
-              <ModeSelector
-                mode={mode}
-                onModeChange={setMode}
-                isOpen={modeDropdownOpen}
-                onToggle={() => {
-                  setModeDropdownOpen(!modeDropdownOpen);
-                  setModelDropdownOpen(false);
-                }}
-              />
+          {/* Swarm-only controls. A plain ask routes to the canonical FastAgent panel. */}
+          {isSpawn && parsedSpawn && (
+            <div className="flex items-center justify-between px-3 pb-3 pt-0">
               <ModelSelector
                 model={model}
                 onModelChange={setModel}
                 isOpen={modelDropdownOpen}
-                onToggle={() => {
-                  setModelDropdownOpen(!modelDropdownOpen);
-                  setModeDropdownOpen(false);
-                }}
+                onToggle={() => setModelDropdownOpen(!modelDropdownOpen)}
               />
-            </div>
-
-            {/* Spawn indicator */}
-            {isSpawn && parsedSpawn && (
               <div className="flex items-center gap-1.5 text-xs text-indigo-600 dark:text-indigo-400">
-                <Zap className="w-3 h-3" />
+                <Zap className="w-3 h-3" aria-hidden="true" />
                 <span>Swarm: {parsedSpawn.agents.length} agents</span>
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
 
         {/* Command Hint */}
@@ -397,7 +272,10 @@ export const AgentCommandBar = memo(function AgentCommandBar({
               </span>
             </div>
             <p className="text-xs text-content-muted mb-2">
-              Use <code className="px-1 bg-surface-secondary rounded">/spawn "query" --agents=doc,media,sec</code>
+              Use{" "}
+              <code className="px-1 bg-surface-secondary rounded">
+                /spawn "query" --agents=doc,media,sec
+              </code>
             </p>
             <div className="flex flex-wrap gap-1">
               {AGENT_SHORTCUTS.map((agent) => {
@@ -416,6 +294,42 @@ export const AgentCommandBar = memo(function AgentCommandBar({
           </div>
         )}
       </div>
+
+      <details className="group w-fit max-w-full">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-1 py-1 text-xs font-medium text-content-muted transition-colors hover:text-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          Suggestions
+          <ChevronDown
+            className="h-3 w-3 transition-transform group-open:rotate-180"
+            aria-hidden="true"
+          />
+        </summary>
+        <div
+          className="mt-2 flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Agent command suggestions"
+        >
+          {QUICK_ACTIONS.map((action) => {
+            const Icon = action.icon;
+            return (
+              <button
+                key={action.label}
+                type="button"
+                onClick={() => handleQuickAction(action)}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-full border border-edge px-2.5 py-1.5",
+                  "bg-surface text-xs font-medium hover:bg-surface-hover transition-colors",
+                )}
+              >
+                <Icon
+                  className="h-3 w-3 text-indigo-600 dark:text-indigo-400"
+                  aria-hidden="true"
+                />
+                {action.label}
+              </button>
+            );
+          })}
+        </div>
+      </details>
     </div>
   );
 });

--- a/src/features/agents/components/AgentStatusCard.tsx
+++ b/src/features/agents/components/AgentStatusCard.tsx
@@ -2,7 +2,7 @@
  * AgentStatusCard.tsx
  *
  * Real-time agent status card with live subscriptions.
- * Displays agent status, current task preview, and quick actions.
+ * Displays only live agent status and task telemetry.
  */
 
 import React, { memo } from "react";
@@ -14,18 +14,12 @@ import {
   Search,
   Zap,
   Clock,
-  Play,
-  Pause,
-  Settings,
-  ChevronDown,
-  ChevronUp,
   Loader2,
   CheckCircle,
   XCircle,
   AlertCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { DEFAULT_MODEL, MODEL_UI_INFO } from "@shared/llm/approvedModels";
 import { SignatureOrb } from "@/shared/ui/SignatureOrb";
 
 // ============================================================================
@@ -114,10 +108,6 @@ export interface AgentStatusCardProps {
   lastActivity?: string;
   tasksCompleted?: number;
   currentTask?: string;
-  isExpanded?: boolean;
-  onToggleExpand?: () => void;
-  onConfigure?: () => void;
-  onToggleStatus?: () => void;
 }
 
 // ============================================================================
@@ -165,10 +155,6 @@ export const AgentStatusCard = memo(function AgentStatusCard({
   lastActivity,
   tasksCompleted = 0,
   currentTask,
-  isExpanded = false,
-  onToggleExpand,
-  onConfigure,
-  onToggleStatus,
 }: AgentStatusCardProps) {
   const config = AGENT_CONFIGS[agentId] || AGENT_CONFIGS.coordinator;
   const Icon = config.icon;
@@ -244,80 +230,6 @@ export const AgentStatusCard = memo(function AgentStatusCard({
         </div>
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-2 px-4 pb-4">
-        <button
-          type="button"
-          onClick={onToggleStatus}
-          className={cn(
-            "flex-1 flex items-center justify-center gap-2 px-3 py-2",
-            "text-xs font-medium rounded-lg border border-edge",
-            "hover:bg-surface-hover transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
-          )}
-        >
-          {isActive ? (
-            <>
-              <Pause className="w-3.5 h-3.5" aria-hidden="true" />
-              Pause
-            </>
-          ) : (
-            <>
-              <Play className="w-3.5 h-3.5" aria-hidden="true" />
-              Start
-            </>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={onConfigure}
-          className={cn(
-            "flex items-center justify-center p-2 rounded-lg",
-            "border border-edge hover:bg-surface-hover transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
-          )}
-          aria-label="Configure agent"
-        >
-          <Settings className="w-4 h-4 text-content-muted" />
-        </button>
-        {onToggleExpand && (
-          <button
-            type="button"
-            onClick={onToggleExpand}
-            className={cn(
-              "flex items-center justify-center p-2 rounded-lg",
-              "border border-edge hover:bg-surface-hover transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
-            )}
-            aria-label={isExpanded ? "Collapse details" : "Expand details"}
-          >
-            {isExpanded ? (
-              <ChevronUp className="w-4 h-4 text-content-muted" />
-            ) : (
-              <ChevronDown className="w-4 h-4 text-content-muted" />
-            )}
-          </button>
-        )}
-      </div>
-
-      {/* Expanded Details */}
-      {isExpanded && (
-        <div className="px-4 pb-4 border-t border-edge pt-3">
-          <div className="text-xs text-content-muted">
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <span className="font-medium">Model:</span> {MODEL_UI_INFO[DEFAULT_MODEL].name}
-              </div>
-              <div>
-                <span className="font-medium">Memory:</span> 2.4k tokens
-              </div>
-              <div>
-                <span className="font-medium">Avg latency:</span> 1.2s
-              </div>
-              <div>
-                <span className="font-medium">Success rate:</span> 98%
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 });

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.PanelHeader.tsx
@@ -117,7 +117,7 @@ export const PanelHeader = memo(function PanelHeader({
   return (
     <div className={cn(
       "flex items-center gap-2 border-b border-edge bg-surface px-3 py-2.5",
-      isCompactSidebar && "px-4 py-3"
+      isCompactSidebar && "px-4 pb-3 pt-[calc(env(safe-area-inset-top,0px)+28px)] sm:py-3"
     )}>
       {/* Status dot + Title */}
       <div className={cn("min-w-0", isCompactSidebar ? "flex-1" : "flex items-center gap-2")}>
@@ -154,9 +154,6 @@ export const PanelHeader = memo(function PanelHeader({
                 )
               )}
             </div>
-            <p className="mt-1 truncate text-[11px] leading-5 text-content-muted">
-              Same chat surface, with files, notebook context, and workspace tools.
-            </p>
           </div>
         ) : (
           <>

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.UIMessageBubble.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.UIMessageBubble.tsx
@@ -2335,13 +2335,14 @@ export function FastAgentUIMessageBubble({
     return { citedCitationLibrary, entityLibrary };
   }, [entityEnrichment, isUser, message._creationTime, toolParts, uiParts.text, visibleText]);
 
-  // Extract media from BOTH tool results AND final text
+  // Structured tool output owns rich media cards. Final-answer Markdown renders
+  // its own links and images, so projecting it into a second gallery duplicates it.
   const extractedMedia = useMemo(() => {
     if (isUser) return { youtubeVideos: [], secDocuments: [], webSources: [], profiles: [], images: [] };
 
     // Only grouped-custom owners feed this renderer. Other owners are consumed
     // by FusedSearchResults, MemoryPill, ToolCallTransparency, or ToolStep.
-    const toolMedia = groupedToolOwners.reduce<ExtractedMedia>((acc, { entry }) => {
+    return groupedToolOwners.reduce<ExtractedMedia>((acc, { entry }) => {
       const media = getToolMedia(entry.part);
 
       return {
@@ -2352,15 +2353,7 @@ export function FastAgentUIMessageBubble({
         images: [...acc.images, ...media.images],
       };
     }, { youtubeVideos: [], secDocuments: [], webSources: [], profiles: [], images: [] });
-
-    // ALSO extract from final text (for when agent synthesizes response)
-    const textMedia = extractMediaFromText(visibleText || '');
-
-    return {
-      toolMedia,
-      textMedia,
-    };
-  }, [groupedToolOwners, isUser, visibleText]);
+  }, [groupedToolOwners, isUser]);
 
   // Extract document actions from tool results
   const extractedDocuments = useMemo(() => {
@@ -2393,7 +2386,7 @@ export function FastAgentUIMessageBubble({
 
     for (const entry of textRenderParts) {
       const text = visibleTextByOriginalIndex.get(entry.originalIndex) ?? '';
-      if (hasMedia(extractMediaFromText(text)) || extractDocumentActions(text).length > 0) {
+      if (extractDocumentActions(text).length > 0) {
         candidates.push(entry.originalIndex);
       }
     }
@@ -3296,161 +3289,6 @@ export function FastAgentUIMessageBubble({
               <Clock className="w-2.5 h-2.5" />
               {readMin} min read
             </span>
-          );
-        })()}
-
-        {/* AI Confidence Indicator */}
-        {!compact && !isUser && message.status !== 'streaming' && (cleanedText || visibleText) && (() => {
-          const text = cleanedText || visibleText || '';
-          const hedges = (text.match(/\b(might|may|could|possibly|perhaps|likely|unlikely|uncertain|not sure|it seems|appears to|I think|I believe|approximately|roughly)\b/gi) || []).length;
-          const totalWords = text.split(/\s+/).length;
-          const hedgeRatio = totalWords > 0 ? hedges / totalWords : 0;
-          const confidence = hedgeRatio > 0.03 ? 'low' : hedgeRatio > 0.01 ? 'medium' : 'high';
-          const confColors = { high: '#22c55e', medium: '#f59e0b', low: '#ef4444' };
-          const confLabels = { high: 'High confidence', medium: 'Moderate confidence', low: 'Low confidence' };
-          return (
-            <div className="flex items-center gap-1.5 mt-0.5" title={`${confLabels[confidence]} — ${hedges} hedging words in ${totalWords} words`}>
-              <div className="flex gap-0.5">
-                {[0, 1, 2].map(i => (
-                  <div
-                    key={i}
-                    className="w-1.5 h-1.5 rounded-full transition-colors"
-                    style={{ background: i <= (confidence === 'high' ? 2 : confidence === 'medium' ? 1 : 0) ? confColors[confidence] : 'var(--border-color)' }}
-                  />
-                ))}
-              </div>
-              <span className="text-xs text-content-muted">{confLabels[confidence]}</span>
-            </div>
-          );
-        })()}
-
-        {/* Inline Source Citations with Hover Preview */}
-        {!isUser && message.status !== 'streaming' && (cleanedText || visibleText || '').match(/\[\d+\]/) && (() => {
-          const text = cleanedText || visibleText || '';
-          const citationNums = [...new Set((text.match(/\[(\d+)\]/g) || []).map(c => c.replace(/[\[\]]/g, '')))];
-          if (citationNums.length === 0) return null;
-          const urls = text.match(/https?:\/\/[^\s)]+/g) || [];
-          return (
-            <div className="flex flex-wrap gap-1 mt-1.5">
-              <span className="text-xs text-content-muted mr-0.5">Sources:</span>
-              {citationNums.slice(0, 8).map((num, i) => {
-                const url = urls[i] || null;
-                let domain = '';
-                try { if (url) domain = new URL(url).hostname.replace('www.', ''); } catch { /* */ }
-                return (
-                  <span key={num} className="relative group/cite">
-                    <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-[8px] font-bold cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800/40 transition-colors">
-                      {num}
-                    </span>
-                    {url && (
-                      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover/cite:flex flex-col w-[200px] bg-surface border border-edge rounded-lg shadow-xl p-2 z-50 pointer-events-none">
-                        <div className="flex items-center gap-1.5 mb-1">
-                          <img src={`https://www.google.com/s2/favicons?domain=${domain}&sz=16`} alt="" className="w-3 h-3 rounded" width={12} height={12} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-                          <span className="text-xs font-medium text-content truncate">{domain}</span>
-                        </div>
-                        <span className="text-[8px] text-content-muted truncate">{url.slice(0, 60)}</span>
-                      </div>
-                    )}
-                  </span>
-                );
-              })}
-            </div>
-          );
-        })()}
-
-        {/* Image/File Inline Previews */}
-        {!isUser && (cleanedText || visibleText || '').match(/!\[.*?\]\(https?:\/\/[^)]+\)/) && (() => {
-          const text = cleanedText || visibleText || '';
-          const imgMatches = [...text.matchAll(/!\[([^\]]*)\]\((https?:\/\/[^)]+)\)/g)];
-          if (imgMatches.length === 0) return null;
-          return (
-            <div className="flex flex-wrap gap-2 mt-2">
-              {imgMatches.slice(0, 4).map((match, i) => (
-                <a
-                  key={i}
-                  href={match[2]}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block rounded-lg overflow-hidden border border-edge hover:border-blue-400 transition-colors shadow-sm"
-                >
-                  <img
-                    src={match[2]}
-                    alt={match[1] || 'Image'}
-                    className="max-w-[160px] max-h-[120px] object-cover"
-                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                  />
-                </a>
-              ))}
-            </div>
-          );
-        })()}
-
-        {/* File Attachment Previews (detect file URLs) */}
-        {!isUser && (cleanedText || visibleText || '').match(/\bhttps?:\/\/\S+\.(pdf|csv|xlsx?|docx?|pptx?|json|xml)\b/i) && (() => {
-          const text = cleanedText || visibleText || '';
-          const fileMatches = [...text.matchAll(/\bhttps?:\/\/\S+\.(pdf|csv|xlsx?|docx?|pptx?|json|xml)\b/gi)];
-          if (fileMatches.length === 0) return null;
-          const fileIcons: Record<string, string> = { pdf: '📕', csv: '📊', xls: '📊', xlsx: '📊', doc: '📝', docx: '📝', pptx: '📽️', ppt: '📽️', json: '📋', xml: '📋' };
-          return (
-            <div className="flex flex-wrap gap-1.5 mt-1.5">
-              {fileMatches.slice(0, 4).map((match, i) => {
-                const ext = match[1].toLowerCase();
-                const filename = match[0].split('/').pop() || `file.${ext}`;
-                return (
-                  <a
-                    key={i}
-                    href={match[0]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="smart-action-chip"
-                  >
-                    <span>{fileIcons[ext] || '📎'}</span>
-                    <span className="truncate max-w-[120px]">{decodeURIComponent(filename)}</span>
-                  </a>
-                );
-              })}
-            </div>
-          );
-        })()}
-
-        {/* Rich Link Preview Cards */}
-        {!isUser && message.status !== 'streaming' && (cleanedText || visibleText || '').match(/https?:\/\/[^\s)]+/) && (() => {
-          const text = cleanedText || visibleText || '';
-          const urlMatches = [...new Set(text.match(/https?:\/\/[^\s)]+/g) || [])];
-          const imageExts = /\.(png|jpg|jpeg|gif|svg|webp|ico)$/i;
-          const fileExts = /\.(pdf|csv|xlsx?|docx?|pptx?|json|xml)$/i;
-          const links = urlMatches.filter(u => !imageExts.test(u) && !fileExts.test(u)).slice(0, 3);
-          if (links.length === 0) return null;
-          return (
-            <div className="flex flex-col gap-1.5 mt-2">
-              {links.map((url, i) => {
-                let domain = '';
-                try { domain = new URL(url).hostname.replace('www.', ''); } catch { domain = url.slice(0, 30); }
-                return (
-                  <a
-                    key={i}
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-edge bg-surface-secondary hover:bg-surface-hover transition-colors group/link"
-                  >
-                    <img
-                      src={`https://www.google.com/s2/favicons?domain=${domain}&sz=32`}
-                      alt=""
-                      className="w-4 h-4 rounded flex-shrink-0"
-                      width={16}
-                      height={16}
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-xs font-medium text-content truncate group-hover/link:underline">{domain}</div>
-                      <div className="text-xs text-content-muted truncate">{url.slice(0, 80)}</div>
-                    </div>
-                    <ExternalLink className="w-3 h-3 text-content-muted flex-shrink-0 opacity-0 group-hover/link:opacity-100 transition-opacity" />
-                  </a>
-                );
-              })}
-            </div>
           );
         })()}
 

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -172,31 +172,6 @@ function DossierFocusSubscription({
  * - Clean, minimal interface
  */
 
-/** R6: Mobile Command Chips — shown above the input bar on mobile (max-width: 1024px). */
-function MobileCommandChips({ onSelect }: { onSelect: (message: string) => void }) {
-  const chips = [
-    { label: "Daily Brief", message: "Generate my daily brief \u2014 what changed, main contradiction, next moves" },
-    { label: "Run Diligence", message: "Run diligence analysis on this company" },
-    { label: "Compare", message: "Compare this company against its top 3 competitors" },
-    { label: "Market Scan", message: "Scan the market for recent changes affecting this company" },
-  ];
-  return (
-    <div className="flex flex-wrap gap-2 px-3 py-2 lg:hidden" role="group" aria-label="Quick command suggestions">
-      {chips.map((c) => (
-        <button
-          key={c.label}
-          type="button"
-          onClick={() => onSelect(c.message)}
-          aria-label={`Send command: ${c.label}`}
-          className="rounded-full border border-edge bg-surface px-3 py-1.5 text-[11px] font-medium text-content-secondary transition-all duration-fast ease-out hover:bg-surface-hover hover:text-content active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/40 motion-reduce:transform-none motion-reduce:transition-none"
-        >
-          {c.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 export const FastAgentPanel = memo(function FastAgentPanel({
   isOpen,
   onClose,
@@ -370,10 +345,12 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     const saved = localStorage.getItem('fastAgentPanel.chatMode');
     return (saved === 'agent-streaming' || saved === 'agent') ? saved : 'agent-streaming';
   });
+  const lastAnnouncedChatModeRef = useRef(chatMode);
 
   // Force anonymous users to agent-streaming mode (agent mode requires auth)
   useEffect(() => {
     if (!isAuthenticated && chatMode === 'agent') {
+      lastAnnouncedChatModeRef.current = 'agent-streaming';
       setChatMode('agent-streaming');
     }
   }, [isAuthenticated, chatMode]);
@@ -445,9 +422,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   const [isAutoScrollPaused, setIsAutoScrollPaused] = useState(false);
   const lastScrollTopRef = useRef(0);
 
-  // Scroll progress
-  const [scrollProgress, setScrollProgress] = useState(0);
-
   // Typing speed indicator
   const typingStartRef = useRef<number>(0);
   const typingWordCountRef = useRef<number>(0);
@@ -472,26 +446,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   // Artifacts/Canvas panel
   const [showArtifacts, setShowArtifacts] = useState(false);
   const [artifactContent, setArtifactContent] = useState<{ type: 'html' | 'svg' | 'code'; content: string; language?: string } | null>(null);
-
-  // Focus/mode presets
-  const FOCUS_MODES = [
-    { id: 'default', label: 'Default', icon: '💬', prompt: '' },
-    { id: 'academic', label: 'Academic', icon: '🎓', prompt: 'Respond in an academic style with citations, formal language, and structured analysis.' },
-    { id: 'creative', label: 'Creative', icon: '🎨', prompt: 'Respond creatively with vivid language, metaphors, and engaging narrative.' },
-    { id: 'precise', label: 'Precise', icon: '🎯', prompt: 'Be extremely precise and concise. Use bullet points. No fluff. Facts only.' },
-    { id: 'code', label: 'Code', icon: '💻', prompt: 'Focus on code. Provide working examples with comments. Use best practices.' },
-  ] as const;
-  const [focusMode, setFocusMode] = useState('default');
-  const [showFocusPicker, setShowFocusPicker] = useState(false);
-
-  // Tone/style presets
-  const TONE_PRESETS = [
-    { id: 'neutral', label: 'Neutral', icon: '⚖️' },
-    { id: 'formal', label: 'Formal', icon: '🏛️' },
-    { id: 'casual', label: 'Casual', icon: '😊' },
-    { id: 'technical', label: 'Technical', icon: '⚙️' },
-  ] as const;
-  const [tonePreset, setTonePreset] = useState('neutral');
 
   // Auto-save drafts (localStorage)
   const draftKey = `fa_draft_${activeThreadId || 'new'}`;
@@ -933,8 +887,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
           setShowContextPruning(false);
         } else if (showPersonaPicker) {
           setShowPersonaPicker(false);
-        } else if (showFocusPicker) {
-          setShowFocusPicker(false);
         } else if (showSearch) {
           setShowSearch(false);
           setSearchQuery('');
@@ -1036,9 +988,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
       }
       lastScrollTopRef.current = scrollTop;
 
-      // Scroll progress bar
-      const maxScroll = scrollHeight - clientHeight;
-      setScrollProgress(maxScroll > 0 ? scrollTop / maxScroll : 0);
     };
 
     container.addEventListener('scroll', handleScroll, { passive: true });
@@ -1178,6 +1127,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     setActiveThreadId(null);
     setAttachedFiles([]);
     setInput(message);
+    lastAnnouncedChatModeRef.current = "agent-streaming";
     setChatMode("agent-streaming");
     setPendingAutoSend({ requestId, message });
   }, [isOpen, onOptionsConsumed, openOptions, isViewportActiveVariant, showsNotebookWorkspaceTabs]);
@@ -1410,6 +1360,12 @@ export const FastAgentPanel = memo(function FastAgentPanel({
       model: msg.model,
     }));
   }, [chatMode, streamingMessages, agentMessages, isAuthenticated, demoMessages, isProductConversationMode, productMessagesToRender]);
+
+  const showPanelTabBar =
+    showsNotebookWorkspaceTabs ||
+    activeTab !== 'chat' ||
+    messagesToRender.length > 0 ||
+    isBusy;
 
   // Auto-title from first exchange (must be after messagesToRender)
   const autoTitle = useMemo(() => {
@@ -1678,8 +1634,10 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     localStorage.setItem('fastAgentPanel.isMinimized', String(isMinimized));
   }, [isMinimized]);
 
-  // Reset active thread when switching chat modes
+  // Reset only after an actual mode change, never during initial mount hydration.
   useEffect(() => {
+    if (lastAnnouncedChatModeRef.current === chatMode) return;
+    lastAnnouncedChatModeRef.current = chatMode;
     setActiveThreadId(null);
     toast.info(`Switched to ${chatMode === 'agent' ? 'Agent' : 'Agent Streaming'} mode`);
   }, [chatMode]);
@@ -2604,6 +2562,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
         )}
 
         {/* Tab Bar - Primary tabs visible, power-user tabs behind overflow (hidden in focus mode) */}
+        {showPanelTabBar && (
         <div className={cn(
           "flex items-center border-b border-edge/50",
           isCompactSidebar
@@ -2670,6 +2629,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
             </div>
           </div>}
         </div>
+        )}
 
         {/* Swarm Lanes View - Shows when thread has active swarm */}
         {activeThreadId && isSwarmActive && (
@@ -2792,13 +2752,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                   </div>
                 )}
 
-                {/* Scroll progress bar */}
-                {scrollProgress > 0.01 && scrollProgress < 0.99 && (
-                  <div className="h-[2px] bg-surface-secondary flex-shrink-0">
-                    <div className="h-full bg-indigo-600 transition-all duration-100" style={{ width: `${scrollProgress * 100}%` }} />
-                  </div>
-                )}
-
                 {/* Main scrollable chat area */}
                 <div
                   ref={scrollContainerRef}
@@ -2847,29 +2800,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                     </div>
                   )}
 
-                  {/* Conversation Memory Chips */}
-                  {activeThreadId && messagesToRender && messagesToRender.length > 2 && (
-                    <div className="flex items-center gap-1.5 flex-wrap mb-2">
-                      <span className="text-xs font-medium text-content-muted mr-1">Context:</span>
-                      {(() => {
-                        const topics = new Set<string>();
-                        messagesToRender.slice(0, 6).forEach((m: any) => {
-                          const t = (m.text || m.content || '').slice(0, 200);
-                          const words = t.split(/\s+/).filter((w: string) => w.length > 5 && /^[A-Z]/.test(w));
-                          words.slice(0, 2).forEach((w: string) => topics.add(w.replace(/[^a-zA-Z]/g, '')));
-                        });
-                        return Array.from(topics).slice(0, 4).map(topic => (
-                          <span key={topic} className="px-2 py-0.5 text-xs font-medium bg-surface-secondary border border-edge rounded-full text-content-secondary">
-                            {topic}
-                          </span>
-                        ));
-                      })()}
-                      <span className="px-2 py-0.5 text-xs font-medium bg-violet-50 dark:bg-violet-900/20 border border-violet-200 dark:border-violet-800 rounded-full text-violet-600 dark:text-violet-400">
-                        {selectedModel}
-                      </span>
-                    </div>
-                  )}
-
                   {/* Parallel Agent Lanes (Live Activity) */}
                   {chatMode === 'agent-streaming' && streamingThread?.agentThreadId && (
                     <div className="mb-4">
@@ -2891,22 +2821,11 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                     />
                   )}
 
-                  {/* Empty State - Branding + Quick Actions */}
+                  {/* Empty State - Quick Actions */}
                   {!activeThreadId && (!messagesToRender || messagesToRender.length === 0) && (
                     <div className="flex-1 flex flex-col overflow-y-auto">
-                      <div className="mx-auto flex w-full max-w-[440px] flex-col items-center justify-center px-4 pb-8 pt-10 text-center">
-                        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 dark:border-white/[0.12] dark:bg-[#171c22] dark:text-gray-300">
-                          <MessageSquare className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
-                          Workspace chat
-                        </div>
-                        <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-content">
-                          Ask directly or pick a starting point
-                        </h2>
-                        <p className="mt-2 max-w-[360px] text-[13px] leading-6 text-content-muted">
-                          Same conversation feel as the chat page, with recent threads and workspace context close at hand.
-                        </p>
-
-                       <div className="mt-6 grid w-full gap-2 sm:grid-cols-2">
+                      <div className="mx-auto flex w-full max-w-[440px] flex-col items-center justify-center px-4 pb-8 pt-6 text-center">
+                       <div className="grid w-full gap-2 sm:grid-cols-2">
                          {[
                            { label: 'What gaps do I have before pitching?', icon: '🎯' },
                            { label: 'Should I build or find a partner?', icon: '🏗️' },
@@ -3217,35 +3136,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                     </div>
                   )}
 
-                  {/* Follow-up suggestion chips (shown after last assistant message, not while streaming) */}
-                  {!isCompactSidebar && !isBusy && messagesToRender && messagesToRender.length > 0 && (() => {
-                    const lastMsg = messagesToRender[messagesToRender.length - 1];
-                    if (lastMsg?.role !== 'assistant') return null;
-                    const txt = (lastMsg.text || lastMsg.content || '').slice(0, 600);
-                    if (!txt || txt.length < 30) return null;
-                    // Extract key noun phrases for follow-up suggestions
-                    const sentences = txt.split(/[.!?\n]+/).filter((s: string) => s.trim().length > 10);
-                    const suggestions: string[] = [];
-                    if (sentences.length > 0) suggestions.push(`Tell me more about ${sentences[0].trim().split(/\s+/).slice(0, 5).join(' ')}...`);
-                    if (sentences.length > 1) suggestions.push(`How does this compare to alternatives?`);
-                    if (txt.length > 200) suggestions.push(`Summarize the key takeaways`);
-                    if (suggestions.length === 0) return null;
-                    return (
-                      <div className="flex flex-wrap gap-2 px-4 pb-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
-                        {suggestions.slice(0, 3).map((s, i) => (
-                          <button
-                            key={i}
-                            type="button"
-                            onClick={() => { setInput(s); void stableSendMessage(s); }}
-                            className="text-xs px-3 py-1.5 rounded-full border border-edge bg-surface-secondary text-content-secondary hover:bg-surface-secondary hover:text-content hover:border-indigo-500/30 transition-all"
-                          >
-                            {s}
-                          </button>
-                        ))}
-                      </div>
-                    );
-                  })()}
-
                   <div ref={messagesEndRef} />
                 </div>
 
@@ -3261,31 +3151,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                   >
                     ↓ New messages
                   </button>
-                )}
-
-                {/* Conversation Minimap (right edge) */}
-                {messagesToRender && messagesToRender.length > 4 && (
-                  <div className="absolute right-1 top-2 bottom-2 w-[6px] z-20 opacity-0 hover:opacity-100 transition-opacity duration-300">
-                    {messagesToRender.map((msg: any, idx: number) => {
-                      const isUser = msg.role === 'user';
-                      const charLen = (msg.text || msg.content || '').length;
-                      const totalChars = messagesToRender.reduce((s: number, m: any) => s + (m.text || m.content || '').length, 0);
-                      const heightPct = Math.max(2, (charLen / Math.max(1, totalChars)) * 100);
-                      return (
-                        <div
-                          key={idx}
-                          className="w-full rounded-sm cursor-pointer hover:brightness-125 transition-all"
-                          style={{
-                            height: `${heightPct}%`,
-                            background: isUser ? '#3b82f6' : '#22c55e',
-                            opacity: 0.5,
-                            marginBottom: '1px',
-                          }}
-                          title={`${isUser ? 'You' : 'AI'}: ${(msg.text || msg.content || '').slice(0, 50)}`}
-                        />
-                      );
-                    })}
-                  </div>
                 )}
 
                 {/* Scroll-to-bottom FAB (Claude/ChatGPT pattern) */}
@@ -3348,105 +3213,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                 </div>
               </div>
             )}
-
-            {/* Quick Actions Toolbar */}
-            {!isCompactSidebar && messagesToRender && messagesToRender.length > 0 && !isBusy && (
-              <div className="flex items-center gap-1 px-3 pt-1.5">
-                <span className="text-[8px] text-content-muted mr-1">Quick:</span>
-                {[
-                  { label: 'Summarize', action: 'Summarize the conversation so far in 3 bullet points' },
-                  { label: 'Simplify', action: 'Explain your last response in simpler terms' },
-                  { label: 'Expand', action: 'Expand on your last point with more detail and examples' },
-                  { label: 'Translate', action: 'Translate your last response to Spanish' },
-                ].map((qa, i) => (
-                  <button
-                    key={i}
-                    type="button"
-                    className="text-xs px-2 py-0.5 rounded-md bg-surface-secondary border border-edge text-content-muted hover:text-content hover:bg-surface-hover transition-colors"
-                    onClick={() => { setInput(qa.action); }}
-                  >
-                    {qa.label}
-                  </button>
-                ))}
-              </div>
-            )}
-
-            {/* Focus Mode + Tone Picker Chips */}
-            {!isCompactSidebar && <div className="flex items-center gap-1.5 px-3 pt-1">
-              {/* Focus Mode Picker */}
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setShowFocusPicker(p => !p)}
-                  className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-md bg-surface-secondary border border-edge text-content-muted hover:text-content transition-colors"
-                  aria-label="Focus mode"
-                >
-                  {FOCUS_MODES.find(m => m.id === focusMode)?.icon} {FOCUS_MODES.find(m => m.id === focusMode)?.label}
-                </button>
-                {showFocusPicker && (
-                  <>
-                    <div className="fixed inset-0 z-40" onClick={() => setShowFocusPicker(false)} />
-                    <div className="absolute bottom-full left-0 mb-1 z-50 bg-surface border border-edge rounded-lg shadow-xl overflow-hidden">
-                      {FOCUS_MODES.map(mode => (
-                        <button
-                          key={mode.id}
-                          type="button"
-                          onClick={() => { setFocusMode(mode.id); setShowFocusPicker(false); }}
-                          className={`w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-surface-secondary text-left transition-colors ${focusMode === mode.id ? 'bg-surface-secondary font-semibold' : ''}`}
-                        >
-                          <span>{mode.icon}</span>
-                          <span>{mode.label}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </>
-                )}
-              </div>
-
-              {/* Tone Preset Chips */}
-              {TONE_PRESETS.map(tone => (
-                <button
-                  key={tone.id}
-                  type="button"
-                  onClick={() => setTonePreset(tone.id)}
-                  className={`text-xs px-1.5 py-0.5 rounded-md border transition-colors ${tonePreset === tone.id ? 'bg-indigo-600/10 border-indigo-500/30 text-indigo-600 dark:text-indigo-400 font-medium' : 'bg-transparent border-transparent text-content-muted hover:text-content'}`}
-                  title={`Tone: ${tone.label}`}
-                >
-                  {tone.icon}
-                </button>
-              ))}
-            </div>}
-
-            {/* Follow-up Suggestion Chips */}
-            {!isCompactSidebar && messagesToRender && messagesToRender.length > 0 && !isBusy && (() => {
-              const lastMsg = messagesToRender[messagesToRender.length - 1] as any;
-              if (!lastMsg || lastMsg.role === 'user') return null;
-              const text = (lastMsg.text || lastMsg.content || '').slice(0, 300).toLowerCase();
-              const suggestions: string[] = [];
-              if (text.includes('financ') || text.includes('revenue') || text.includes('earning')) {
-                suggestions.push('Compare to competitors', 'Show quarterly trends', 'Break down by segment');
-              } else if (text.includes('research') || text.includes('study') || text.includes('paper')) {
-                suggestions.push('Find related papers', 'Summarize key findings', 'What are the limitations?');
-              } else if (text.includes('code') || text.includes('function') || text.includes('implement')) {
-                suggestions.push('Add error handling', 'Write tests', 'Optimize performance');
-              } else {
-                suggestions.push('Tell me more', 'Give me examples', 'What are the alternatives?');
-              }
-              return (
-                <div className="flex flex-wrap gap-1.5 px-3 pt-2">
-                  {suggestions.map((s, i) => (
-                    <button
-                      key={i}
-                      type="button"
-                      className="smart-action-chip text-xs"
-                      onClick={() => { setInput(s); }}
-                    >
-                      {s}
-                    </button>
-                  ))}
-                </div>
-              );
-            })()}
 
             {/* Reply-To Indicator */}
             {replyToMsg && (
@@ -3533,10 +3299,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                   <span className="text-xs text-content-muted">A</span>
                 </div>
               </div>}
-              {/* R6: Mobile Command Chips — always visible above input on mobile */}
-              <MobileCommandChips
-                onSelect={(msg) => { setInput(msg); void stableSendMessage(msg); }}
-              />
               {isProductConversationMode ? (
                 <ProductIntakeComposer
                   value={input}

--- a/src/features/agents/components/FastAgentPanel/__tests__/FastAgentUIMessageBubble.contract.test.tsx
+++ b/src/features/agents/components/FastAgentPanel/__tests__/FastAgentUIMessageBubble.contract.test.tsx
@@ -28,7 +28,11 @@ vi.mock("@/hooks/useVoiceOutput", () => ({
 
 function message(
   parts: Array<Record<string, unknown>>,
-  overrides: Partial<UIMessage> & { text?: string } = {},
+  overrides: Partial<UIMessage> & {
+    text?: string;
+    tokensUsed?: { input: number; output: number };
+    model?: string;
+  } = {},
 ): UIMessage {
   return {
     id: "message-1",
@@ -300,6 +304,66 @@ describe("FastAgentUIMessageBubble AI Elements contract", () => {
     });
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute("href", "https://example.com/evidence");
+  });
+
+  it("keeps canonical Markdown without heuristic confidence or duplicate source projections", () => {
+    const { container } = render(
+      <FastAgentUIMessageBubble
+        message={message(
+          [
+            {
+              type: "text",
+              text: `This may be uncertain [1].
+
+[Evidence link](https://example.com/evidence)
+
+![Evidence image](https://example.com/chart.png)
+
+[Evidence report](https://example.com/report.pdf)`,
+            },
+          ],
+          { text: undefined },
+        )}
+      />,
+    );
+
+    expect(screen.queryByText(/^(high|moderate|low) confidence$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Sources:")).not.toBeInTheDocument();
+    expect(container.querySelectorAll('a[href="https://example.com/evidence"]')).toHaveLength(1);
+    expect(container.querySelectorAll('img[src="https://example.com/chart.png"]')).toHaveLength(1);
+    expect(container.querySelectorAll('a[href="https://example.com/report.pdf"]')).toHaveLength(1);
+    expect(container.querySelectorAll('img[src*="google.com/s2/favicons"]')).toHaveLength(0);
+  });
+
+  it("renders canonical sources and token/model provenance exactly once", () => {
+    const { container } = render(
+      <FastAgentUIMessageBubble
+        message={message(
+          [
+            {
+              type: "source-url",
+              sourceId: "provenance-source-1",
+              url: "https://example.com/provenance",
+              title: "Provenance source sentinel",
+            },
+          ],
+          {
+            tokensUsed: { input: 1200, output: 345 },
+            model: "gpt-5.4-mini",
+          },
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Used 1 sources" }));
+    expect(
+      screen.getAllByRole("link", { name: "Provenance source sentinel" }),
+    ).toHaveLength(1);
+
+    const provenanceBadges = container.querySelectorAll('[title*="gpt-5.4-mini"]');
+    expect(provenanceBadges).toHaveLength(1);
+    expect(provenanceBadges[0]).toHaveTextContent("1.2K↓");
+    expect(provenanceBadges[0]).toHaveTextContent("345↑");
   });
 
   it("renders canonical standard owners in their original interleaved order", () => {

--- a/src/features/agents/components/HumanApprovalQueue.tsx
+++ b/src/features/agents/components/HumanApprovalQueue.tsx
@@ -338,19 +338,9 @@ export const HumanApprovalQueue = memo(function HumanApprovalQueue({
     );
   }
 
-  // Empty state
+  // Nothing is actionable, so the hub stays quiet.
   if (pendingRequests.length === 0) {
-    return (
-      <div className={cn("p-6 text-center", className)}>
-        <div className="w-10 h-10 rounded-full bg-green-500/10 border border-green-500/20 flex items-center justify-center mx-auto mb-3">
-          <CheckCircle className="w-5 h-5 text-green-600" />
-        </div>
-        <p className="text-sm font-medium text-content">All caught up!</p>
-        <p className="text-xs text-content-muted mt-1">
-          No pending approval requests
-        </p>
-      </div>
-    );
+    return null;
   }
 
   const displayRequests = pendingRequests.slice(0, maxItems);

--- a/src/features/agents/components/TopicCanvasPanel.test.tsx
+++ b/src/features/agents/components/TopicCanvasPanel.test.tsx
@@ -13,7 +13,7 @@ vi.mock("convex/react", () => ({
 }));
 
 describe("buildTopicCanvasEntries", () => {
-  it("derives sorted topic cards with memory, resources, and next actions", () => {
+  it("sorts topics and exposes only recorded context and resources", () => {
     const entries = buildTopicCanvasEntries([
       {
         _id: "session_older" as never,
@@ -39,15 +39,20 @@ describe("buildTopicCanvasEntries", () => {
     ] as TaskSession[]);
 
     expect(entries[0].title).toBe("ByteDance strategy topic");
-    expect(entries[0].memoryLabel).toContain("Every conclusion is grounded");
+    expect(entries[0].description).toBe(
+      "Compare public market moves with trace-backed evidence.",
+    );
+    expect(entries[0].contextLabel).toContain("Every conclusion is grounded");
     expect(entries[0].resourceLabels).toEqual([
       "10-Q filing",
       "discover_tools",
       "get_workflow_chain",
       "2 agents",
     ]);
-    expect(entries[0].nextAction).toMatch(/proof pack/i);
     expect(entries[0].traceHref).toContain("session_latest");
+    expect(entries[1].description).toBeUndefined();
+    expect(entries[1].contextLabel).toBeUndefined();
+    expect(entries[1].resourceLabels).toEqual([]);
   });
 });
 
@@ -67,7 +72,8 @@ describe("TopicCanvasPanel", () => {
             {
               _id: "session_1",
               title: "AI infrastructure topic",
-              description: "Track model, supplier, and investor signals as one durable topic.",
+              description:
+                "Track model, supplier, and investor signals as one durable topic.",
               type: "agent",
               visibility: "public",
               status: "running",
@@ -84,10 +90,16 @@ describe("TopicCanvasPanel", () => {
 
     render(<TopicCanvasPanel />);
 
-    expect(screen.getByText("Topic canvas")).toBeInTheDocument();
-    expect(screen.getByText(/Topics, not sessions/i)).toBeInTheDocument();
+    expect(screen.getByText("Recent topics")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 shown · 1 active · 1 sourced/i),
+    ).toBeInTheDocument();
     expect(screen.getByText("AI infrastructure topic")).toBeInTheDocument();
-    expect(screen.getByText(/Track model, supplier, and investor signals/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Track model, supplier, and investor signals/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Canvas memory/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Next action/i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open trace/i })).toHaveAttribute(
       "href",
       "/execution-trace?session=session_1",

--- a/src/features/agents/components/TopicCanvasPanel.tsx
+++ b/src/features/agents/components/TopicCanvasPanel.tsx
@@ -2,15 +2,9 @@ import React, { useMemo } from "react";
 import { useConvexAuth, useQuery } from "convex/react";
 import {
   ArrowUpRight,
-  Bot,
   CheckCircle2,
   Clock3,
-  FileText,
-  Layers3,
-  Link2,
   Loader2,
-  Sparkles,
-  Wrench,
   XCircle,
 } from "lucide-react";
 
@@ -21,16 +15,15 @@ import { cn } from "@/lib/utils";
 export interface TopicCanvasEntry {
   id: string;
   title: string;
-  summary: string;
+  description?: string;
   status: TaskSessionStatus;
   statusLabel: string;
   statusClassName: string;
-  memoryLabel: string;
+  contextLabel?: string;
   resourceLabels: string[];
-  resourceSummary: string;
-  nextAction: string;
   traceHref: string;
   typeLabel: string;
+  startedAtLabel: string;
 }
 
 function getStatusMeta(status: TaskSessionStatus): {
@@ -40,7 +33,7 @@ function getStatusMeta(status: TaskSessionStatus): {
   switch (status) {
     case "completed":
       return {
-        label: "Verified-ready",
+        label: "Complete",
         className:
           "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
       };
@@ -52,7 +45,7 @@ function getStatusMeta(status: TaskSessionStatus): {
       };
     case "failed":
       return {
-        label: "Needs intervention",
+        label: "Needs review",
         className:
           "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300",
       };
@@ -71,12 +64,12 @@ function getStatusMeta(status: TaskSessionStatus): {
   }
 }
 
-function buildMemoryLabel(session: TaskSession): string {
+function buildContextLabel(session: TaskSession): string | undefined {
   const criterion = session.successCriteria?.[0]?.trim();
   if (criterion) return criterion;
-  if (session.goalId) return `Goal locked: ${session.goalId}`;
-  if (session.visionSnapshot) return session.visionSnapshot;
-  return "Topic continuity comes from the live trace, attached tools, and source set.";
+  if (session.goalId?.trim()) return session.goalId.trim();
+  if (session.visionSnapshot?.trim()) return session.visionSnapshot.trim();
+  return undefined;
 }
 
 function buildResourceLabels(session: TaskSession): string[] {
@@ -91,81 +84,59 @@ function buildResourceLabels(session: TaskSession): string[] {
   }
 
   if ((session.agentsInvolved?.length ?? 0) > 0) {
-    labels.push(`${session.agentsInvolved!.length} agent${session.agentsInvolved!.length === 1 ? "" : "s"}`);
+    labels.push(
+      `${session.agentsInvolved!.length} agent${session.agentsInvolved!.length === 1 ? "" : "s"}`,
+    );
   }
 
   return [...new Set(labels)].slice(0, 4);
 }
 
-function buildSummary(session: TaskSession): string {
-  if (session.description?.trim()) return session.description.trim();
-  if (session.status === "completed") {
-    return "Topic finished a full run and is ready for verdict review, drafting, or trace-backed publication.";
-  }
-  if (session.status === "failed") {
-    return "Topic hit a failure boundary and needs evidence review before retry, escalation, or scope reduction.";
-  }
-  if (session.status === "running") {
-    return "Topic is actively gathering evidence, traversing tools, or updating the trace in real time.";
-  }
-  return "Topic is staged with reusable context so the next action can resume from the existing work surface.";
-}
-
-function buildNextAction(session: TaskSession): string {
-  if (session.status === "completed") {
-    return "Open the trace, confirm the proof pack, and turn the verified outcome into a draft or final operator decision.";
-  }
-  if (session.status === "failed") {
-    return "Inspect the failing trace span, narrow the topic boundary, and relaunch with a more explicit evidence contract.";
-  }
-  if (session.status === "running") {
-    return "Monitor the live trace and attached sources, then decide whether the topic should keep running, branch, or escalate.";
-  }
-  if (session.status === "cancelled") {
-    return "Review why the topic stopped and either archive it or restart from the last durable source and tool context.";
-  }
-  return "Attach the missing resources, confirm the memory contract, and let the next agent step continue from this topic.";
-}
-
 function formatTypeLabel(type: TaskSession["type"]): string {
   switch (type) {
     case "agent":
-      return "Agent topic";
+      return "Agent";
     case "swarm":
-      return "Swarm topic";
+      return "Swarm";
     case "cron":
-      return "Cron topic";
+      return "Cron";
     case "scheduled":
-      return "Scheduled topic";
+      return "Scheduled";
     default:
-      return "Manual topic";
+      return "Manual";
   }
 }
 
-export function buildTopicCanvasEntries(sessions: TaskSession[]): TopicCanvasEntry[] {
+function formatStartedAt(startedAt: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(startedAt));
+}
+
+export function buildTopicCanvasEntries(
+  sessions: TaskSession[],
+): TopicCanvasEntry[] {
   return [...sessions]
     .sort((a, b) => b.startedAt - a.startedAt)
     .slice(0, 6)
     .map((session) => {
       const statusMeta = getStatusMeta(session.status);
-      const resourceLabels = buildResourceLabels(session);
 
       return {
         id: String(session._id),
         title: session.title,
-        summary: buildSummary(session),
+        description: session.description?.trim() || undefined,
         status: session.status,
         statusLabel: statusMeta.label,
         statusClassName: statusMeta.className,
-        memoryLabel: buildMemoryLabel(session),
-        resourceLabels,
-        resourceSummary:
-          resourceLabels.length > 0
-            ? `${resourceLabels.length} attached resource${resourceLabels.length === 1 ? "" : "s"}`
-            : "No attached sources yet",
-        nextAction: buildNextAction(session),
+        contextLabel: buildContextLabel(session),
+        resourceLabels: buildResourceLabels(session),
         traceHref: `/execution-trace?session=${encodeURIComponent(String(session._id))}`,
         typeLabel: formatTypeLabel(session.type),
+        startedAtLabel: formatStartedAt(session.startedAt),
       };
     });
 }
@@ -198,171 +169,106 @@ export function TopicCanvasPanel() {
 
   const sessions = useMemo(
     () =>
-      ((effectiveIsPublic ? publicSessionsData?.sessions : userSessionsData?.sessions) ?? []) as TaskSession[],
-    [effectiveIsPublic, publicSessionsData?.sessions, userSessionsData?.sessions],
+      ((effectiveIsPublic
+        ? publicSessionsData?.sessions
+        : userSessionsData?.sessions) ?? []) as TaskSession[],
+    [
+      effectiveIsPublic,
+      publicSessionsData?.sessions,
+      userSessionsData?.sessions,
+    ],
   );
   const entries = useMemo(() => buildTopicCanvasEntries(sessions), [sessions]);
 
-  const activeCount = entries.filter((entry) => entry.status === "running" || entry.status === "pending").length;
-  const citedCount = entries.filter((entry) => entry.resourceLabels.length > 0).length;
-  const interventionCount = entries.filter((entry) => entry.status === "failed").length;
+  const activeCount = entries.filter(
+    (entry) => entry.status === "running" || entry.status === "pending",
+  ).length;
+  const citedCount = entries.filter(
+    (entry) => entry.resourceLabels.length > 0,
+  ).length;
+  const interventionCount = entries.filter(
+    (entry) => entry.status === "failed",
+  ).length;
 
   return (
-    <section className="nb-surface-card p-5">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="max-w-3xl">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-2 rounded-full border border-edge bg-surface-secondary/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-content-muted">
-              <Layers3 className="h-3.5 w-3.5 text-accent" />
-              Topic-first workspace
-            </span>
-            <span className="rounded-full border border-primary/15 bg-primary/8 px-2.5 py-1 text-[11px] font-medium text-primary">
-              Topics, not sessions
-            </span>
-          </div>
-          <h2 className="mt-3 type-section-title text-content">Topic canvas</h2>
-          <p className="mt-2 text-sm leading-relaxed text-content-secondary">
-            Keep agent work anchored as durable topics with attached memory, reusable resources, and the next operator move
-            already spelled out. This shifts the hub away from one-off chat sessions and toward continuous work packages.
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:w-[420px]">
-          {[
-            {
-              label: "Active topics",
-              value: activeCount,
-              tone: "text-sky-700 dark:text-sky-300",
-            },
-            {
-              label: "Resource-backed",
-              value: citedCount,
-              tone: "text-emerald-700 dark:text-emerald-300",
-            },
-            {
-              label: "Need intervention",
-              value: interventionCount,
-              tone: "text-rose-700 dark:text-rose-300",
-            },
-          ].map((item) => (
-            <div key={item.label} className="rounded-xl border border-edge bg-surface-secondary/40 p-3">
-              <div className={cn("text-lg font-semibold", item.tone)}>{item.value}</div>
-              <div className="mt-1 text-[11px] uppercase tracking-[0.16em] text-content-muted">{item.label}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="mt-4 grid gap-3 md:grid-cols-3">
-        {[
-          {
-            title: "Canvas memory",
-            body: "Success criteria, goals, and prior context stay attached to the topic instead of being lost in message history.",
-            icon: Sparkles,
-          },
-          {
-            title: "Hot-plug resources",
-            body: "Sources, tools, and agents become the working shape of the topic, so the operator sees what the topic can actually use.",
-            icon: Link2,
-          },
-          {
-            title: "Self-directed next move",
-            body: "Every topic card ends with an explicit next action so the agent or operator can continue without re-deriving state.",
-            icon: Bot,
-          },
-        ].map((pillar) => (
-          <div key={pillar.title} className="rounded-xl border border-edge bg-surface-secondary/40 p-4">
-            <div className="flex items-center gap-2 text-sm font-medium text-content">
-              <pillar.icon className="h-4 w-4 text-accent" />
-              {pillar.title}
-            </div>
-            <p className="mt-2 text-xs leading-relaxed text-content-muted">{pillar.body}</p>
-          </div>
-        ))}
+    <section className="nb-surface-card overflow-hidden">
+      <div className="flex flex-wrap items-baseline justify-between gap-3 border-b border-edge px-4 py-3">
+        <h2 className="type-section-title text-content">Recent topics</h2>
+        <p className="text-xs text-content-muted">
+          {entries.length} shown · {activeCount} active · {citedCount} sourced
+          {interventionCount > 0 ? ` · ${interventionCount} needs review` : ""}
+        </p>
       </div>
 
       {entries.length === 0 ? (
-        <div className="mt-5 rounded-2xl border border-dashed border-edge bg-surface-secondary/30 px-4 py-6 text-sm text-content-secondary">
-          No live topics yet. Launch a request from the command bar and the next agent run will land here with memory, resources,
-          and its trace continuation path.
-        </div>
+        <p className="px-4 py-5 text-sm text-content-muted">
+          No recent topics. Start a request above.
+        </p>
       ) : (
-        <div className="mt-5 grid gap-4 xl:grid-cols-2">
+        <div className="divide-y divide-edge">
           {entries.map((entry) => {
             const StatusIcon = getStatusIcon(entry.status);
             return (
-              <article key={entry.id} className="rounded-2xl border border-edge bg-surface-secondary/35 p-4">
+              <article key={entry.id} className="px-4 py-3">
                 <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-content-muted">
-                      {entry.typeLabel}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <h3 className="truncate text-sm font-semibold text-content">
+                        {entry.title}
+                      </h3>
+                      <span className="text-xs text-content-muted">
+                        {entry.typeLabel} · {entry.startedAtLabel}
+                      </span>
                     </div>
-                    <h3 className="mt-1 truncate text-base font-semibold text-content">{entry.title}</h3>
+                    {entry.description ? (
+                      <p className="mt-1 line-clamp-2 text-sm text-content-secondary">
+                        {entry.description}
+                      </p>
+                    ) : null}
                   </div>
                   <span
                     className={cn(
-                      "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium",
+                      "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium",
                       entry.statusClassName,
                     )}
                   >
                     <StatusIcon
                       className={cn(
-                        "h-3.5 w-3.5",
-                        entry.status === "running" && "motion-safe:animate-spin",
+                        "h-3 w-3",
+                        entry.status === "running" &&
+                          "motion-safe:animate-spin",
                       )}
+                      aria-hidden="true"
                     />
                     {entry.statusLabel}
                   </span>
                 </div>
 
-                <p className="mt-3 text-sm leading-relaxed text-content-secondary">{entry.summary}</p>
-
-                <div className="mt-4 grid gap-3 md:grid-cols-3">
-                  <div className="rounded-xl border border-edge bg-surface/80 p-3">
-                    <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-content-muted">
-                      <Sparkles className="h-3.5 w-3.5 text-primary" />
-                      Memory
-                    </div>
-                    <p className="mt-2 text-sm leading-relaxed text-content-secondary">{entry.memoryLabel}</p>
-                  </div>
-                  <div className="rounded-xl border border-edge bg-surface/80 p-3">
-                    <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-content-muted">
-                      <Wrench className="h-3.5 w-3.5 text-primary" />
-                      Resources
-                    </div>
-                    <p className="mt-2 text-sm leading-relaxed text-content-secondary">{entry.resourceSummary}</p>
-                    {entry.resourceLabels.length > 0 ? (
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {entry.resourceLabels.map((label) => (
-                          <span
-                            key={`${entry.id}-${label}`}
-                            className="rounded-full border border-edge bg-surface-secondary/50 px-2 py-1 text-[11px] text-content-muted"
-                          >
-                            {label}
-                          </span>
-                        ))}
-                      </div>
+                {entry.contextLabel || entry.resourceLabels.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-content-muted">
+                    {entry.contextLabel ? (
+                      <span className="max-w-full truncate">
+                        Context: {entry.contextLabel}
+                      </span>
                     ) : null}
+                    {entry.resourceLabels.map((label) => (
+                      <span
+                        key={`${entry.id}-${label}`}
+                        className="rounded-full border border-edge px-2 py-0.5"
+                      >
+                        {label}
+                      </span>
+                    ))}
                   </div>
-                  <div className="rounded-xl border border-edge bg-surface/80 p-3">
-                    <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-content-muted">
-                      <FileText className="h-3.5 w-3.5 text-primary" />
-                      Next action
-                    </div>
-                    <p className="mt-2 text-sm leading-relaxed text-content-secondary">{entry.nextAction}</p>
-                  </div>
-                </div>
+                ) : null}
 
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-edge pt-3">
-                  <div className="text-xs text-content-muted">
-                    Continue this topic with the trace and keep the same sources, tools, and operator framing attached.
-                  </div>
+                <div className="mt-2 flex justify-end">
                   <a
                     href={entry.traceHref}
-                    className="inline-flex items-center gap-1 rounded-lg border border-edge px-3 py-1.5 text-xs font-medium text-content-secondary transition hover:bg-surface-hover hover:text-content"
+                    className="inline-flex items-center gap-1 text-xs font-medium text-content-secondary transition hover:text-content hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     Open trace
-                    <ArrowUpRight className="h-3.5 w-3.5" />
+                    <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
                   </a>
                 </div>
               </article>

--- a/src/features/agents/views/AgentsHub.test.ts
+++ b/src/features/agents/views/AgentsHub.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { routeAgentCommand } from "./AgentsHub";
+
+describe("routeAgentCommand", () => {
+  it("opens the canonical chat panel for a plain question", async () => {
+    const spawnSwarm = vi.fn();
+    const openWithContext = vi.fn();
+
+    await routeAgentCommand(
+      "Summarize today's signals",
+      { model: "gemini-2.5-flash" },
+      { spawnSwarm, openWithContext },
+    );
+
+    expect(spawnSwarm).not.toHaveBeenCalled();
+    expect(openWithContext).toHaveBeenCalledWith({
+      initialMessage: "Summarize today's signals",
+      initialTab: "chat",
+    });
+  });
+
+  it("keeps explicit swarm commands on the swarm path", async () => {
+    const spawnSwarm = vi.fn().mockResolvedValue(undefined);
+    const openWithContext = vi.fn();
+
+    await routeAgentCommand(
+      "Compare filings",
+      { model: "gemini-2.5-flash", agents: ["doc", "sec"] },
+      { spawnSwarm, openWithContext },
+    );
+
+    expect(openWithContext).not.toHaveBeenCalled();
+    expect(spawnSwarm).toHaveBeenCalledWith({
+      query: "Compare filings",
+      agents: ["doc", "sec"],
+      pattern: "fan_out_gather",
+      model: "gemini-2.5-flash",
+    });
+  });
+});

--- a/src/features/agents/views/AgentsHub.test.ts
+++ b/src/features/agents/views/AgentsHub.test.ts
@@ -14,6 +14,7 @@ describe("routeAgentCommand", () => {
     );
 
     expect(spawnSwarm).not.toHaveBeenCalled();
+    expect(openWithContext).toHaveBeenCalledTimes(1);
     expect(openWithContext).toHaveBeenCalledWith({
       initialMessage: "Summarize today's signals",
       initialTab: "chat",
@@ -31,6 +32,7 @@ describe("routeAgentCommand", () => {
     );
 
     expect(openWithContext).not.toHaveBeenCalled();
+    expect(spawnSwarm).toHaveBeenCalledTimes(1);
     expect(spawnSwarm).toHaveBeenCalledWith({
       query: "Compare filings",
       agents: ["doc", "sec"],

--- a/src/features/agents/views/AgentsHub.tsx
+++ b/src/features/agents/views/AgentsHub.tsx
@@ -25,7 +25,6 @@ import {
   Cpu,
   ClipboardList,
   ExternalLink,
-  PanelTop,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { api } from "../../../../convex/_generated/api";
@@ -38,14 +37,11 @@ import { PageHeroHeader } from "@shared/ui/PageHeroHeader";
 
 // Agent-specific components (always visible on initial render)
 import { AgentStatusCard, AGENT_CONFIGS, type AgentStatus } from "../components/AgentStatusCard";
-import { AgentCommandBar, type AgentMode, type ApprovedModel } from "../components/AgentCommandBar";
+import { AgentCommandBar, type ApprovedModel } from "../components/AgentCommandBar";
 
 // Lazy-loaded heavy sub-components (behind tabs/expandable sections/conditional rendering)
 const HumanApprovalQueue = lazy(() =>
   import("../components/HumanApprovalQueue").then((mod) => ({ default: mod.HumanApprovalQueue }))
-);
-const AgentSidebar = lazy(() =>
-  import("../components/AgentSidebar").then((mod) => ({ default: mod.AgentSidebar }))
 );
 const AutonomousOperationsPanel = lazy(() =>
   import("../components/AutonomousOperationsPanel").then((mod) => ({ default: mod.AutonomousOperationsPanel }))
@@ -68,6 +64,7 @@ const TaskManagerView = lazy(() =>
 
 // Hooks
 import { useSwarmActions } from "@/hooks/useSwarm";
+import { useFastAgent } from "@/features/agents/context/FastAgentContext";
 
 // ============================================================================
 // Types
@@ -79,6 +76,32 @@ interface AgentStatusData {
   lastActivity: number | null;
   tasksCompleted: number;
   currentTask: string | null;
+}
+
+export async function routeAgentCommand(
+  query: string,
+  options: { model: ApprovedModel; agents?: string[] },
+  actions: {
+    spawnSwarm: (params: {
+      query: string;
+      agents: string[];
+      pattern: "fan_out_gather";
+      model: ApprovedModel;
+    }) => Promise<unknown>;
+    openWithContext: (options: { initialMessage: string; initialTab: "chat" }) => void;
+  },
+) {
+  if (options.agents && options.agents.length > 0) {
+    await actions.spawnSwarm({
+      query,
+      agents: options.agents,
+      pattern: "fan_out_gather",
+      model: options.model,
+    });
+    return;
+  }
+
+  actions.openWithContext({ initialMessage: query, initialTab: "chat" });
 }
 
 // ============================================================================
@@ -170,23 +193,9 @@ function QuickStatsBar() {
 // ============================================================================
 
 function AgentGrid() {
-  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
-
   const agentStatuses = useQuery(
     api.domains.agents.agentHubQueries.getAllAgentStatuses
   ) as AgentStatusData[] | undefined;
-
-  const toggleExpand = useCallback((agentId: string) => {
-    setExpandedAgents((prev) => {
-      const next = new Set(prev);
-      if (next.has(agentId)) {
-        next.delete(agentId);
-      } else {
-        next.add(agentId);
-      }
-      return next;
-    });
-  }, []);
 
   const formatTimeAgo = (timestamp: number | null): string => {
     if (!timestamp) return "Never";
@@ -227,10 +236,6 @@ function AgentGrid() {
           lastActivity={agent.lastActivity}
           tasksCompleted={agent.tasksCompleted}
           currentTask={agent.currentTask}
-          isExpanded={expandedAgents.has(agent.id)}
-          onToggleExpand={() => toggleExpand(agent.id)}
-          onConfigure={() => {}}
-          onToggleStatus={() => {}}
         />
       ))}
     </div>
@@ -309,61 +314,10 @@ function ActiveSwarmsSection() {
 // Main Component
 // ============================================================================
 
-function QuickActionsSummary({ onShowAdvanced }: { onShowAdvanced: () => void }) {
-  return (
-    <div className="nb-surface-card p-5">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-2">
-            <PanelTop className="h-4 w-4 text-accent" />
-            <h2 className="type-section-title text-content">Quick actions</h2>
-          </div>
-          <p className="mt-2 text-sm text-content-secondary">
-            Start a request, review running tasks, or approve blocked work without opening the full operator cockpit.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onShowAdvanced}
-          className="rounded-lg border border-edge px-3 py-1.5 text-xs font-medium text-content-muted transition hover:bg-surface-hover hover:text-content-secondary"
-        >
-          Open advanced view
-        </button>
-      </div>
-
-      <div className="mt-4 grid gap-3 md:grid-cols-3">
-        {[
-          {
-            title: "Run a request",
-            body: "Use the command bar to launch research, compare sources, or hand work to an agent.",
-          },
-          {
-            title: "Review active work",
-            body: "The running tasks lane below is the fastest way to see what the system is doing right now.",
-          },
-          {
-            title: "Approve blocked actions",
-            body: "Use the human approval queue for any step that needs review before it can continue.",
-          },
-        ].map((item) => (
-          <div key={item.title} className="rounded-xl border border-edge bg-surface-secondary/40 p-4">
-            <div className="text-sm font-medium text-content">{item.title}</div>
-            <p className="mt-1 text-xs leading-relaxed text-content-muted">{item.body}</p>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export function AgentsHub() {
   const [advancedMode, setAdvancedMode] = useState(() => {
     return loadAgentsViewMode() === "advanced";
   });
-  const setViewMode = useCallback((mode: "basic" | "advanced") => {
-    saveAgentsViewMode(mode);
-    setAdvancedMode(mode === "advanced");
-  }, []);
   const toggleMode = useCallback(() => {
     setAdvancedMode((prev) => {
       const next = !prev;
@@ -373,30 +327,20 @@ export function AgentsHub() {
   }, []);
 
   const { spawnSwarm } = useSwarmActions();
+  const { openWithContext } = useFastAgent();
 
   const handleCommandSubmit = useCallback(
     async (
       query: string,
-      options: { mode: AgentMode; model: ApprovedModel; agents?: string[] }
+      options: { model: ApprovedModel; agents?: string[] }
     ) => {
-
-      if (options.agents && options.agents.length > 0) {
-        // Spawn swarm
-        try {
-          await spawnSwarm({
-            query,
-            agents: options.agents,
-            pattern: "fan_out_gather",
-            model: options.model,
-          });
-        } catch (error) {
-          console.error("Failed to spawn swarm:", error);
-        }
-      } else {
-        // Single agent query - would route to FastAgentPanel
+      try {
+        await routeAgentCommand(query, options, { spawnSwarm, openWithContext });
+      } catch (error) {
+        console.error("Failed to run agent command:", error);
       }
     },
-    [spawnSwarm]
+    [openWithContext, spawnSwarm]
   );
 
   return (
@@ -432,11 +376,6 @@ export function AgentsHub() {
               </Suspense>
             </div>
 
-            {!advancedMode && (
-              <div className="mb-6">
-                <QuickActionsSummary onShowAdvanced={() => setViewMode("advanced")} />
-              </div>
-            )}
 
             {/* Active Swarms — always visible */}
             <div className="mb-6">
@@ -458,7 +397,7 @@ export function AgentsHub() {
             </div>
 
             {/* Mode toggle */}
-            <div className="mb-6 flex items-center justify-between">
+            <div className="mb-6">
               <button
                 type="button"
                 onClick={toggleMode}
@@ -467,11 +406,6 @@ export function AgentsHub() {
                 <Cpu className="h-3.5 w-3.5" />
                 {advancedMode ? "Show less" : "Advanced view"}
               </button>
-              {!advancedMode && (
-                <p className="text-[11px] text-content-muted">
-                  Advanced view adds the operator sidebar, Oracle controls, stats, rankings, and task history.
-                </p>
-              )}
             </div>
 
             {/* ── Advanced sections ── */}
@@ -531,25 +465,7 @@ export function AgentsHub() {
                 </div>
               </>
             )}
-
-            {/* Background Research Banner — always visible */}
-            <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
-              <div className="flex items-center gap-3 mb-2">
-                <Sparkles className="w-5 h-5 text-accent" />
-                <h3 className="font-semibold text-content">
-                  Background Research Active
-                </h3>
-              </div>
-              <p className="text-sm text-content-secondary">
-                AI is continuously researching in the background — scanning news, processing signals,
-                and publishing updates at no extra cost.
-                More powerful analysis runs when you ask for deep research.
-              </p>
-            </div>
           </div>
-
-          {/* Sidebar */}
-          {advancedMode ? <Suspense fallback={<div className="w-64" />}><AgentSidebar /></Suspense> : null}
         </div>
       </div>
     </div>

--- a/src/layouts/CockpitLayout.tsx
+++ b/src/layouts/CockpitLayout.tsx
@@ -914,7 +914,7 @@ export function CockpitLayout({
              the toggle's ~34px height overlapped the trace bar's ~28px band, visually clipping
              the clock on every surface where both render (found via live visual-judge scan:
              benchmarks/pulse/changelog/about). Raised the xl offset to clear the trace bar. */}
-        {!isCompactLayout && !isStandaloneInfoView && !isDesktopPublicShell ? (
+        {isObjectFirstSurface && !isCompactLayout && !isStandaloneInfoView && !isDesktopPublicShell ? (
           <div className="fixed bottom-16 right-4 z-50 xl:bottom-12">
             <ObjectFirstGlobalToggle showLabel />
           </div>

--- a/src/shared/ui/UnifiedHubPills.tsx
+++ b/src/shared/ui/UnifiedHubPills.tsx
@@ -1,8 +1,17 @@
 import React from "react";
+import { ChevronDown } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { buildCockpitPath } from "@/lib/registry/viewRegistry";
 
 type Hub = "documents" | "calendar" | "agents" | "roadmap" | "workspace";
+
+const HUB_LABELS: Record<Hub, string> = {
+  agents: "Agents",
+  workspace: "Workspace",
+  documents: "Documents",
+  calendar: "Schedule",
+  roadmap: "Roadmap",
+};
 
 export function UnifiedHubPills({
   active,
@@ -18,7 +27,7 @@ export function UnifiedHubPills({
   const navigate = useNavigate();
 
   const container = [
-    "inline-flex items-center gap-0.5 p-1 rounded-lg bg-surface-secondary/80 backdrop-blur-sm border border-edge/60 shadow-sm",
+    "items-center gap-0.5 p-1 rounded-lg bg-surface-secondary/80 backdrop-blur-sm border border-edge/60 shadow-sm",
     className ?? "",
   ]
     .join(" ")
@@ -42,8 +51,47 @@ export function UnifiedHubPills({
   const goRoadmap = () => { try { navigate(buildCockpitPath({ surfaceId: "workspace" as any, extra: { view: "roadmap" } })); } catch {} };
   const goWorkspace = () => { try { navigate(buildCockpitPath({ surfaceId: "workspace" as any, extra: { view: "workspace" } })); } catch {} };
 
+  const hubs: Array<{
+    id: Hub;
+    label: string;
+    disabled?: boolean;
+    onSelect: () => void;
+  }> = [
+    { id: "agents", label: HUB_LABELS.agents, onSelect: goAgents },
+    { id: "workspace", label: HUB_LABELS.workspace, onSelect: goWorkspace },
+    { id: "documents", label: HUB_LABELS.documents, onSelect: goDocs },
+    { id: "calendar", label: HUB_LABELS.calendar, onSelect: goCalendar },
+    ...(showRoadmap
+      ? [{ id: "roadmap" as const, label: HUB_LABELS.roadmap, disabled: roadmapDisabled, onSelect: goRoadmap }]
+      : []),
+  ];
+
   return (
-    <nav className={container} role="tablist" aria-label="Primary hubs">
+    <>
+      <div className={["relative sm:hidden", className ?? ""].join(" ").trim()}>
+        <select
+          value={active}
+          aria-label={`Choose hub. Current hub: ${HUB_LABELS[active]}`}
+          className="h-10 min-w-40 appearance-none rounded-lg border border-edge/60 bg-surface-secondary/80 py-2 pl-3 pr-9 text-xs font-semibold text-content shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          onChange={(event) => {
+            const selected = hubs.find((hub) => hub.id === event.target.value);
+            if (!selected || selected.disabled) return;
+            selected.onSelect();
+          }}
+        >
+          {hubs.map((hub) => (
+            <option key={hub.id} value={hub.id} disabled={hub.disabled}>
+              {hub.label}{hub.disabled ? " — unavailable" : ""}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-content-muted"
+          aria-hidden="true"
+        />
+      </div>
+
+    <nav className={["hidden sm:inline-flex", container].join(" ")} role="tablist" aria-label="Primary hubs">
       <button className={btnCls("agents")} onClick={goAgents} role="tab" aria-selected={active === "agents"} aria-current={active === "agents" ? "page" : undefined}>
         {active === "agents" ? <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" /> : null}
         Agents
@@ -76,5 +124,6 @@ export function UnifiedHubPills({
         </button>
       )}
     </nav>
+    </>
   );
 }

--- a/src/test/UnifiedHubPills.test.tsx
+++ b/src/test/UnifiedHubPills.test.tsx
@@ -79,4 +79,76 @@ describe("UnifiedHubPills", () => {
       buildCockpitPath({ surfaceId: "workspace" as any, extra: { view: "roadmap" } }),
     );
   });
+
+  it("uses a compact mobile chooser that names the active hub", () => {
+    renderWithRouter(<UnifiedHubPills active="documents" showRoadmap />);
+
+    const chooser = screen.getByRole("combobox", {
+      name: "Choose hub. Current hub: Documents",
+    });
+    expect(chooser).toHaveValue("documents");
+    expect(screen.getAllByRole("option").map((item) => item.textContent)).toEqual([
+      "Agents",
+      "Workspace",
+      "Documents",
+      "Schedule",
+      "Roadmap — unavailable",
+    ]);
+    expect((screen.getByRole("option", { name: "Documents" }) as HTMLOptionElement).selected).toBe(true);
+  });
+
+  it("keeps disabled Roadmap semantics in the mobile chooser", () => {
+    renderWithRouter(<UnifiedHubPills active="calendar" showRoadmap roadmapDisabled />);
+
+    const chooser = screen.getByRole("combobox", {
+      name: "Choose hub. Current hub: Schedule",
+    });
+    const roadmap = screen.getByRole("option", { name: "Roadmap — unavailable" });
+
+    expect(roadmap).toBeDisabled();
+
+    fireEvent.change(chooser, { target: { value: "roadmap" } });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates from the mobile chooser", () => {
+    renderWithRouter(
+      <UnifiedHubPills active="agents" showRoadmap roadmapDisabled={false} />,
+    );
+    const chooser = screen.getByRole("combobox", {
+      name: "Choose hub. Current hub: Agents",
+    });
+
+    fireEvent.change(chooser, { target: { value: "roadmap" } });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      buildCockpitPath({ surfaceId: "workspace" as any, extra: { view: "roadmap" } }),
+    );
+  });
+
+  it("uses a native, focusable select for keyboard operation", () => {
+    renderWithRouter(<UnifiedHubPills active="documents" />);
+    const chooser = screen.getByRole("combobox", {
+      name: "Choose hub. Current hub: Documents",
+    });
+
+    expect(chooser.tagName).toBe("SELECT");
+    chooser.focus();
+    expect(chooser).toHaveFocus();
+    expect(chooser).not.toHaveAttribute("tabindex", "-1");
+  });
+
+  it("preserves the original tab rail at sm and above", () => {
+    renderWithRouter(<UnifiedHubPills active="agents" showRoadmap roadmapDisabled={false} />);
+
+    const desktopRail = screen.getByRole("tablist", { name: "Primary hubs" });
+    expect(desktopRail).toHaveClass("hidden", "sm:inline-flex");
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Agents",
+      "Workspace",
+      "Documents",
+      "Schedule",
+      "Roadmap",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Makes the `/agents` composer the primary action and repairs ordinary prompts so they open the canonical FastAgent chat path; `/spawn` remains the explicit swarm path.
- Replaces false, no-op, duplicated, and text-inferred UI with recorded topic state and canonical chat-part ownership.
- Compacts the mobile hub rail and recent-topic presentation without removing status, trace, approval, export, source, streaming, or domain/tool-card capabilities.
- Improves FastAgent mobile safe-area positioning.

Rendered-element counts fell 657 → 462, mobile controls 36 → 24, and the measured mobile topic region 3,381px → 689px. These are descriptive deltas, not optimization targets.

## What was wrong

The primary agent paths were buried under decorative, duplicated, dead, or heuristic presentation controls, and ordinary prompts from `/agents` were silently ignored.

## Why it happened

The hub and panel accumulated UI projections without runtime backing, while the command router only dispatched explicit swarm requests and never forwarded ordinary asks to FastAgent.

## Safety contract

- No Convex schema, backend contract, provider routing, or deployment workflow changed.
- Streaming, `/spawn`, approvals, exports, structured sources, tool/domain cards, canonical Markdown, and model/token provenance remain authoritative.
- Current private QA artifacts remain local and untracked.
- The existing coordination claim remains local until merge and is not part of this PR.

## Validation

- [x] `npx tsc --noEmit --pretty false`
- [x] `npx tsc -p convex/tsconfig.json --noEmit --pretty false`
- [x] Focused declutter tests: 33/33
- [x] FastAgentPanel: 142 passed, 19 skipped
- [x] Runtime/streaming guards: 54/54
- [x] `npm run test:design`: 13/13
- [x] `npm run lint:design`: exit 0, no high-severity findings
- [x] `npm run build`
- [x] `git diff --check`
- [x] Independent local responsive/theme review: no P0/P1, overflow, console, or mojibake regression
- [ ] Public-safe preview captures at desktop and mobile widths
- [ ] Required checks: Typecheck / Runtime smoke / Build / Tier B vs preview URL
- [ ] Post-merge production deployment and live rendered-DOM verification

## Evidence boundary

The raw captures include production topic content and intentionally remain ignored under `.qa/`. The PR records only the sanitized aggregate results above. FastAgent desktop before/after proof is not claimed; preview and live checks will cover the shipped responsive surface.

## Changelog lanes

- `CHANGELOG/pages/agents.md`
- `CHANGELOG/components/fast-agent-panel.md`
