### PR TITLE
docs(release): seal agents declutter evidence

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -161,6 +161,17 @@ Server Error) for an unknown slug.
 
 ## Recently shipped (this ScratchNode session)
 
+- **#533 Codex** - decluttered the Agents hub and FastAgent shell, repaired plain
+  prompts to open canonical chat, preserved explicit `/spawn`, and retained
+  streaming, approvals, exports, structured sources, tool/domain cards, model
+  provenance, statuses, and trace links. Canonical main commit `655d1556`.
+  Required Typecheck, Runtime smoke, Build, and Tier B checks passed; production
+  deployment `dpl_CjV1PkzsMKK9c3Le3p1jcWpWJW9K` reached READY and both
+  production Post-Deploy Verify runs passed. Sanitized live assertions found no
+  removed placebo copy or controls, no mobile overflow, a 689px six-row topic
+  region, and exactly one canonical panel dispatch for the production routing
+  probe. No Convex deploy ran because the PR changed no backend deploy paths.
+
 - **#531 Codex** - exact queued-prompt validation, explicit bounded-context
   provider input, and safe internal-error redaction. Canonical main commit
   `fa397589`. Signed-in production run `j9742r0yg3zkfsdqvgpx9he8k98ahv8t`

--- a/CHANGELOG/components/fast-agent-panel.md
+++ b/CHANGELOG/components/fast-agent-panel.md
@@ -7,14 +7,14 @@ Append-only lane for behavior-preserving AI Elements adoption inside
 
 The unopened panel now keeps the composer and four real starter actions as its primary surface. Empty tabs, duplicate command rails, decorative progress/minimap UI, placebo Focus/Tone controls, and text-inferred confidence/citation/media projections are removed while canonical streaming, approvals, structured sources, tool/domain cards, model/token provenance, Markdown, and exports remain.
 
-**PR / canonical main commit**: `PENDING #533 MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #533 / `655d1556`.
 
 **Evidence state**:
-- Source: pending.
-- Checks: local current-tree FastAgent, streaming, typecheck, design, and build gates passed; required PR checks pending.
-- Visual proof: private local responsive/theme captures independently reviewed; public-safe preview captures pending.
-- Preview: pending.
-- Production live: pending.
+- Source: merged to `main`.
+- Checks: the local FastAgent, streaming, typecheck, design, and build gates passed; required PR Typecheck, Runtime smoke, Build, and Tier B checks passed; main CI run `29393842917` passed.
+- Visual proof: private local responsive/theme captures were independently reviewed. Sanitized preview and production DOM sweeps confirmed the removed empty/heuristic chrome stays absent and the canonical prompt, model, swarm, status, and trace controls remain reachable.
+- Preview: exact-head `549e5895` deployment `5452564772` reached READY; Tier B run `29393537476` passed.
+- Production live: deployment `dpl_CjV1PkzsMKK9c3Le3p1jcWpWJW9K` reached READY; both production Post-Deploy Verify runs, `post-deploy:verify`, and the nine-test live smoke passed. The plain-prompt repair opened one canonical panel with one user message and no swarm or duplicate dispatch; the anonymous quota gate returned the honest sign-in response before model execution.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../pages/agents.md`](../pages/agents.md).

--- a/CHANGELOG/pages/agents.md
+++ b/CHANGELOG/pages/agents.md
@@ -6,14 +6,14 @@ Append-only lane for the `/agents` hub, its primary command path, topic list, an
 
 Ordinary prompts now open the canonical FastAgent chat while `/spawn` remains the explicit swarm path. The hub shows recorded topic fields instead of fabricated narrative metrics, defers suggestions, removes dead controls, and uses a reachable native selector for the mobile hub rail.
 
-**PR / canonical main commit**: `PENDING #533 MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #533 / `655d1556`.
 
 **Evidence state**:
-- Source: pending.
-- Checks: local current-tree typechecks, focused tests, design gates, runtime guards, and production build passed; required PR checks pending.
-- Visual proof: private local responsive/theme captures independently reviewed; public-safe preview captures pending.
-- Preview: pending.
-- Production live: pending.
+- Source: merged to `main`.
+- Checks: Typecheck, Runtime smoke, Build, and the PR-associated Tier B preview gate passed; main CI run `29393842917` also passed.
+- Visual proof: private local responsive/theme captures were independently reviewed. Sanitized preview and production DOM sweeps confirmed the removed copy and controls stay absent, desktop tabs collapse into one mobile chooser, and the six-row topic region is 689 CSS px at 375x812 with no horizontal overflow.
+- Preview: exact-head `549e5895` deployment `5452564772` reached READY; Tier B run `29393537476` passed.
+- Production live: deployment `dpl_CjV1PkzsMKK9c3Le3p1jcWpWJW9K` reached READY on `www.nodebenchai.com`; production Post-Deploy Verify runs `29393958512` and `29394068684`, `post-deploy:verify`, and the nine-test live smoke passed. One plain prompt opened the canonical AI Chat Panel with one user message, one quota-gated assistant response, no swarm indicator, and no duplicate send; the anonymous quota gate prevented an exact model-token assertion.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../components/fast-agent-panel.md`](../components/fast-agent-panel.md).


### PR DESCRIPTION
## Summary

- Seals the Agents/FastAgent declutter changelog with PR #533 and canonical main SHA `655d1556`.
- Records sanitized preview, required-check, production deployment, live-DOM, and quota-gated routing evidence.
- Moves the completed release into the coordination ledger's Recently shipped section.

## Scope

Documentation only. No runtime, Convex, package, deployment, or workflow files change. Private `.qa` evidence remains local and untracked.

## Validation

- [x] `git diff --check`
- [x] Product PR #533 required checks passed
- [x] Production deployment READY
- [x] Production Post-Deploy Verify and nine-test live smoke passed