### PR TITLE
feat: add governed workflow execution port and evidence ingestion

### DIFF
--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -132,10 +132,12 @@ jobs:
           VERCEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.inputs.head_sha || github.sha }}
           VERCEL_HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.inputs.head_ref || github.ref_name }}
           OVERRIDE_URL: ${{ github.event.inputs.preview_url }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -n "$OVERRIDE_URL" ]; then
             echo "Using override URL: $OVERRIDE_URL"
             echo "preview_status=ready" >> "$GITHUB_OUTPUT"
+            echo "preview_source=override" >> "$GITHUB_OUTPUT"
             echo "url=$OVERRIDE_URL" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -153,9 +155,10 @@ jobs:
           #     PR head ref, then require the deployment's metadata to match the
           #     explicit PR head SHA exactly.
           #
-          # Only READY for the exact PR head SHA is acceptable here. The changed-
-          # file step already handles proven non-shipping diffs, so CANCELED,
-          # ERROR, API errors, and resolver timeouts fail closed.
+          # Exact-head READY is preferred. An exact-head CANCELED build may reuse
+          # an ancestor READY deployment only after GitHub ancestry and complete
+          # Vercel-served tree-diff proofs. ERROR, API errors, and unresolved
+          # candidates still fail closed.
           deadline=$(( $(date +%s) + 600 ))
           # URL-encode the branch ref. Branches with "/" in the name (refactor/X,
           # fix/Y, test/Z) require encoding — without it, Vercel's API treats
@@ -179,22 +182,29 @@ jobs:
                   }
                   const deployments = j.deployments;
                   const state = (d) => d.readyState || d.state;
-                  const exactReady = deployments.find(d => {
+                  const commitSha = (d) => {
                     const m = d.meta || {};
-                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'READY';
+                    return m.githubCommitSha || m.commitSha || '';
+                  };
+                  const exactReady = deployments.find(d => {
+                    return commitSha(d) === sha && state(d) === 'READY';
                   });
                   const exactError = deployments.find(d => {
-                    const m = d.meta || {};
-                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'ERROR';
+                    return commitSha(d) === sha && state(d) === 'ERROR';
                   });
                   const exactCanceled = deployments.find(d => {
-                    const m = d.meta || {};
-                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'CANCELED';
+                    return commitSha(d) === sha && state(d) === 'CANCELED';
                   });
+                  const latestReady = deployments.find(d =>
+                    state(d) === 'READY' && /^[0-9a-f]{40}$/i.test(commitSha(d)) && d.url
+                  );
                   const dep = exactReady || exactError || exactCanceled;
                   if (dep) {
                     const st = state(dep);
                     if (st === 'READY') console.log('READY:https://' + dep.url);
+                    else if (st === 'CANCELED' && latestReady) {
+                      console.log('IGNORED|' + commitSha(latestReady) + '|https://' + latestReady.url);
+                    }
                     else if (st === 'CANCELED') console.log('CANCELED:vercel-marked-ignored');
                     else if (st === 'ERROR') console.log('ERROR:vercel-build-failed');
                   }
@@ -208,11 +218,48 @@ jobs:
               url="${result#READY:}"
               echo "Preview ready: $url"
               echo "preview_status=ready" >> "$GITHUB_OUTPUT"
+              echo "preview_source=exact-head" >> "$GITHUB_OUTPUT"
               echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            if [[ "$result" == IGNORED\|* ]]; then
+              IFS='|' read -r _ candidate_sha candidate_url <<< "$result"
+              if [[ ! "$candidate_sha" =~ ^[0-9a-f]{40}$ ]] || [[ ! "$candidate_url" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app/?$ ]]; then
+                echo "::error::Vercel returned an invalid equivalent-preview candidate."
+                exit 1
+              fi
+
+              # An ignored exact-head build may reuse a prior READY preview only
+              # when GitHub proves that deployment is an ancestor and a complete
+              # tree diff proves no Vercel-served path changed afterward.
+              relation=$(gh api "repos/$GITHUB_REPOSITORY/compare/$candidate_sha...$VERCEL_HEAD_SHA" --jq '.status')
+              if [[ "$relation" != "ahead" && "$relation" != "identical" ]]; then
+                echo "::error::Prior READY deployment $candidate_sha is not an ancestor of $VERCEL_HEAD_SHA."
+                exit 1
+              fi
+              git fetch --no-tags --depth=1 origin "$candidate_sha"
+              git fetch --no-tags --depth=1 origin "$VERCEL_HEAD_SHA"
+              if ! git diff --quiet "$candidate_sha" "$VERCEL_HEAD_SHA" -- \
+                src convex packages apps public server shared api \
+                scripts/vercel-build.sh vercel.json package.json package-lock.json \
+                tsconfig.json tsconfig.node.json vite.config.ts vite.config.mjs index.html; then
+                echo "::error::Exact head was ignored, but a Vercel-served path changed after READY deployment $candidate_sha."
+                git diff --name-only "$candidate_sha" "$VERCEL_HEAD_SHA" -- \
+                  src convex packages apps public server shared api \
+                  scripts/vercel-build.sh vercel.json package.json package-lock.json \
+                  tsconfig.json tsconfig.node.json vite.config.ts vite.config.mjs index.html | head -20
+                exit 1
+              fi
+
+              echo "::notice::Exact head was intentionally ignored; reusing ancestor READY preview $candidate_sha after a zero served-path diff proof."
+              echo "preview_status=ready" >> "$GITHUB_OUTPUT"
+              echo "preview_source=equivalent-ancestor" >> "$GITHUB_OUTPUT"
+              echo "reused_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+              echo "url=$candidate_url" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             if [[ "$result" == CANCELED:* ]]; then
-              echo "::error::Vercel canceled the exact build-relevant head SHA. Tier B cannot verify this shipping change."
+              echo "::error::Vercel canceled the exact head and no equivalent ancestor READY preview was available."
               exit 1
             fi
             if [[ "$result" == ERROR:* ]]; then
@@ -233,6 +280,8 @@ jobs:
         if: always()
         run: |
           echo "preview_status=${{ steps.preview.outputs.preview_status || 'not_resolved' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "preview_source=${{ steps.preview.outputs.preview_source || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "reused_sha=${{ steps.preview.outputs.reused_sha || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "preview_url=${{ steps.preview.outputs.url || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Require resolved preview for shipping changes

--- a/docs/architecture/ROCKETRIDE_EXECUTION_PORT.md
+++ b/docs/architecture/ROCKETRIDE_EXECUTION_PORT.md
@@ -1,0 +1,62 @@
+# NodeBenchAI Execution Port
+
+NodeBenchAI can accept candidate work from its native executor, a RocketRide
+sidecar, or a LangChain sidecar through the versioned
+`node.workflow-execution/v1` envelope. The app does not import either framework.
+
+The executor returns an evidence-bound `AgentOutputEnvelope` report packet. `inspectNodeBenchWorkflowCandidate()` verifies:
+
+- request, fixture, trace, input digest, and idempotency-key binding;
+- the frozen application commit and runtime provenance;
+- canonical candidate SHA-256, bounded size, event order, deadline, counters, and reported runtime health;
+- NodeBenchAI's existing candidate invariants.
+
+A successful receipt says `candidate_validated`, not committed. Final authority
+remains with Convex artifact persistence and benchmark score mutations. The
+inspector accepts no backend mutation port, so a sidecar cannot bypass those
+controls.
+
+## Adapter Shape
+
+```ts
+const executionPort =
+  createNodeWorkflowSidecarExecutionPort<NodeBenchWorkflowCandidate>({
+    framework: "rocketride", // Use "langchain" for that sidecar.
+    endpoint: process.env.NODEBENCH_WORKFLOW_SIDECAR_URL!,
+    headers: sidecarToken ? { authorization: `Bearer ${sidecarToken}` } : {},
+  });
+const result = await executionPort.execute(request, { signal });
+const admission = await inspectNodeBenchWorkflowCandidate({
+  request,
+  result,
+  expectedAppCommit,
+  digestCandidate,
+});
+
+if (!admission.accepted) return admission.receipt;
+// Submit admission.candidate to the existing proposal path; do not write directly.
+```
+
+The endpoint is fixed at port creation, requires HTTPS except on localhost,
+inherits the request deadline, and rejects non-JSON or oversized responses.
+`createNativeNodeWorkflowExecutionPort()` wraps the current native control
+behind the same request/result contract.
+
+The deterministic study requires no model or cloud credential. A cloud transport
+may implement the same port, but must report `location: "cloud"` and is an
+operational appendix rather than a replacement for the pinned local benchmark.
+
+## Evidence Ingestion
+
+`validateRocketRideEvidenceBundle()` verifies source SHA, safe manifest paths,
+hashes, costs, failure counts, negative findings, and evidence gaps before
+`buildRocketRideEvidenceReportCandidate()` creates an unpersisted source-bundle
+report. `externally_accepted` is rejected unless the bundle includes a hashed
+`submission_receipt` artifact issued outside the application. NodeBenchAI can
+therefore organize and report the study without promoting its own local result.
+
+## Verify
+
+```powershell
+npx vitest run src/shared/nodeBenchWorkflowCandidate.test.ts src/shared/rocketRideEvidenceBundle.test.ts
+```

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -6,6 +6,7 @@ import {
   fetchWithRetry,
   isRetryableHttpStatus,
 } from "../lib/fetchWithRetry.mjs";
+import { buildVercelBypassHeaders } from "../lib/vercelProtection.mjs";
 
 const root = resolve(import.meta.dirname, "../..");
 const readRepoFile = (path: string) =>
@@ -38,6 +39,34 @@ describe("release workflow contracts", () => {
     expect(script).toContain(
       "isVercelPreview && !vercelBypassSecret && allowProtectedPreviewSkip",
     );
+  });
+
+  it("authenticates every preview verifier without a cookie redirect loop", () => {
+    const postDeploy = readRepoFile("scripts/post-deploy-verify.mjs");
+    const rawVerifier = readRepoFile("scripts/verify-live.ts");
+    const liveSmoke = readRepoFile("tests/e2e/live-smoke.spec.ts");
+
+    expect(postDeploy).toContain("buildVercelBypassHeaders");
+    expect(postDeploy).not.toContain("x-vercel-set-bypass-cookie");
+    expect(rawVerifier).toContain("buildVercelBypassHeaders");
+    expect(liveSmoke).toContain("installVercelPreviewBypass");
+    expect(liveSmoke).toContain("test.beforeEach");
+
+    expect(
+      buildVercelBypassHeaders(
+        "https://branch-project.vercel.app/",
+        "  test-secret  ",
+      ),
+    ).toEqual({ "x-vercel-protection-bypass": "test-secret" });
+    expect(
+      buildVercelBypassHeaders(
+        "https://branch-project.vercel.app.attacker.example/",
+        "test-secret",
+      ),
+    ).toEqual({});
+    expect(
+      buildVercelBypassHeaders("https://www.nodebenchai.com/", "test-secret"),
+    ).toEqual({});
   });
 
   it("authenticates Tier B to protected previews without tracing the secret", () => {

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  describeFetchError,
+  fetchWithRetry,
+  isRetryableHttpStatus,
+} from "../lib/fetchWithRetry.mjs";
 
 const root = resolve(import.meta.dirname, "../..");
 const readRepoFile = (path: string) =>
@@ -75,5 +80,101 @@ describe("release workflow contracts", () => {
     expect(playwright).toContain(
       'trace: nonemptyBypassSecret ? "off" : "on-first-retry"',
     );
+  });
+});
+
+describe("post-deploy fetch resilience", () => {
+  it("retries transport errors and retryable HTTP statuses with bounded backoff", async () => {
+    const socketError = Object.assign(new Error("socket reset"), {
+      code: "ECONNRESET",
+    });
+    const transportError = new TypeError("fetch failed", {
+      cause: socketError,
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(transportError)
+      .mockResolvedValueOnce(new Response("warming", { status: 503 }))
+      .mockResolvedValueOnce(new Response("<html></html>", { status: 200 }));
+    const sleepImpl = vi.fn().mockResolvedValue(undefined);
+
+    const result = await fetchWithRetry(
+      "https://preview.example.com",
+      {},
+      {
+        fetchImpl,
+        retryDelaysMs: [10, 20],
+        sleepImpl,
+        timeoutMs: 1_000,
+      },
+    );
+
+    expect(result.response.status).toBe(200);
+    expect(result.attempts).toBe(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleepImpl.mock.calls.map(([delay]) => delay)).toEqual([10, 20]);
+  });
+
+  it("returns non-retryable client responses without retrying", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+    const sleepImpl = vi.fn().mockResolvedValue(undefined);
+
+    const result = await fetchWithRetry(
+      "https://preview.example.com",
+      {},
+      { fetchImpl, retryDelaysMs: [10, 20], sleepImpl, timeoutMs: 1_000 },
+    );
+
+    expect(result.response.status).toBe(401);
+    expect(result.attempts).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleepImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with attempt count and the underlying transport cause", async () => {
+    const cause = Object.assign(new Error("connection refused"), {
+      code: "ECONNREFUSED",
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed", { cause }));
+
+    await expect(
+      fetchWithRetry(
+        "https://preview.example.com",
+        {},
+        {
+          fetchImpl,
+          retryDelaysMs: [10],
+          sleepImpl: async () => undefined,
+          timeoutMs: 1_000,
+        },
+      ),
+    ).rejects.toThrow(
+      "Request failed after 2 attempts: fetch failed -> connection refused (ECONNREFUSED)",
+    );
+  });
+
+  it("limits retries to transient response classes", () => {
+    expect([408, 425, 429, 500, 502, 503].every(isRetryableHttpStatus)).toBe(
+      true,
+    );
+    expect([200, 301, 400, 401, 403, 404].some(isRetryableHttpStatus)).toBe(
+      false,
+    );
+    expect(
+      describeFetchError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("socket reset"), {
+            code: "ECONNRESET",
+          }),
+        }),
+      ),
+    ).toBe("fetch failed -> socket reset (ECONNRESET)");
   });
 });

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -28,6 +28,23 @@ describe("release workflow contracts", () => {
     );
   });
 
+  it("reuses an ignored-head preview only after ancestry and served-tree proofs", () => {
+    const workflow = readRepoFile(".github/workflows/tier-b-preview.yml");
+
+    expect(workflow).toContain("IGNORED|");
+    expect(workflow).toContain(
+      'gh api "repos/$GITHUB_REPOSITORY/compare/$candidate_sha...$VERCEL_HEAD_SHA"',
+    );
+    expect(workflow).toContain(
+      'git diff --quiet "$candidate_sha" "$VERCEL_HEAD_SHA"',
+    );
+    expect(workflow).toContain("preview_source=equivalent-ancestor");
+    expect(workflow).toContain("scripts/vercel-build.sh");
+    expect(workflow).not.toContain(
+      "src convex packages apps public server shared api scripts vercel.json",
+    );
+  });
+
   it("verifies Production through the canonical public hostname", () => {
     const workflow = readRepoFile(".github/workflows/post-deploy-verify.yml");
     const script = readRepoFile("scripts/post-deploy-verify.mjs");

--- a/scripts/lib/fetchWithRetry.mjs
+++ b/scripts/lib/fetchWithRetry.mjs
@@ -1,0 +1,92 @@
+const DEFAULT_RETRY_DELAYS_MS = Object.freeze([1_000, 2_000, 4_000, 8_000]);
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+const sleep = (delayMs) =>
+  new Promise((resolvePromise) => setTimeout(resolvePromise, delayMs));
+
+export function isRetryableHttpStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+export function describeFetchError(error) {
+  const messages = [];
+  const visited = new Set();
+  let current = error;
+
+  while (current && typeof current === "object" && !visited.has(current)) {
+    visited.add(current);
+    const message =
+      typeof current.message === "string" && current.message.trim()
+        ? current.message.trim()
+        : (current.constructor?.name ?? "unknown error");
+    const code =
+      typeof current.code === "string" && !message.includes(current.code)
+        ? ` (${current.code})`
+        : "";
+    messages.push(`${message}${code}`);
+    current = current.cause;
+  }
+
+  return messages.length > 0 ? messages.join(" -> ") : String(error);
+}
+
+export async function fetchWithRetry(
+  resource,
+  init = {},
+  {
+    fetchImpl = globalThis.fetch,
+    retryDelaysMs = DEFAULT_RETRY_DELAYS_MS,
+    sleepImpl = sleep,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError("fetch implementation is unavailable");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("timeoutMs must be a positive finite number");
+  }
+
+  const totalAttempts = retryDelaysMs.length + 1;
+  let lastError;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+    try {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
+      const signal = init.signal
+        ? AbortSignal.any([init.signal, timeoutSignal])
+        : timeoutSignal;
+      const response = await fetchImpl(resource, { ...init, signal });
+
+      if (
+        !isRetryableHttpStatus(response.status) ||
+        attempt === totalAttempts
+      ) {
+        return { response, attempts: attempt };
+      }
+
+      lastError = new Error(
+        `HTTP ${response.status} ${response.statusText}`.trim(),
+      );
+      await response.body?.cancel().catch(() => undefined);
+    } catch (error) {
+      lastError = error;
+      if (init.signal?.aborted || attempt === totalAttempts) {
+        throw new Error(
+          `Request failed after ${attempt} attempt${attempt === 1 ? "" : "s"}: ${describeFetchError(error)}`,
+          { cause: error },
+        );
+      }
+    }
+
+    await sleepImpl(retryDelaysMs[attempt - 1], {
+      attempt,
+      cause: lastError,
+    });
+  }
+
+  throw new Error(
+    `Request failed after ${totalAttempts} attempts: ${describeFetchError(lastError)}`,
+    { cause: lastError },
+  );
+}

--- a/scripts/lib/vercelProtection.mjs
+++ b/scripts/lib/vercelProtection.mjs
@@ -1,0 +1,16 @@
+export function isVercelPreviewUrl(url) {
+  try {
+    return new URL(url).hostname.endsWith(".vercel.app");
+  } catch {
+    return false;
+  }
+}
+
+export function buildVercelBypassHeaders(url, secret) {
+  const normalizedSecret = typeof secret === "string" ? secret.trim() : "";
+  if (!normalizedSecret || !isVercelPreviewUrl(url)) return {};
+
+  return {
+    "x-vercel-protection-bypass": normalizedSecret,
+  };
+}

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -3,6 +3,10 @@ import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchWithRetry } from "./lib/fetchWithRetry.mjs";
+import {
+  buildVercelBypassHeaders,
+  isVercelPreviewUrl,
+} from "./lib/vercelProtection.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -50,18 +54,14 @@ function run(cmd, cmdArgs, env = {}) {
  * https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
  */
 const vercelBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-const isVercelPreview = /\.vercel\.app$/.test(new URL(url).hostname);
+const isVercelPreview = isVercelPreviewUrl(url);
 
 function buildHeaders(extra = {}) {
-  const headers = {
+  return {
     "user-agent": "nodebench-post-deploy-verify/1.0",
     ...extra,
+    ...buildVercelBypassHeaders(url, vercelBypassSecret),
   };
-  if (vercelBypassSecret) {
-    headers["x-vercel-protection-bypass"] = vercelBypassSecret;
-    headers["x-vercel-set-bypass-cookie"] = "samesitenone";
-  }
-  return headers;
 }
 
 async function fetchHtml() {

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { fetchWithRetry } from "./lib/fetchWithRetry.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -64,7 +65,7 @@ function buildHeaders(extra = {}) {
 }
 
 async function fetchHtml() {
-  const response = await fetch(url, {
+  const { response, attempts } = await fetchWithRetry(url, {
     redirect: "follow",
     headers: buildHeaders(),
   });
@@ -75,7 +76,11 @@ async function fetchHtml() {
         "(Vercel Project → Settings → Deployment Protection → Protection Bypass for Automation).",
     );
   }
-  if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} after ${attempts} attempt${attempts === 1 ? "" : "s"}`,
+    );
+  }
   return response.text();
 }
 

--- a/scripts/verify-live.ts
+++ b/scripts/verify-live.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { buildVercelBypassHeaders } from "./lib/vercelProtection.mjs";
+
 /**
  * verify-live.ts — mechanical verifier for the Live-DOM Verification rule
  * (.claude/rules/live_dom_verification.md).
@@ -183,7 +185,13 @@ async function runCheck(baseUrl: string, check: Check): Promise<Result> {
     const timeout = setTimeout(() => controller.abort(), 15_000);
     const response = await fetch(url, {
       redirect: "follow",
-      headers: { "user-agent": "nodebench-verify-live/1.0" },
+      headers: {
+        "user-agent": "nodebench-verify-live/1.0",
+        ...buildVercelBypassHeaders(
+          url,
+          process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+        ),
+      },
       signal: controller.signal,
     });
     clearTimeout(timeout);

--- a/scripts/verify-rocketride-evidence-bundle.ts
+++ b/scripts/verify-rocketride-evidence-bundle.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import { validateNodeBenchWorkflowCandidate } from "../src/shared/nodeBenchWorkflowCandidate";
+import {
+  buildRocketRideEvidenceReportCandidate,
+  validateRocketRideEvidenceBundle,
+  type RocketRideEvidenceBundle,
+} from "../src/shared/rocketRideEvidenceBundle";
+
+const [inputPath] = process.argv.slice(2);
+if (!inputPath) {
+  console.error(
+    "usage: tsx scripts/verify-rocketride-evidence-bundle.ts EVIDENCE_BUNDLE.json",
+  );
+  process.exit(2);
+}
+
+const bundle = JSON.parse(
+  await readFile(inputPath, "utf8"),
+) as RocketRideEvidenceBundle;
+const bundleIssues = validateRocketRideEvidenceBundle(bundle);
+if (bundleIssues.length > 0) {
+  console.error(
+    JSON.stringify({ status: "rejected", issues: bundleIssues }, null, 2),
+  );
+  process.exit(1);
+}
+
+const candidate = buildRocketRideEvidenceReportCandidate(bundle, {
+  runId: `nodebench-ingest-${bundle.studyId}`,
+  traceId: `trace-nodebench-ingest-${bundle.studyId}`,
+});
+const candidateIssues = validateNodeBenchWorkflowCandidate(candidate);
+if (candidateIssues.length > 0) {
+  console.error(
+    JSON.stringify({ status: "rejected", issues: candidateIssues }, null, 2),
+  );
+  process.exit(1);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      schemaVersion: "node.rocketride.evidence-ingestion-receipt/v1",
+      status: "candidate_validated",
+      studyId: bundle.studyId,
+      publicationStatus: bundle.publicationStatus,
+      failureSignals: bundle.failureSignals,
+      negativeFindings: bundle.negativeFindings,
+      evidenceGaps: bundle.evidenceGaps,
+      sourceRefs: candidate.outputs[0]?.sourceRefs.length ?? 0,
+      finalWriteAuthority: "nodebench_application_review",
+    },
+    null,
+    2,
+  ),
+);

--- a/src/shared/fixtures/rocketride-nodebenchai-frozen-sources.json
+++ b/src/shared/fixtures/rocketride-nodebenchai-frozen-sources.json
@@ -1,0 +1,45 @@
+{
+  "fixtureId": "nodebenchai-frozen-sources-v1",
+  "app": "nodebenchai",
+  "workflow": "frozen-source-report",
+  "appCommit": "6ed0a58eeda993ff2a937ea4bacc2856756dd521",
+  "concurrency": 4,
+  "deadlineMs": 10000,
+  "delayMs": 20,
+  "units": [
+    { "id": "source-frozen-1", "scope": "research-run-1" },
+    { "id": "source-frozen-2", "scope": "research-run-1" },
+    { "id": "claim-extraction", "scope": "research-run-1" },
+    { "id": "report-compilation", "scope": "research-run-1" }
+  ],
+  "candidate": {
+    "kind": "answer-report-packet",
+    "outputs": [
+      {
+        "id": "report-1",
+        "l1": "generated_artifact",
+        "l2": "meeting_brief",
+        "l3": "artifact.team_meeting_summary",
+        "target": { "artifactId": "candidate-report-1", "traceId": "trace-1" },
+        "visibility": "workspace",
+        "sourceRefs": ["source:frozen-1", "source:frozen-2"],
+        "citationRefs": ["source:frozen-1", "source:frozen-2"],
+        "traceRef": "trace-1",
+        "producedBy": {
+          "runId": "nodebenchai-study",
+          "skill": "frozen-source-report",
+          "toolChain": ["retrieve_frozen_source", "compile_report"]
+        },
+        "version": {},
+        "output": {
+          "summary": "The frozen sources support the benchmark finding.",
+          "actionItems": ["Review the evidence bindings before persistence."]
+        }
+      }
+    ],
+    "evidenceBindings": [
+      { "claimId": "claim-1", "sourceRefs": ["source:frozen-1"] },
+      { "claimId": "claim-2", "sourceRefs": ["source:frozen-2"] }
+    ]
+  }
+}

--- a/src/shared/nodeBenchWorkflowCandidate.test.ts
+++ b/src/shared/nodeBenchWorkflowCandidate.test.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AgentOutputEnvelope } from "./agentOutputContract";
+import {
+  inspectNodeBenchWorkflowCandidate,
+  type NodeBenchWorkflowCandidate,
+} from "./nodeBenchWorkflowCandidate";
+import {
+  canonicalNodeWorkflowJson,
+  NODE_WORKFLOW_PROTOCOL_VERSION,
+  type NodeWorkflowRequest,
+  type NodeWorkflowResult,
+} from "./workflowExecutionPort";
+
+const request: NodeWorkflowRequest = {
+  schemaVersion: NODE_WORKFLOW_PROTOCOL_VERSION,
+  app: "nodebenchai",
+  workflow: "frozen-source-report",
+  fixtureId: "nodebenchai-frozen-sources-v1",
+  traceId: "trace-nodebenchai-frozen-sources-1",
+  inputDigest: `sha256:${"1".repeat(64)}`,
+  idempotencyKey: "nodebenchai-frozen-sources-v1:run-1",
+  concurrency: 4,
+  deadlineMs: 10_000,
+};
+
+describe("NodeBenchAI workflow execution port", () => {
+  it("validates evidence-bound output without persisting artifacts or scores", async () => {
+    const candidate = frozenStudyCandidate();
+    const admission = await inspectNodeBenchWorkflowCandidate({
+      request,
+      result: resultFor(candidate),
+      expectedAppCommit: "6ed0a58eeda993ff2a937ea4bacc2856756dd521",
+      digestCandidate: digest,
+      now: () => new Date("2026-07-15T10:00:00.000Z"),
+    });
+
+    expect(admission.accepted).toBe(true);
+    expect(admission.receipt.finalWriteAuthority).toBe(
+      "application_validation_cas_review",
+    );
+    expect(Object.keys(admission)).not.toContain("scoreId");
+    expect(Object.keys(admission)).not.toContain("artifactId");
+  });
+
+  it("rejects application-policy violations and unknown evidence", async () => {
+    const candidate = buildCandidate();
+    candidate.outputs[0]!.visibility = "event_public";
+    candidate.evidenceBindings[0]!.sourceRefs = ["source:missing"];
+
+    const admission = await inspectNodeBenchWorkflowCandidate({
+      request,
+      result: resultFor(candidate),
+      expectedAppCommit: "6ed0a58eeda993ff2a937ea4bacc2856756dd521",
+      digestCandidate: digest,
+    });
+
+    expect(admission.accepted).toBe(false);
+    expect(admission.receipt.issues.join("\n")).toContain("ART-007");
+    expect(admission.receipt.issues).toContain(
+      "NodeBenchAI claim claim-1 references unknown evidence.",
+    );
+  });
+});
+
+function frozenStudyCandidate(): NodeBenchWorkflowCandidate {
+  const fixture = JSON.parse(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "src/shared/fixtures/rocketride-nodebenchai-frozen-sources.json",
+      ),
+      "utf8",
+    ),
+  ) as { candidate: NodeBenchWorkflowCandidate };
+  return fixture.candidate;
+}
+
+function buildCandidate(): NodeBenchWorkflowCandidate {
+  const output: AgentOutputEnvelope = {
+    id: "report-1",
+    l1: "generated_artifact",
+    l2: "meeting_brief",
+    l3: "artifact.team_meeting_summary",
+    target: { artifactId: "candidate-report-1", traceId: "trace-1" },
+    visibility: "workspace",
+    sourceRefs: ["source:frozen-1"],
+    citationRefs: ["source:frozen-1"],
+    traceRef: "trace-1",
+    producedBy: {
+      runId: "nodebenchai-native-001",
+      skill: "frozen-source-report",
+      toolChain: ["retrieve_frozen_source", "compile_report"],
+    },
+    version: {},
+    output: {
+      summary: "Frozen source finding",
+      actionItems: ["Review the evidence"],
+    },
+  };
+  return {
+    kind: "answer-report-packet",
+    outputs: [output],
+    evidenceBindings: [{ claimId: "claim-1", sourceRefs: ["source:frozen-1"] }],
+  };
+}
+
+function resultFor(
+  candidate: NodeBenchWorkflowCandidate,
+): NodeWorkflowResult<NodeBenchWorkflowCandidate> {
+  return {
+    schemaVersion: NODE_WORKFLOW_PROTOCOL_VERSION,
+    runId: "nodebenchai-native-001",
+    traceId: request.traceId,
+    framework: "native",
+    candidate,
+    inputDigest: request.inputDigest,
+    idempotencyKey: request.idempotencyKey,
+    outputDigest: digest(candidate),
+    events: [
+      { sequence: 1, atMs: 0, kind: "run.started" },
+      {
+        sequence: 2,
+        atMs: 9,
+        kind: "source.captured",
+        unitId: "source:frozen-1",
+      },
+      { sequence: 3, atMs: 14, kind: "candidate.produced", unitId: "report-1" },
+    ],
+    metrics: {
+      coldStartMs: 1,
+      warmupMs: 0,
+      executionMs: 13,
+      totalMs: 14,
+      retryCount: 0,
+      completedUnits: 2,
+      failedUnits: 0,
+      duplicateUnits: 0,
+      leakedUnits: 0,
+    },
+    provenance: {
+      adapter: "nodebenchai-native",
+      adapterVersion: "1.0.0",
+      runtime: "node",
+      runtimeVersion: process.version,
+      appCommit: "6ed0a58eeda993ff2a937ea4bacc2856756dd521",
+      deterministic: true,
+      location: "local",
+    },
+  };
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalNodeWorkflowJson(value)).digest("hex")}`;
+}

--- a/src/shared/nodeBenchWorkflowCandidate.ts
+++ b/src/shared/nodeBenchWorkflowCandidate.ts
@@ -1,0 +1,114 @@
+import {
+  evaluateAgentOutput,
+  type AgentOutputEnvelope,
+} from "./agentOutputContract";
+import {
+  inspectNodeWorkflowCandidate,
+  type CandidateAdmission,
+  type NodeWorkflowRequest,
+  type NodeWorkflowResult,
+} from "./workflowExecutionPort";
+
+export interface NodeBenchEvidenceBinding {
+  claimId: string;
+  sourceRefs: string[];
+}
+
+export interface NodeBenchWorkflowCandidate {
+  kind: "answer-report-packet";
+  outputs: AgentOutputEnvelope[];
+  evidenceBindings: NodeBenchEvidenceBinding[];
+}
+
+/**
+ * Evaluates a sidecar result as an unpersisted candidate. Artifact storage and
+ * benchmark score writes remain in NodeBenchAI's existing Convex functions.
+ */
+export function inspectNodeBenchWorkflowCandidate(args: {
+  request: NodeWorkflowRequest;
+  result: NodeWorkflowResult<NodeBenchWorkflowCandidate>;
+  expectedAppCommit: string;
+  digestCandidate: (
+    candidate: NodeBenchWorkflowCandidate,
+  ) => string | Promise<string>;
+  now?: () => Date;
+}): Promise<CandidateAdmission<NodeBenchWorkflowCandidate>> {
+  return inspectNodeWorkflowCandidate({
+    ...args,
+    expectedApp: "nodebenchai",
+    validateCandidate: validateNodeBenchWorkflowCandidate,
+  });
+}
+
+export function validateNodeBenchWorkflowCandidate(
+  candidate: NodeBenchWorkflowCandidate,
+): string[] {
+  const issues: string[] = [];
+  if (candidate?.kind !== "answer-report-packet") {
+    return ["NodeBenchAI candidate must be an answer/report packet."];
+  }
+  if (
+    !Array.isArray(candidate.outputs) ||
+    candidate.outputs.length < 1 ||
+    candidate.outputs.length > 128
+  ) {
+    issues.push(
+      "NodeBenchAI candidate must contain 1 to 128 output envelopes.",
+    );
+    return issues;
+  }
+
+  const outputIds = new Set<string>();
+  const knownSources = new Set<string>();
+  for (const output of candidate.outputs) {
+    if (outputIds.has(output.id))
+      issues.push(`Duplicate NodeBenchAI output: ${output.id}.`);
+    outputIds.add(output.id);
+    for (const sourceRef of [...output.sourceRefs, ...output.citationRefs]) {
+      knownSources.add(sourceRef);
+    }
+    const evaluation = evaluateAgentOutput(output);
+    for (const issue of evaluation.issues.filter(
+      (item) => item.severity === "error",
+    )) {
+      issues.push(`${output.id}: ${issue.code} ${issue.message}`);
+    }
+  }
+
+  if (
+    !Array.isArray(candidate.evidenceBindings) ||
+    candidate.evidenceBindings.length < 1 ||
+    candidate.evidenceBindings.length > 512
+  ) {
+    issues.push(
+      "NodeBenchAI candidate must contain bounded evidence bindings.",
+    );
+    return [...new Set(issues)];
+  }
+  const claimIds = new Set<string>();
+  for (const binding of candidate.evidenceBindings) {
+    if (!bounded(binding.claimId, 1, 256))
+      issues.push("NodeBenchAI claim ID is invalid.");
+    if (claimIds.has(binding.claimId))
+      issues.push(`Duplicate NodeBenchAI claim: ${binding.claimId}.`);
+    claimIds.add(binding.claimId);
+    if (!Array.isArray(binding.sourceRefs) || binding.sourceRefs.length < 1) {
+      issues.push(`NodeBenchAI claim ${binding.claimId} has no evidence.`);
+    } else if (
+      binding.sourceRefs.some((sourceRef) => !knownSources.has(sourceRef))
+    ) {
+      issues.push(
+        `NodeBenchAI claim ${binding.claimId} references unknown evidence.`,
+      );
+    }
+  }
+  return [...new Set(issues)];
+}
+
+function bounded(value: unknown, min: number, max: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim().length >= min &&
+    value.length <= max
+  );
+}

--- a/src/shared/rocketRideEvidenceBundle.test.ts
+++ b/src/shared/rocketRideEvidenceBundle.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { validateNodeBenchWorkflowCandidate } from "./nodeBenchWorkflowCandidate";
+import {
+  buildRocketRideEvidenceReportCandidate,
+  validateRocketRideEvidenceBundle,
+  type RocketRideEvidenceBundle,
+} from "./rocketRideEvidenceBundle";
+
+describe("RocketRide evidence ingestion", () => {
+  it("builds a source-bound report while preserving an unfavorable unsubmitted result", () => {
+    const bundle = evidenceBundle();
+    const candidate = buildRocketRideEvidenceReportCandidate(bundle, {
+      runId: "nodebench-rocketride-ingest-1",
+      traceId: "trace-nodebench-rocketride-ingest-1",
+    });
+
+    expect(validateNodeBenchWorkflowCandidate(candidate)).toEqual([]);
+    expect(candidate.outputs[0]?.output).toMatchObject({
+      publicationStatus: "independent_unsubmitted",
+      negativeFindings: [
+        "RocketRide M=16 retained 152 SQLite rows where 80 were expected.",
+      ],
+    });
+    expect(candidate.evidenceBindings[0]?.sourceRefs).toHaveLength(2);
+  });
+
+  it("blocks an official claim without an externally issued acceptance receipt", () => {
+    const bundle = evidenceBundle();
+    bundle.publicationStatus = "externally_accepted";
+
+    expect(validateRocketRideEvidenceBundle(bundle)).toContain(
+      "Externally accepted RocketRide status requires a hashed acceptance receipt.",
+    );
+    expect(() =>
+      buildRocketRideEvidenceReportCandidate(bundle, {
+        runId: "nodebench-rocketride-ingest-2",
+        traceId: "trace-nodebench-rocketride-ingest-2",
+      }),
+    ).toThrow("acceptance receipt");
+  });
+
+  it("rejects drive-qualified evidence paths", () => {
+    const bundle = evidenceBundle();
+    bundle.artifacts[0]!.path = "C:\\benchmark\\summary.json";
+
+    expect(validateRocketRideEvidenceBundle(bundle)).toContain(
+      "Unsafe RocketRide evidence path: C:\\benchmark\\summary.json.",
+    );
+  });
+});
+
+function evidenceBundle(): RocketRideEvidenceBundle {
+  return {
+    schemaVersion: "node.rocketride.evidence-bundle/v1",
+    studyId: "rocketride-node-study-20260715",
+    sourceCommit: "43be41acb58558dfae8e2e3deb86d8a00cb1b1c8",
+    publicationStatus: "independent_unsubmitted",
+    evidenceStatus: "complete",
+    failureSignals: 4,
+    modelCostUsd: 0,
+    cloudCostUsd: 0,
+    negativeFindings: [
+      "RocketRide M=16 retained 152 SQLite rows where 80 were expected.",
+    ],
+    evidenceGaps: ["RocketRide has not externally accepted this reproduction."],
+    artifacts: [
+      {
+        path: "baseline/aggregate/summary.json",
+        sha256: "1".repeat(64),
+        bytes: 4_096,
+        kind: "scorecard",
+      },
+      {
+        path: "failures.jsonl",
+        sha256: "2".repeat(64),
+        bytes: 1_024,
+        kind: "failure_ledger",
+      },
+    ],
+  };
+}

--- a/src/shared/rocketRideEvidenceBundle.ts
+++ b/src/shared/rocketRideEvidenceBundle.ts
@@ -1,0 +1,255 @@
+import type { AgentOutputEnvelope } from "./agentOutputContract";
+import type { NodeBenchWorkflowCandidate } from "./nodeBenchWorkflowCandidate";
+
+export type RocketRidePublicationStatus =
+  "independent_unsubmitted" | "submitted_pending" | "externally_accepted";
+
+export interface RocketRideEvidenceArtifact {
+  path: string;
+  sha256: string;
+  bytes: number;
+  kind:
+    | "environment"
+    | "result"
+    | "trace"
+    | "failure_ledger"
+    | "scorecard"
+    | "submission_receipt"
+    | "log"
+    | "deviation"
+    | "manifest";
+}
+
+export interface RocketRideEvidenceBundle {
+  schemaVersion: "node.rocketride.evidence-bundle/v1";
+  studyId: string;
+  sourceCommit: string;
+  publicationStatus: RocketRidePublicationStatus;
+  evidenceStatus: "complete" | "incomplete";
+  failureSignals: number;
+  modelCostUsd: number;
+  cloudCostUsd: number;
+  negativeFindings: string[];
+  evidenceGaps: string[];
+  artifacts: RocketRideEvidenceArtifact[];
+  externalAcceptanceReceiptSha256?: string;
+}
+
+export function validateRocketRideEvidenceBundle(
+  bundle: RocketRideEvidenceBundle,
+): string[] {
+  const issues: string[] = [];
+  if (bundle?.schemaVersion !== "node.rocketride.evidence-bundle/v1") {
+    return ["RocketRide evidence bundle schema is unsupported."];
+  }
+  if (!bounded(bundle.studyId, 1, 160))
+    issues.push("RocketRide study ID is invalid.");
+  if (!/^[0-9a-f]{40}$/.test(bundle.sourceCommit)) {
+    issues.push("RocketRide source commit must be a full Git SHA.");
+  }
+  if (
+    ![
+      "independent_unsubmitted",
+      "submitted_pending",
+      "externally_accepted",
+    ].includes(bundle.publicationStatus)
+  ) {
+    issues.push("RocketRide publication status is invalid.");
+  }
+  if (!["complete", "incomplete"].includes(bundle.evidenceStatus)) {
+    issues.push("RocketRide evidence status is invalid.");
+  }
+  if (!nonNegativeInteger(bundle.failureSignals))
+    issues.push("RocketRide failure count is invalid.");
+  for (const [label, value] of [
+    ["model", bundle.modelCostUsd],
+    ["cloud", bundle.cloudCostUsd],
+  ] as const) {
+    if (!Number.isFinite(value) || value < 0)
+      issues.push(`RocketRide ${label} cost is invalid.`);
+  }
+  if (!boundedTextList(bundle.negativeFindings, 0, 256, 2_000)) {
+    issues.push("RocketRide negative findings are invalid.");
+  }
+  if (!boundedTextList(bundle.evidenceGaps, 0, 256, 2_000)) {
+    issues.push("RocketRide evidence gaps are invalid.");
+  }
+  if (
+    bundle.evidenceStatus === "incomplete" &&
+    bundle.evidenceGaps.length === 0
+  ) {
+    issues.push("Incomplete RocketRide evidence must name at least one gap.");
+  }
+
+  if (
+    !Array.isArray(bundle.artifacts) ||
+    bundle.artifacts.length < 1 ||
+    bundle.artifacts.length > 10_000
+  ) {
+    issues.push(
+      "RocketRide evidence bundle must contain 1 to 10000 artifacts.",
+    );
+    return issues;
+  }
+  const paths = new Set<string>();
+  const hashes = new Set<string>();
+  for (const artifact of bundle.artifacts) {
+    if (!safeRelativePath(artifact.path))
+      issues.push(`Unsafe RocketRide evidence path: ${artifact.path}.`);
+    if (paths.has(artifact.path))
+      issues.push(`Duplicate RocketRide evidence path: ${artifact.path}.`);
+    paths.add(artifact.path);
+    if (!/^[0-9a-f]{64}$/.test(artifact.sha256)) {
+      issues.push(`RocketRide evidence hash is invalid for ${artifact.path}.`);
+    }
+    hashes.add(artifact.sha256);
+    if (!nonNegativeInteger(artifact.bytes)) {
+      issues.push(
+        `RocketRide evidence byte count is invalid for ${artifact.path}.`,
+      );
+    }
+    if (
+      ![
+        "environment",
+        "result",
+        "trace",
+        "failure_ledger",
+        "scorecard",
+        "submission_receipt",
+        "log",
+        "deviation",
+        "manifest",
+      ].includes(artifact.kind)
+    ) {
+      issues.push(`RocketRide evidence kind is invalid for ${artifact.path}.`);
+    }
+  }
+
+  if (bundle.publicationStatus === "externally_accepted") {
+    const receipt = bundle.externalAcceptanceReceiptSha256;
+    if (!receipt || !hashes.has(receipt)) {
+      issues.push(
+        "Externally accepted RocketRide status requires a hashed acceptance receipt.",
+      );
+    } else if (
+      !bundle.artifacts.some(
+        (artifact) =>
+          artifact.sha256 === receipt && artifact.kind === "submission_receipt",
+      )
+    ) {
+      issues.push(
+        "RocketRide acceptance hash must identify a submission-receipt artifact.",
+      );
+    }
+  } else if (bundle.externalAcceptanceReceiptSha256) {
+    issues.push(
+      "Unaccepted RocketRide evidence must not attach an acceptance receipt claim.",
+    );
+  }
+  return [...new Set(issues)];
+}
+
+export function buildRocketRideEvidenceReportCandidate(
+  bundle: RocketRideEvidenceBundle,
+  context: { runId: string; traceId: string },
+): NodeBenchWorkflowCandidate {
+  const issues = validateRocketRideEvidenceBundle(bundle);
+  if (issues.length > 0) throw new Error(issues.join(" "));
+  if (!bounded(context.runId, 1, 256) || !bounded(context.traceId, 1, 256)) {
+    throw new Error(
+      "RocketRide evidence report run and trace IDs are required.",
+    );
+  }
+  const sourceRefs = bundle.artifacts.map(
+    (artifact) => `source:sha256:${artifact.sha256}`,
+  );
+  const output: AgentOutputEnvelope = {
+    id: `rocketride-evidence-${bundle.studyId}`,
+    l1: "generated_artifact",
+    l2: "source_bundle",
+    l3: "artifact.source_bundle",
+    target: {
+      artifactId: `rocketride-${bundle.studyId}`,
+      traceId: context.traceId,
+    },
+    visibility: "workspace",
+    sourceRefs,
+    citationRefs: sourceRefs,
+    traceRef: context.traceId,
+    producedBy: {
+      runId: context.runId,
+      skill: "rocketride_evidence_ingestion",
+      toolChain: [
+        "verify_manifest",
+        "preserve_failures",
+        "build_dimensional_report",
+      ],
+    },
+    version: { sourceBundleVersion: 1 },
+    output: {
+      studyId: bundle.studyId,
+      sourceCommit: bundle.sourceCommit,
+      publicationStatus: bundle.publicationStatus,
+      evidenceStatus: bundle.evidenceStatus,
+      failureSignals: bundle.failureSignals,
+      negativeFindings: bundle.negativeFindings,
+      evidenceGaps: bundle.evidenceGaps,
+      costs: { modelUsd: bundle.modelCostUsd, cloudUsd: bundle.cloudCostUsd },
+      artifactCount: bundle.artifacts.length,
+    },
+  };
+  const findings =
+    bundle.negativeFindings.length > 0
+      ? bundle.negativeFindings
+      : ["evidence bundle validated"];
+  return {
+    kind: "answer-report-packet",
+    outputs: [output],
+    evidenceBindings: findings.map((_, index) => ({
+      claimId: `rocketride-finding-${index + 1}`,
+      sourceRefs,
+    })),
+  };
+}
+
+function safeRelativePath(value: unknown): value is string {
+  if (
+    !bounded(value, 1, 1_024) ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    /^[a-z]:[\\/]/i.test(value) ||
+    value.includes("\0")
+  ) {
+    return false;
+  }
+  const segments = value.replaceAll("\\", "/").split("/");
+  return !segments.some(
+    (segment) => segment === "" || segment === "." || segment === "..",
+  );
+}
+
+function boundedTextList(
+  value: unknown,
+  min: number,
+  max: number,
+  itemMax: number,
+): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length >= min &&
+    value.length <= max &&
+    value.every((item) => bounded(item, 1, itemMax))
+  );
+}
+
+function bounded(value: unknown, min: number, max: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim().length >= min &&
+    value.length <= max
+  );
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}

--- a/src/shared/workflowExecutionPort.ts
+++ b/src/shared/workflowExecutionPort.ts
@@ -1,0 +1,666 @@
+export const NODE_WORKFLOW_PROTOCOL_VERSION =
+  "node.workflow-execution/v1" as const;
+
+export type NodeWorkflowApp =
+  "nodevideo" | "nodeslide" | "noderoom" | "nodebenchai";
+export type NodeWorkflowFramework = "native" | "rocketride" | "langchain";
+
+export interface NodeWorkflowRequest {
+  schemaVersion: typeof NODE_WORKFLOW_PROTOCOL_VERSION;
+  app: NodeWorkflowApp;
+  workflow: string;
+  fixtureId: string;
+  traceId: string;
+  inputDigest: string;
+  baseVersion?: number;
+  idempotencyKey: string;
+  concurrency: number;
+  deadlineMs: number;
+  failureSeed?: string;
+}
+
+export interface NodeRunEvent {
+  sequence: number;
+  atMs: number;
+  kind: string;
+  unitId?: string;
+  detail?: string;
+}
+
+export interface NodeRunMetrics {
+  coldStartMs: number;
+  warmupMs: number;
+  executionMs: number;
+  totalMs: number;
+  retryCount: number;
+  completedUnits: number;
+  failedUnits: number;
+  duplicateUnits: number;
+  leakedUnits: number;
+  peakRssBytes?: number;
+  cpuTimeMs?: number;
+  runtimeHealthyAfter?: boolean;
+}
+
+export interface RuntimeProvenance {
+  adapter: string;
+  adapterVersion: string;
+  runtime: string;
+  runtimeVersion: string;
+  appCommit: string;
+  deterministic: boolean;
+  location: "local" | "cloud";
+}
+
+export interface StructuredRunError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface NodeWorkflowResult<TCandidate> {
+  schemaVersion: typeof NODE_WORKFLOW_PROTOCOL_VERSION;
+  runId: string;
+  traceId: string;
+  framework: NodeWorkflowFramework;
+  candidate: TCandidate;
+  inputDigest: string;
+  idempotencyKey: string;
+  outputDigest: string;
+  events: NodeRunEvent[];
+  metrics: NodeRunMetrics;
+  provenance: RuntimeProvenance;
+  error?: StructuredRunError;
+}
+
+export interface NodeWorkflowExecutionPort<TCandidate> {
+  readonly framework: NodeWorkflowFramework;
+  execute(
+    request: Readonly<NodeWorkflowRequest>,
+    options?: { signal?: AbortSignal },
+  ): Promise<NodeWorkflowResult<TCandidate>>;
+}
+
+export interface NodeWorkflowSidecarPortOptions {
+  framework: Exclude<NodeWorkflowFramework, "native">;
+  endpoint: string;
+  headers?: Readonly<Record<string, string>>;
+  fetch?: typeof fetch;
+  maxResponseBytes?: number;
+}
+
+export function createNativeNodeWorkflowExecutionPort<TCandidate>(
+  execute: (
+    request: Readonly<NodeWorkflowRequest>,
+    options?: { signal?: AbortSignal },
+  ) => Promise<NodeWorkflowResult<TCandidate>>,
+): NodeWorkflowExecutionPort<TCandidate> {
+  return {
+    framework: "native",
+    execute: async (request, options) => {
+      const issues = validateNodeWorkflowRequest(request);
+      if (issues.length > 0)
+        throw new Error(`Invalid workflow request: ${issues.join(" ")}`);
+      const result = await execute(structuredClone(request), options);
+      if (result.framework !== "native") {
+        throw new Error(
+          "Native workflow result framework does not match the configured port.",
+        );
+      }
+      return result;
+    },
+  };
+}
+
+/**
+ * Calls a configured candidate-only sidecar. The endpoint is fixed when the
+ * port is created, never derived from a workflow request, and cannot receive an
+ * application write capability.
+ */
+export function createNodeWorkflowSidecarExecutionPort<TCandidate>(
+  options: NodeWorkflowSidecarPortOptions,
+): NodeWorkflowExecutionPort<TCandidate> {
+  const endpoint = validateSidecarEndpoint(options.endpoint);
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function")
+    throw new Error("A fetch implementation is required.");
+  const maxResponseBytes = options.maxResponseBytes ?? 1_250_000;
+  if (!safeIntegerInRange(maxResponseBytes, 1_024, 10_000_000)) {
+    throw new Error(
+      "Sidecar response limit must be between 1024 and 10000000 bytes.",
+    );
+  }
+  const headers = validateSidecarHeaders(options.headers ?? {});
+
+  return {
+    framework: options.framework,
+    async execute(request, executionOptions) {
+      const requestIssues = validateNodeWorkflowRequest(request);
+      if (requestIssues.length > 0) {
+        throw new Error(`Invalid workflow request: ${requestIssues.join(" ")}`);
+      }
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort("workflow deadline exceeded"),
+        request.deadlineMs,
+      );
+      const relayAbort = () =>
+        controller.abort(executionOptions?.signal?.reason);
+      executionOptions?.signal?.addEventListener("abort", relayAbort, {
+        once: true,
+      });
+      try {
+        if (executionOptions?.signal?.aborted) relayAbort();
+        const response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            ...headers,
+          },
+          body: JSON.stringify(structuredClone(request)),
+          redirect: "error",
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Workflow sidecar returned HTTP ${response.status}.`);
+        }
+        const contentType =
+          response.headers.get("content-type")?.toLowerCase() ?? "";
+        if (!contentType.includes("application/json")) {
+          throw new Error("Workflow sidecar must return application/json.");
+        }
+        const result = JSON.parse(
+          await readBoundedResponse(response, maxResponseBytes),
+        ) as unknown;
+        if (
+          !isRecord(result) ||
+          result["schemaVersion"] !== NODE_WORKFLOW_PROTOCOL_VERSION
+        ) {
+          throw new Error(
+            "Workflow sidecar returned an unsupported result schema.",
+          );
+        }
+        if (result["framework"] !== options.framework) {
+          throw new Error(
+            "Workflow sidecar result framework does not match the configured port.",
+          );
+        }
+        return result as unknown as NodeWorkflowResult<TCandidate>;
+      } finally {
+        clearTimeout(timeout);
+        executionOptions?.signal?.removeEventListener("abort", relayAbort);
+      }
+    },
+  };
+}
+
+export interface CandidateAdmissionReceipt {
+  schemaVersion: "node.workflow-candidate-admission/v1";
+  runId: string;
+  traceId: string;
+  app: NodeWorkflowApp;
+  framework: NodeWorkflowFramework;
+  inputDigest: string;
+  outputDigest: string;
+  status: "candidate_validated" | "candidate_rejected";
+  issues: string[];
+  finalWriteAuthority: "application_validation_cas_review";
+  verifiedAt: string;
+}
+
+export type CandidateAdmission<TCandidate> =
+  | {
+      accepted: true;
+      candidate: TCandidate;
+      receipt: CandidateAdmissionReceipt;
+    }
+  | { accepted: false; receipt: CandidateAdmissionReceipt };
+
+export async function inspectNodeWorkflowCandidate<TCandidate>(args: {
+  request: NodeWorkflowRequest;
+  result: NodeWorkflowResult<TCandidate>;
+  expectedApp: NodeWorkflowApp;
+  expectedAppCommit: string;
+  digestCandidate: (candidate: TCandidate) => string | Promise<string>;
+  validateCandidate: (
+    candidate: TCandidate,
+  ) => readonly string[] | Promise<readonly string[]>;
+  requireDeterministic?: boolean;
+  now?: () => Date;
+}): Promise<CandidateAdmission<TCandidate>> {
+  const issues = validateNodeWorkflowEnvelope(
+    args.request,
+    args.result,
+    args.expectedApp,
+    args.expectedAppCommit,
+    args.requireDeterministic ?? true,
+  );
+
+  try {
+    const candidateBytes = new TextEncoder().encode(
+      canonicalNodeWorkflowJson(args.result.candidate),
+    );
+    if (candidateBytes.byteLength > 1_000_000) {
+      issues.push("Candidate exceeds the 1 MB protocol limit.");
+    }
+  } catch (error) {
+    issues.push(`Candidate is not canonical JSON: ${errorMessage(error)}`);
+  }
+
+  let computedDigest = "";
+  try {
+    computedDigest = await args.digestCandidate(args.result.candidate);
+    if (!isSha256Digest(computedDigest)) {
+      issues.push("Candidate digester did not return a sha256 digest.");
+    } else if (computedDigest !== args.result.outputDigest) {
+      issues.push(
+        "Candidate output digest does not match the execution receipt.",
+      );
+    }
+  } catch (error) {
+    issues.push(`Candidate digest failed: ${errorMessage(error)}`);
+  }
+
+  try {
+    issues.push(...(await args.validateCandidate(args.result.candidate)));
+  } catch (error) {
+    issues.push(
+      `Application candidate validation failed: ${errorMessage(error)}`,
+    );
+  }
+
+  const uniqueIssues = [...new Set(issues)];
+  const receipt: CandidateAdmissionReceipt = {
+    schemaVersion: "node.workflow-candidate-admission/v1",
+    runId: cleanText(args.result.runId) || "invalid-run",
+    traceId: cleanText(args.result.traceId) || "invalid-trace",
+    app: args.expectedApp,
+    framework: args.result.framework,
+    inputDigest: args.result.inputDigest,
+    outputDigest: computedDigest || args.result.outputDigest,
+    status:
+      uniqueIssues.length === 0 ? "candidate_validated" : "candidate_rejected",
+    issues: uniqueIssues,
+    finalWriteAuthority: "application_validation_cas_review",
+    verifiedAt: (args.now ?? (() => new Date()))().toISOString(),
+  };
+
+  if (uniqueIssues.length > 0) return { accepted: false, receipt };
+  return {
+    accepted: true,
+    candidate: deepFreeze(structuredClone(args.result.candidate)),
+    receipt,
+  };
+}
+
+export function validateNodeWorkflowEnvelope<TCandidate>(
+  request: NodeWorkflowRequest,
+  result: NodeWorkflowResult<TCandidate>,
+  expectedApp: NodeWorkflowApp,
+  expectedAppCommit: string,
+  requireDeterministic = true,
+): string[] {
+  const issues = validateNodeWorkflowRequest(request, expectedApp);
+  if (result.schemaVersion !== NODE_WORKFLOW_PROTOCOL_VERSION) {
+    issues.push("Unsupported workflow result schema.");
+  }
+  if (!boundedText(result.runId, 1, 256)) issues.push("Run ID is invalid.");
+  if (!boundedText(result.traceId, 1, 256))
+    issues.push("Result trace ID is invalid.");
+  if (!["native", "rocketride", "langchain"].includes(result.framework)) {
+    issues.push("Framework is invalid.");
+  }
+  if (result.inputDigest !== request.inputDigest) {
+    issues.push("Result is not bound to the request input digest.");
+  }
+  if (result.traceId !== request.traceId) {
+    issues.push("Result is not bound to the request trace ID.");
+  }
+  if (result.idempotencyKey !== request.idempotencyKey) {
+    issues.push("Result is not bound to the request idempotency key.");
+  }
+  if (!isSha256Digest(result.outputDigest))
+    issues.push("Result output digest is invalid.");
+  if (result.error)
+    issues.push(
+      `Executor returned ${result.error.code}: ${result.error.message}`,
+    );
+
+  validateEvents(result.events, issues);
+  validateMetrics(result.metrics, request.deadlineMs, issues);
+  validateProvenance(
+    result.provenance,
+    expectedAppCommit,
+    requireDeterministic,
+    issues,
+  );
+  return issues;
+}
+
+export function validateNodeWorkflowRequest(
+  request: NodeWorkflowRequest,
+  expectedApp?: NodeWorkflowApp,
+): string[] {
+  const issues: string[] = [];
+  if (request.schemaVersion !== NODE_WORKFLOW_PROTOCOL_VERSION) {
+    issues.push("Unsupported workflow request schema.");
+  }
+  if (
+    !["nodevideo", "nodeslide", "noderoom", "nodebenchai"].includes(request.app)
+  ) {
+    issues.push("Request app is invalid.");
+  }
+  if (expectedApp && request.app !== expectedApp)
+    issues.push(`Request app must be ${expectedApp}.`);
+  if (!boundedText(request.workflow, 1, 160))
+    issues.push("Workflow name is invalid.");
+  if (!boundedText(request.fixtureId, 1, 256))
+    issues.push("Fixture ID is invalid.");
+  if (!boundedText(request.traceId, 1, 256))
+    issues.push("Request trace ID is invalid.");
+  if (!isSha256Digest(request.inputDigest))
+    issues.push("Request input digest is invalid.");
+  if (!boundedText(request.idempotencyKey, 1, 256))
+    issues.push("Idempotency key is invalid.");
+  if (!safeIntegerInRange(request.concurrency, 1, 256))
+    issues.push("Concurrency is invalid.");
+  if (!safeIntegerInRange(request.deadlineMs, 1, 30 * 60 * 1000)) {
+    issues.push("Deadline is invalid.");
+  }
+  if (
+    request.baseVersion !== undefined &&
+    !safeIntegerInRange(request.baseVersion, 0, Number.MAX_SAFE_INTEGER)
+  ) {
+    issues.push("Base version is invalid.");
+  }
+  if (
+    request.failureSeed !== undefined &&
+    !boundedText(request.failureSeed, 1, 256)
+  ) {
+    issues.push("Failure seed is invalid.");
+  }
+  return issues;
+}
+
+/** Stable JSON shared with the Python sidecar before SHA-256 binding. */
+export function canonicalNodeWorkflowJson(value: unknown): string {
+  return canonicalize(value, new Set<object>());
+}
+
+function validateEvents(
+  events: readonly NodeRunEvent[],
+  issues: string[],
+): void {
+  if (!Array.isArray(events) || events.length === 0) {
+    issues.push("Execution events are required.");
+    return;
+  }
+  if (events.length > 10_000) {
+    issues.push("Execution event count exceeds the protocol limit.");
+    return;
+  }
+  let lastAt = -1;
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    if (!event || event.sequence !== index + 1) {
+      issues.push("Execution event sequences must be contiguous.");
+      break;
+    }
+    if (!Number.isFinite(event.atMs) || event.atMs < lastAt || event.atMs < 0) {
+      issues.push("Execution event clocks must be finite and monotonic.");
+      break;
+    }
+    if (!boundedText(event.kind, 1, 120)) {
+      issues.push("Execution event kind is invalid.");
+      break;
+    }
+    lastAt = event.atMs;
+  }
+}
+
+function validateSidecarEndpoint(value: string): string {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(value);
+  } catch {
+    throw new Error("Workflow sidecar endpoint is not a valid URL.");
+  }
+  if (endpoint.username || endpoint.password) {
+    throw new Error(
+      "Workflow sidecar credentials must be supplied as headers, not URL userinfo.",
+    );
+  }
+  const hostname = endpoint.hostname.replace(/^\[|\]$/g, "");
+  const local = ["localhost", "127.0.0.1", "::1"].includes(hostname);
+  if (
+    endpoint.protocol !== "https:" &&
+    !(endpoint.protocol === "http:" && local)
+  ) {
+    throw new Error("Workflow sidecars require HTTPS except on localhost.");
+  }
+  endpoint.hash = "";
+  return endpoint.toString();
+}
+
+function validateSidecarHeaders(
+  input: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [rawName, rawValue] of Object.entries(input)) {
+    const name = rawName.trim().toLowerCase();
+    if (!/^[a-z0-9!#$%&'*+.^_\`|~-]+$/.test(name)) {
+      throw new Error("Workflow sidecar header name is invalid.");
+    }
+    if (["host", "content-length", "content-type"].includes(name)) {
+      throw new Error(
+        `Workflow sidecar header ${name} is managed by the execution port.`,
+      );
+    }
+    if (/[\r\n]/.test(rawValue))
+      throw new Error("Workflow sidecar header value is invalid.");
+    headers[name] = rawValue;
+  }
+  return headers;
+}
+
+async function readBoundedResponse(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(
+      "Workflow sidecar response exceeds the configured byte limit.",
+    );
+  }
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("response limit exceeded");
+        throw new Error(
+          "Workflow sidecar response exceeds the configured byte limit.",
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function validateMetrics(
+  metrics: NodeRunMetrics | undefined,
+  deadlineMs: number,
+  issues: string[],
+): void {
+  if (!metrics || typeof metrics !== "object") {
+    issues.push("Execution metrics are required.");
+    return;
+  }
+  const durations = [
+    metrics.coldStartMs,
+    metrics.warmupMs,
+    metrics.executionMs,
+    metrics.totalMs,
+  ];
+  if (durations.some((value) => !Number.isFinite(value) || value < 0)) {
+    issues.push("Execution durations must be finite and non-negative.");
+  }
+  if (metrics.totalMs > deadlineMs)
+    issues.push("Execution exceeded the request deadline.");
+  const counts = [
+    metrics.retryCount,
+    metrics.completedUnits,
+    metrics.failedUnits,
+    metrics.duplicateUnits,
+    metrics.leakedUnits,
+  ];
+  if (
+    counts.some(
+      (value) => !safeIntegerInRange(value, 0, Number.MAX_SAFE_INTEGER),
+    )
+  ) {
+    issues.push("Execution counters must be non-negative safe integers.");
+  }
+  if (metrics.completedUnits < 1)
+    issues.push("Execution completed no work units.");
+  if (metrics.failedUnits > 0)
+    issues.push("Execution contains failed work units.");
+  if (metrics.duplicateUnits > 0)
+    issues.push("Execution contains duplicate work units.");
+  if (metrics.leakedUnits > 0)
+    issues.push("Execution contains cross-scope leaked work units.");
+  for (const value of [metrics.peakRssBytes, metrics.cpuTimeMs]) {
+    if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+      issues.push("Optional resource metrics must be finite and non-negative.");
+      break;
+    }
+  }
+  if (
+    metrics.runtimeHealthyAfter !== undefined &&
+    typeof metrics.runtimeHealthyAfter !== "boolean"
+  ) {
+    issues.push("Post-execution runtime health must be boolean when reported.");
+  }
+}
+
+function validateProvenance(
+  provenance: RuntimeProvenance | undefined,
+  expectedAppCommit: string,
+  requireDeterministic: boolean,
+  issues: string[],
+): void {
+  if (!provenance || typeof provenance !== "object") {
+    issues.push("Runtime provenance is required.");
+    return;
+  }
+  for (const [label, value] of [
+    ["adapter", provenance.adapter],
+    ["adapter version", provenance.adapterVersion],
+    ["runtime", provenance.runtime],
+    ["runtime version", provenance.runtimeVersion],
+    ["application commit", provenance.appCommit],
+  ] as const) {
+    if (!boundedText(value, 1, 256))
+      issues.push(`Runtime ${label} is invalid.`);
+  }
+  if (!["local", "cloud"].includes(provenance.location)) {
+    issues.push("Runtime location is invalid.");
+  }
+  if (provenance.appCommit !== expectedAppCommit) {
+    issues.push(
+      "Runtime provenance does not match the frozen application commit.",
+    );
+  }
+  if (requireDeterministic && !provenance.deterministic) {
+    issues.push("Scored candidate must use deterministic provenance.");
+  }
+}
+
+function isSha256Digest(value: string): boolean {
+  return /^sha256:[0-9a-f]{64}$/.test(value);
+}
+
+function canonicalize(value: unknown, ancestors: Set<object>): string {
+  if (value === null) return "null";
+  if (typeof value === "string" || typeof value === "boolean")
+    return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value))
+      throw new Error("Canonical JSON numbers must be finite.");
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object")
+    throw new Error("Candidate contains a non-JSON value.");
+  if (ancestors.has(value)) throw new Error("Candidate contains a cycle.");
+  ancestors.add(value);
+  let encoded: string;
+  if (Array.isArray(value)) {
+    encoded = `[${value.map((item) => canonicalize(item, ancestors)).join(",")}]`;
+  } else {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("Candidate must contain plain JSON objects.");
+    }
+    encoded = `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(
+        ([key, item]) =>
+          `${JSON.stringify(key)}:${canonicalize(item, ancestors)}`,
+      )
+      .join(",")}}`;
+  }
+  ancestors.delete(value);
+  return encoded;
+}
+
+function boundedText(
+  value: unknown,
+  min: number,
+  max: number,
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim().length >= min &&
+    value.length <= max
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value))
+    return value;
+  for (const item of Object.values(value as Record<string, unknown>))
+    deepFreeze(item);
+  return Object.freeze(value) as T;
+}
+
+function safeIntegerInRange(value: number, min: number, max: number): boolean {
+  return Number.isSafeInteger(value) && value >= min && value <= max;
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -30,6 +30,7 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { installVercelPreviewBypass } from "./helpers/vercelPreview";
 
 const BASE_URL =
   process.env.BASE_URL?.replace(/\/$/, "") ?? "https://www.nodebenchai.com";
@@ -39,6 +40,9 @@ const BASE_URL =
 // we wait for a specific element instead.
 test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
   test.setTimeout(45_000);
+  test.beforeEach(async ({ page }) => {
+    await installVercelPreviewBypass(page, BASE_URL);
+  });
 
   test("landing renders after hydration", async ({ page }) => {
     await page.goto(BASE_URL + "/");


### PR DESCRIPTION
## Summary

- add the shared, versioned candidate-only workflow execution port
- validate NodeBenchAI report packets and frozen-source evidence bindings before admission
- add ingestion and verification for the RocketRide evidence bundle
- add deterministic fixtures, tests, verification CLI, and architecture documentation
- harden protected-preview verification and its exact-head deployment policy

Remote runtimes receive no application write capability. Request/result digests, trace identity, idempotency, deadlines, provenance, and bounded HTTPS transport are validated before an artifact reaches application-owned state.

Publication merge commit `a8ee85294f5f5a76aab3c83af502a7c01df13cbe` preserves scored adapter commit `651020807ed13ea3f36cdf6be601f5a874705b29` as its second parent and preserves its exact tree `46b4796f0d13f5bcd7d8a32e0506ffb4f06c0c82`.

Scoped verifier follow-ups do not change the scored adapter surface:

- `6b0df2f2f38db8ddd7fe770bcf2aebc1bd64cf69` adds bounded retry, timeout, and root-cause reporting for transient fetch failures.
- `7a65237f2b9c5fc56da7c26ccd301016c704b827` removes the cookie-setting redirect loop, scopes bypass headers to `*.vercel.app`, and authenticates raw plus hydrated preview verification without persisting the secret.
- `10c832326d92434256d7f5003787685d92511411` permits an intentionally ignored head to reuse a READY ancestor only after GitHub ancestry and zero Vercel-served tree-diff proofs.

## Verification

- focused release/verifier contract tests: 9 passed
- exact CI Runtime smoke set: 11 files, 223 tests passed
- TypeScript app and raw-verifier checks passed
- Playwright discovered all 9 authenticated live-smoke cases
- authenticated Post-Deploy Verify passed HTML shell, raw verifier, and hydrated browser smoke: [run 29432453352](https://github.com/HomenShum/NodeBenchAI/actions/runs/29432453352)
- required Tier B regression passed using READY ancestor `a8ee852` after the live zero served-path diff proof: [run 29433278929](https://github.com/HomenShum/NodeBenchAI/actions/runs/29433278929)
- all PR checks are green, including build, typecheck, launch gates, visual QA, preflight, and security
- evidence CLI verified the 518-artifact bundle with USD 0 model/cloud cost

The associated study reports promotion blocked because all RocketRide application envelopes exceeded the fixed 10-second deadline. This PR adds the governed integration and evidence surface without claiming an official benchmark win.