### PR TITLE
docs(agents): seal authority TasteBench release

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -68,8 +68,8 @@ Server Error) for an unknown slug.
 
 ## Hand-offs (built + ready for the other agent to call)
 
-- **2026-07-15 · Codex release candidate · branch
-  `feat/agents-autonomy-tastebench`** — scoped notebook authority is available through
+- **2026-07-15 · Codex shipped via PR #538 · canonical main `ba743534`** — scoped
+  notebook authority is available through
   `domains/agents/autonomy/grants:{createGrant,getGrant,listGrants,getAuthorityState,pauseGrant,resumeGrant,revokeGrant}`,
   proposals/receipts through
   `domains/agents/autonomy/proposals:{submitBlockProposal,rejectProposal,approveProposal,getProposal,listProposals,getOperationState,listOperationStates,getReceipt,listReceipts}`,


### PR DESCRIPTION
## Summary

- replace the stale authority/TasteBench “release candidate” ledger label with the actual shipped PR and canonical `main` commit
- keep the backend callable handoff intact for future agents

## Verification

- PR #538 is merged at `ba743534`
- Vercel production and CI-managed Convex deployment succeeded
- production bundles contain `TasteBench` and `notebook-authority`
- `git diff --check` passes

Documentation-only release-state correction.