### PR TITLE
refactor: finalize pipeline session contract

### DIFF
--- a/convex/domains/pipelines/pipelineOwnership.auth.test.ts
+++ b/convex/domains/pipelines/pipelineOwnership.auth.test.ts
@@ -172,18 +172,6 @@ describe.skipIf(!convexTestAvailable)("pipeline caller ownership", () => {
     expect(listA.map((row: any) => row.runId)).toEqual(["run-a"]);
     expect(listB.map((row: any) => row.runId)).toEqual(["run-b"]);
 
-    const legacyListA = await t.query(
-      pipelines.pipelineRunsQueries.listRecentRuns,
-      { ownerKey: "session:anon-session-a", limit: 10 },
-    );
-    expect(legacyListA.map((row: any) => row.runId)).toEqual(["run-a"]);
-    await expect(
-      t.query(pipelines.pipelineRunsQueries.listRecentRuns, {
-        ownerKey: "user:victim",
-        limit: 10,
-      }),
-    ).rejects.toThrow(/authentication or anonymous session required/i);
-
     expect(
       await t.query(pipelines.pipelineRunsQueries.getRunDetail, {
         ...sessionA,

--- a/convex/domains/pipelines/pipelineOwnership.ts
+++ b/convex/domains/pipelines/pipelineOwnership.ts
@@ -31,22 +31,6 @@ export async function requirePipelineCallerOwnerKey(
   return `session:${sessionId}`;
 }
 
-/**
- * Transitional reader compatibility for the pre-session public query shape.
- * Only anonymous session owner keys are accepted; `user:*` remains derived
- * exclusively from server authentication.
- */
-export function anonymousSessionFromLegacyOwnerKey(
-  ownerKey?: string | null,
-): string | undefined {
-  const value = ownerKey?.trim() ?? "";
-  if (!value.startsWith("session:")) return undefined;
-  const sessionId = value.slice("session:".length);
-  return ANONYMOUS_SESSION_PATTERN.test(sessionId) && sessionId !== "anon-fallback"
-    ? sessionId
-    : undefined;
-}
-
 /** Resolve a cost-bearing public pipeline operation from server auth only. */
 export async function requireAuthenticatedPipelineOwnerKey(
   ctx: PipelineCallerContext,

--- a/convex/domains/pipelines/pipelineRunsQueries.ts
+++ b/convex/domains/pipelines/pipelineRunsQueries.ts
@@ -9,7 +9,6 @@
 import { v } from "convex/values";
 import { internalQuery, query } from "../../_generated/server";
 import {
-  anonymousSessionFromLegacyOwnerKey,
   pipelineOwnerMatches,
   requirePipelineCallerOwnerKey,
 } from "./pipelineOwnership";
@@ -26,7 +25,6 @@ export const listRecentRuns = query({
       ),
     ),
     anonymousSessionId: v.optional(v.string()),
-    ownerKey: v.optional(v.string()),
   },
   returns: v.array(
     v.object({
@@ -53,7 +51,7 @@ export const listRecentRuns = query({
   handler: async (ctx, args) => {
     const ownerKey = await requirePipelineCallerOwnerKey(
       ctx,
-      args.anonymousSessionId ?? anonymousSessionFromLegacyOwnerKey(args.ownerKey),
+      args.anonymousSessionId,
     );
     const limit = Math.min(args.limit ?? 25, 100);
     const candidateLimit = args.pipelineKind ? Math.min(limit * 4, 400) : limit;
@@ -130,7 +128,6 @@ export const getRunDetail = query({
   args: {
     runId: v.string(),
     anonymousSessionId: v.optional(v.string()),
-    ownerKey: v.optional(v.string()),
   },
   returns: v.union(
     v.null(),
@@ -178,7 +175,7 @@ export const getRunDetail = query({
   handler: async (ctx, args) => {
     const ownerKey = await requirePipelineCallerOwnerKey(
       ctx,
-      args.anonymousSessionId ?? anonymousSessionFromLegacyOwnerKey(args.ownerKey),
+      args.anonymousSessionId,
     );
     const run = await ctx.db
       .query("pipelineRuns")
@@ -242,7 +239,6 @@ export const getRunBundleDownloadUrl = query({
   args: {
     runId: v.string(),
     anonymousSessionId: v.optional(v.string()),
-    ownerKey: v.optional(v.string()),
   },
   returns: v.union(
     v.null(),
@@ -254,7 +250,7 @@ export const getRunBundleDownloadUrl = query({
   handler: async (ctx, args) => {
     const ownerKey = await requirePipelineCallerOwnerKey(
       ctx,
-      args.anonymousSessionId ?? anonymousSessionFromLegacyOwnerKey(args.ownerKey),
+      args.anonymousSessionId,
     );
     const run = await ctx.db
       .query("pipelineRuns")
@@ -288,10 +284,7 @@ export const getRunBundleDownloadUrl = query({
 });
 
 export const getRunSummaryStats = query({
-  args: {
-    anonymousSessionId: v.optional(v.string()),
-    ownerKey: v.optional(v.string()),
-  },
+  args: { anonymousSessionId: v.optional(v.string()) },
   returns: v.object({
     totalRuns: v.number(),
     succeeded: v.number(),
@@ -303,7 +296,7 @@ export const getRunSummaryStats = query({
   handler: async (ctx, args) => {
     const ownerKey = await requirePipelineCallerOwnerKey(
       ctx,
-      args.anonymousSessionId ?? anonymousSessionFromLegacyOwnerKey(args.ownerKey),
+      args.anonymousSessionId,
     );
     const recent = await ctx.db
       .query("pipelineRuns")

--- a/src/features/pipelines/views/PipelineRunsPanel.tsx
+++ b/src/features/pipelines/views/PipelineRunsPanel.tsx
@@ -183,11 +183,11 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
   const anonymousSessionId = useMemo(() => getAnonymousProductSessionId(), []);
   const runs = useStableQuery(
     api.domains.pipelines.pipelineRunsQueries.listRecentRuns,
-    { limit: queryLimit, ownerKey: `session:${anonymousSessionId}` },
+    { limit: queryLimit, anonymousSessionId },
   );
   const stats = useStableQuery(
     api.domains.pipelines.pipelineRunsQueries.getRunSummaryStats,
-    {},
+    { anonymousSessionId },
   );
 
   const safeRuns = useMemo(() => runs ?? [], [runs]);


### PR DESCRIPTION
## Summary
- switch pipeline run readers fully to the anonymous-session contract
- remove the temporary session-only legacy owner-key compatibility layer
- retain server-auth precedence and cross-owner isolation

## Verification
- pipeline ownership suite: 9/9
- app and Convex typechecks
- anonymous one-flow browser regression: pass, zero console errors

## Rollout
This follows #541 after its compatibility backend deployed successfully, avoiding frontend/backend validator skew.