### PR TITLE
docs: seal runtime-grounded release evidence

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,24 +57,6 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-07-15 · Codex due-diligence public-surface subtraction →**
-  `convex/domains/agents/dueDiligence/{investorProtection,investorPlaybook,deepResearch}/**`
-  and adjacent unreachable eval/test exports · removing caller-selected ownership and
-  global private reads from dead public DD surfaces while preserving trusted internal
-  execution contracts · branch `codex/runtime-grounded-control-focus`.
-
-- **2026-07-15 · Codex parallel-task subtraction →**
-  `convex/domains/agents/parallelTaskTree.ts` and removed parallel-task UI/API paths ·
-  deleting the unreachable timeline, kanban, hook, and public orchestrator while retaining
-  only four bounded, owner-chain-checked internal mutations used by due diligence · branch
-  `codex/runtime-grounded-control-focus`.
-
-- **2026-07-15 · Codex pipeline truth isolation →** `convex/schema.ts#pipelineRuns`,
-  `convex/domains/pipelines/**` · adding optional logical-attempt/workflow-instance
-  fences so manual refreshes and scheduled occurrences isolate rows while durable
-  retries reuse only their own attempt; also separating consulted research sources
-  from synthesis-bound citations · branch `codex/runtime-grounded-control-focus`.
-
 - **2026-06-03 · Claude →** `convex/*#handoff-token`, `src/.../ScratchnodePrivateBridge`,
   `src/App.tsx#events-private-route`, `public/proto/home-v5.html#private-handoff` ·
   shipping the cross-domain private-notes token bridge (opaque stateful token, PR #496) ·
@@ -204,6 +186,17 @@ Server Error) for an unknown slug.
   actually enters a room. The live counter + share moment both honor this.
 
 ## Recently shipped (this ScratchNode session)
+
+- **2026-07-15 Codex — runtime-grounded control focus (#541 `15eb9a0a`, strict
+  rollout #542 `16d3ceeb`, verifier #543 `56d8413a`)** — removed dead/no-op and
+  fixture-backed cockpit/Agents/FastAgent controls, closed public private-data
+  surfaces, added exact owner and durable pipeline attempt/generation fencing,
+  separated consulted sources from bound citations, and completed the anonymous
+  pipeline reader migration without frontend/backend validator skew. Required CI
+  gates passed on every PR; Vercel run `29475582335` and Convex run `29475582657`
+  deployed the strict contract; Post-Deploy Verify `29476029941` passed and the
+  canonical production matrix passed all 17
+  assertions with one blank mobile navigation transient passing on isolated rerun.
 
 - **#533 Codex** - decluttered the Agents hub and FastAgent shell, repaired plain
   prompts to open canonical chat, preserved explicit `/spawn`, and retained

--- a/CHANGELOG/components/fast-agent-panel.md
+++ b/CHANGELOG/components/fast-agent-panel.md
@@ -7,14 +7,14 @@ Append-only lane for behavior-preserving AI Elements adoption inside
 
 The pending candidate removes the scripted guest transcript, projected queue and streaming metrics, local-only preference and feedback controls, unsupported attachment and mention affordances, duplicate actions, the unreachable nested command palette and telemetry view, no-op entity-selection controls, synthetic receipt fallbacks, an unreferenced bearer-stream component and HTTP route, and the unrendered parallel timeline and kanban path. Canonical authenticated and anonymous streaming, stop and recovery, owned thread deletion, structured sources and tool cards, approvals, exports, and backend-supplied model and token provenance remain. Generated code can be copied or exported but cannot execute with the signed-in app's origin authority. Document, memory, plan, and fused-search cards fail closed unless successful structured tool output supplies their state and provenance; assistant prose, malformed results, running tools, and errors cannot mint a success card. Reader-position-aware auto-scroll follows the actual streaming message list without pulling a reader away from earlier content, and every shortcut or skip link focuses whichever real composer is mounted. Retrieved sources remain visible as consulted evidence, but the server no longer injects source tokens into unrelated prose or promotes an unbound URL into a claim citation. TRACE and receipt reads are owner-scoped, both direct and tool-driven document creation verify exact thread ownership before reading or linking content, MCP document/folder/spreadsheet reads and writes verify exact object ownership, receipt hashes bind the exact output payload, receipt persistence is required for trust-labeled completion, and every TRACE row distinguishes deterministic code from AI-model output or uses the neutral `Recorded` label; unavailable data renders as loading, empty, or not measured instead of as a fixture.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #541 / `15eb9a0a`; strict session rollout #542 / `16d3ceeb`; live-verifier alignment #543 / `56d8413a`.
 
 **Evidence state**:
-- Source: pending; this worktree candidate is not merged to `main`.
-- Checks: not recorded for a canonical `main` SHA.
-- Visual proof: not recorded in source; local-only candidate artifacts are not release evidence.
-- Preview: not recorded.
-- Production live: not recorded.
+- Source: merged to `main` through CI-gated squash PRs #541, #542, and #543.
+- Checks: required Typecheck, Runtime smoke, Build, and Tier B checks passed on all three PRs; source CI `29474652151`, strict-rollout CI `29475282082`, and verifier CI `29475698322`.
+- Visual proof: private responsive/theme artifacts remain outside git; the production exact/mobile/product/one-flow matrix passed all 17 assertions, with one blank mobile navigation transient passing on immediate isolated rerun.
+- Preview: #541 exact-head preview `nodebench-2otgtyneq-hshum2018-gmailcoms-projects.vercel.app` passed Tier B run `29474652192`; #542 preview `nodebench-iwmpxngv3-hshum2018-gmailcoms-projects.vercel.app` passed `29475281999`.
+- Production live: Vercel main deploy verification run `29475582335` and Convex deploy `29475582657` passed for strict SHA `16d3ceeb`; canonical `https://www.nodebenchai.com` passed the runtime-grounded production matrix and automated Post-Deploy Verify run `29476029941`.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../pages/agents.md`](../pages/agents.md), [`../pages/exact-cockpit.md`](../pages/exact-cockpit.md), and [`../integrations/pipeline-runtime.md`](../integrations/pipeline-runtime.md).

--- a/CHANGELOG/integrations/pipeline-runtime.md
+++ b/CHANGELOG/integrations/pipeline-runtime.md
@@ -13,14 +13,14 @@ Force-fresh launches now mint a unique logical attempt before the durable workfl
 
 Research bundles and Workspace documents now distinguish `sourcesConsulted` from `citationsUsed`. Only in-range `[N]` markers that actually appear in the synthesis bind a citation. Zero-source, unbound-source, non-canonical, or out-of-range citation states deterministically prevent a `verified` verdict and land on `needs_review`, regardless of a model's requested tier.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #541 / `15eb9a0a`; strict session rollout #542 / `16d3ceeb`; live-verifier alignment #543 / `56d8413a`.
 
 **Evidence state**:
-- Source: pending; this worktree candidate is not merged to `main`.
-- Checks: not recorded for a canonical `main` SHA.
-- Visual proof: not recorded.
-- Preview: not recorded.
-- Production live: not recorded.
+- Source: merged to `main` through CI-gated squash PRs #541, #542, and #543.
+- Checks: required Typecheck, Runtime smoke, Build, and Tier B checks passed on all three PRs; source CI `29474652151`, strict-rollout CI `29475282082`, and verifier CI `29475698322`.
+- Visual proof: private responsive/theme artifacts remain outside git; the production exact/mobile/product/one-flow matrix passed all 17 assertions, with one blank mobile navigation transient passing on immediate isolated rerun.
+- Preview: #541 exact-head preview `nodebench-2otgtyneq-hshum2018-gmailcoms-projects.vercel.app` passed Tier B run `29474652192`; #542 preview `nodebench-iwmpxngv3-hshum2018-gmailcoms-projects.vercel.app` passed `29475281999`.
+- Production live: Vercel main deploy verification run `29475582335` and Convex deploy `29475582657` passed for strict SHA `16d3ceeb`; canonical `https://www.nodebenchai.com` passed the runtime-grounded production matrix and automated Post-Deploy Verify run `29476029941`.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../pages/exact-cockpit.md`](../pages/exact-cockpit.md), [`../pages/agents.md`](../pages/agents.md), and [`../components/fast-agent-panel.md`](../components/fast-agent-panel.md).

--- a/CHANGELOG/pages/agents.md
+++ b/CHANGELOG/pages/agents.md
@@ -6,14 +6,14 @@ Append-only lane for the `/agents` hub, its primary command path, topic list, an
 
 The pending candidate keeps the composer, explicit `/spawn` path, running swarms, approvals, runtime topic rows, and trace links as the primary controls. It removes signed-out exposure of private task history, hardcoded agent or savings metrics, response-shape confidence labels, and client-callable fixture seeds; defers operator tooling behind an advanced disclosure; distinguishes loading and unmeasured state from zero; and reports stale health as unknown rather than healthy. Task sessions, traces, spans, decisions, verifications, evidence, approvals, swarm records, and swarm tasks require authenticated ownership, while raw orchestrator writes and secret-gated service calls use internal owner-checked contracts. The unreachable parallel timeline, kanban, hook, and public orchestrator are gone; due diligence keeps only four bounded, owner-chain-checked internal task mutations. Unused public due-diligence, investor, demo, and evaluation functions were internalized or deleted, and retained job, branch, memo, and executor error writes revalidate exact ownership. Verifier outages remain unavailable instead of being converted into a passing score. Server-confirmed viewers, admins, and owners may read operator health; only admins and owners may run maintenance.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #541 / `15eb9a0a`; strict session rollout #542 / `16d3ceeb`; live-verifier alignment #543 / `56d8413a`.
 
 **Evidence state**:
-- Source: pending; this worktree candidate is not merged to `main`.
-- Checks: not recorded for a canonical `main` SHA.
-- Visual proof: not recorded in source; local-only candidate artifacts are not release evidence.
-- Preview: not recorded.
-- Production live: not recorded.
+- Source: merged to `main` through CI-gated squash PRs #541, #542, and #543.
+- Checks: required Typecheck, Runtime smoke, Build, and Tier B checks passed on all three PRs; source CI `29474652151`, strict-rollout CI `29475282082`, and verifier CI `29475698322`.
+- Visual proof: private responsive/theme artifacts remain outside git; the production exact/mobile/product/one-flow matrix passed all 17 assertions, with one blank mobile navigation transient passing on immediate isolated rerun.
+- Preview: #541 exact-head preview `nodebench-2otgtyneq-hshum2018-gmailcoms-projects.vercel.app` passed Tier B run `29474652192`; #542 preview `nodebench-iwmpxngv3-hshum2018-gmailcoms-projects.vercel.app` passed `29475281999`.
+- Production live: Vercel main deploy verification run `29475582335` and Convex deploy `29475582657` passed for strict SHA `16d3ceeb`; canonical `https://www.nodebenchai.com` passed the runtime-grounded production matrix and automated Post-Deploy Verify run `29476029941`.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../components/fast-agent-panel.md`](../components/fast-agent-panel.md), [`exact-cockpit.md`](exact-cockpit.md), and [`../integrations/pipeline-runtime.md`](../integrations/pipeline-runtime.md).

--- a/CHANGELOG/pages/exact-cockpit.md
+++ b/CHANGELOG/pages/exact-cockpit.md
@@ -8,14 +8,14 @@ Newest entries first.
 
 The pending candidate removes named report, inbox, identity, plan, usage, vanity-metric, mobile-answer, and developer-terminal fixtures from reachable product paths. Authenticated Home users start the real background workflow; guests receive a sign-in gate that preserves the typed or scenario query through the return URL. Reports renders stored owner-scoped reports and pipeline activity, Chat uses one runtime-backed implementation across desktop and mobile, Inbox mutates live owned nudges with visible failure handling, and Me labels missing account data honestly; loading, empty, and not-found states no longer fall through to sample companies or canned results. Desktop and mobile Inbox and Me now reuse the same runtime-backed component trees, deleting the duplicate unreachable queue/profile renders and their hard-coded plan, usage, connector, local-draft, and toast-only controls. The cockpit Chat header now contains only a truthful title and its real search action instead of unwired thread/share/model controls, connection copy and color agree across offline/loading/degraded/authenticated/guest states, and Command Palette search/document actions target the canonical composer and document event. Approval responses and cancellations expose backend failures beside the affected request and preserve typed text for retry instead of failing silently.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: #541 / `15eb9a0a`; strict session rollout #542 / `16d3ceeb`; live-verifier alignment #543 / `56d8413a`.
 
 **Evidence state**:
-- Source: pending; this worktree candidate is not merged to `main`.
-- Checks: not recorded for a canonical `main` SHA.
-- Visual proof: not recorded in source; local-only candidate artifacts are not release evidence.
-- Preview: not recorded.
-- Production live: not recorded.
+- Source: merged to `main` through CI-gated squash PRs #541, #542, and #543.
+- Checks: required Typecheck, Runtime smoke, Build, and Tier B checks passed on all three PRs; source CI `29474652151`, strict-rollout CI `29475282082`, and verifier CI `29475698322`.
+- Visual proof: private responsive/theme artifacts remain outside git; the production exact/mobile/product/one-flow matrix passed all 17 assertions, with one blank mobile navigation transient passing on immediate isolated rerun.
+- Preview: #541 exact-head preview `nodebench-2otgtyneq-hshum2018-gmailcoms-projects.vercel.app` passed Tier B run `29474652192`; #542 preview `nodebench-iwmpxngv3-hshum2018-gmailcoms-projects.vercel.app` passed `29475281999`.
+- Production live: Vercel main deploy verification run `29475582335` and Convex deploy `29475582657` passed for strict SHA `16d3ceeb`; canonical `https://www.nodebenchai.com` passed the runtime-grounded production matrix and automated Post-Deploy Verify run `29476029941`.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`agents.md`](agents.md), [`../components/fast-agent-panel.md`](../components/fast-agent-panel.md), and [`../integrations/pipeline-runtime.md`](../integrations/pipeline-runtime.md).


### PR DESCRIPTION
## Summary
- replace pending release markers with canonical PRs and main SHAs
- record required CI, exact-head previews, production Vercel and Convex deploys
- record the 17-assertion production matrix and successful Post-Deploy Verify run 29476029941
- retire the three stale Codex active claims into Recently shipped

## Release chain
- source #541 / 15eb9a0a
- strict session rollout #542 / 16d3ceeb
- live verifier #543 / 56d8413a

Private .qa evidence remains intentionally outside git.