### PR TITLE
feat(redesign): establish governed agent workspace

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -6,6 +6,17 @@ For in-app release notes, see Research Hub > Changelog.
 
 ---
 
+## Unreleased (July 15, 2026)
+
+### First-class agent workspace
+
+- Replaced the redesigned Chat route's stacked status banners with one runtime-grounded run contract: objective, read scope, review-only write boundary, verification state, and review handoff.
+- Reworked the right inspector into Run and Evidence views, removing inferred background-agent claims, fabricated trace durations, and decorative progress bars.
+- Removed toast-only Export and Track actions plus the simulated client-side batch runner; live batch telemetry remains read-only and Convex-backed.
+- Unified phone and desktop Chat on the same real run tree, preserved the five canonical destinations, and fixed initial scroll, hidden inspector-row, composer reachability, and mobile navigation overflow.
+
+---
+
 ## v0.4.1 (February 2, 2026)
 
 Document system enhancements: MCP gateway document tools, batch operations, full-text content search, Markdown export, document duplication, and version comparison.

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -225,8 +225,10 @@ export default function RedesignShell() {
       return true;
     })();
 
-  // Mobile path overrides everything except /redesign/workspace (which keeps its own surface).
-  if (isMobile && surface !== "workspace" && !isPrototypeKit) {
+  // Chat keeps the canonical runtime-backed workspace at every breakpoint.
+  // The former MobileShell chat was a separate static tree with no submit/run
+  // contract, so it could not honestly represent or continue an agent run.
+  if (isMobile && surface !== "workspace" && surface !== "chat" && !isPrototypeKit) {
     const mobileSurface: SurfaceId = (surface === "workspace" ? "reports" : surface) as SurfaceId;
     // Edition flag bypasses MobileShell at the home surface so the
     // single-column editorial layout stays responsive at any width.

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -29,6 +29,14 @@ export interface AgentRailMetric {
   tone?: "green" | "amber" | "accent";
 }
 
+export interface AgentWorkspaceContract {
+  objective: string;
+  reads: string;
+  writes: string;
+  verification: string;
+  reviewHref?: string;
+}
+
 export interface AgentRailSnapshot {
   title: string;
   subtitle?: string;
@@ -40,11 +48,12 @@ export interface AgentRailSnapshot {
   backgroundAgents: AgentRailItem[];
   sources: AgentRailItem[];
   metrics?: AgentRailMetric[];
+  contract?: AgentWorkspaceContract;
 }
 
 const chatContextTabs = [
-  { id: "session", label: "Session" },
-  { id: "trace", label: "Trace" },
+  { id: "session", label: "Run" },
+  { id: "trace", label: "Evidence" },
 ] as const;
 
 type ChatContextTab = typeof chatContextTabs[number]["id"];
@@ -121,9 +130,35 @@ export function RightInspector({ activeLiveArtifactDetail, agentSnapshot }: Righ
 }
 
 function SessionContextPanel({ snapshot }: { snapshot: AgentRailSnapshot }) {
+  const contract = snapshot.contract ?? {
+    objective: snapshot.subtitle ?? "Waiting for a request.",
+    reads: "No runtime context recorded.",
+    writes: "No automatic writes.",
+    verification: "Not started.",
+  };
   return (
     <>
-      <ChatContextSection title="Progress">
+      <div className="chat-run-contract" data-status={snapshot.status}>
+        <div className="chat-run-contract__head">
+          <div>
+            <div className="chat-ctx-label">Current run</div>
+            <strong>{snapshot.title}</strong>
+          </div>
+          <StatusPill status={snapshot.status} />
+        </div>
+        <p>{contract.objective}</p>
+        {snapshot.runId && <code>run {snapshot.runId}</code>}
+      </div>
+
+      <ChatContextSection title="Scope">
+        <dl className="chat-run-scope">
+          <div><dt>Reads</dt><dd>{contract.reads}</dd></div>
+          <div><dt>Writes</dt><dd>{contract.writes}</dd></div>
+          <div><dt>Checks</dt><dd>{contract.verification}</dd></div>
+        </dl>
+      </ChatContextSection>
+
+      <ChatContextSection title="Execution">
         {snapshot.progress.map((item) => (
           <div className="chat-ctx-task" key={item.id}>
             <span className={`chat-ctx-task-dot ${taskDotClass(item.status)}`} />
@@ -144,21 +179,12 @@ function SessionContextPanel({ snapshot }: { snapshot: AgentRailSnapshot }) {
         )}
       </ChatContextSection>
 
-      <ChatContextSection title="Agents">
-        {snapshot.backgroundAgents.map((item, index) => (
-          <div className="chat-ctx-agent" key={item.id}>
-            <span className="chat-ctx-agent-dot" style={{ background: agentDotColor(item.status, index) }} />
-            <span className="chat-ctx-agent-name">{item.label}</span>
-            <span className="chat-ctx-agent-role">{agentRoleLabel(item)}</span>
-          </div>
-        ))}
-      </ChatContextSection>
-
-      <ChatContextSection title="Sources">
-        {snapshot.sources.map((item) => (
-          <ContextSourceRow key={item.id} item={item} />
-        ))}
-      </ChatContextSection>
+      {contract.reviewHref && (
+        <div className="chat-run-handoff">
+          <a href={contract.reviewHref}>Open review workspace <span aria-hidden="true">→</span></a>
+          <small>Inspect sources and proposed changes before any shared write.</small>
+        </div>
+      )}
     </>
   );
 }
@@ -173,7 +199,7 @@ function TraceContextPanel({
   const traceItems = traceRowsForSnapshot(snapshot);
   const toolCalls = metricValue(snapshot, "tools", String(traceItems.length));
   const latency = metricValue(snapshot, "latency", traceLatencyFallback(snapshot));
-  const contextSize = metricValue(snapshot, "tokens", graphPacket ? graphPacket.packedNodes.toLocaleString() : "0");
+  const contextSize = metricValue(snapshot, "context", graphPacket ? graphPacket.packedNodes.toLocaleString() : "0");
   const cost = metricValue(snapshot, "cost", metricValue(snapshot, "paid", "$0.00"));
 
   return (
@@ -192,16 +218,19 @@ function TraceContextPanel({
             <div className="chat-trace-item-body">
               <div className="chat-trace-item-name">{traceName(item)}</div>
               <div className="chat-trace-item-meta">
-                <span>{traceDuration(item, index)}</span>
-                <span>{item.meta ?? traceMeta(item)}</span>
+                <span>{item.status ?? "not recorded"}</span>
+                <span>{item.detail ?? item.meta ?? "No runtime detail recorded."}</span>
               </div>
-            </div>
-            <div className="chat-trace-item-bar">
-              <div className="chat-trace-item-bar-fill" style={{ width: `${traceBarWidth(item, index)}%` }} />
             </div>
           </div>
         ))}
       </div>
+
+      <ChatContextSection title="Sources">
+        {snapshot.sources.map((item) => (
+          <ContextSourceRow key={item.id} item={item} />
+        ))}
+      </ChatContextSection>
 
       <div className="chat-trace-model">
         <div className="chat-ctx-label">Model usage</div>
@@ -218,8 +247,8 @@ function TraceContextPanel({
           <span className="chat-trace-model-val">{graphPacket?.topology ? `${graphPacket.topology.view} ${graphPacket.topology.densityScore}` : "not attached"}</span>
         </div>
         <div className="chat-trace-model-row">
-          <span className="chat-trace-model-name">Safe writes</span>
-          <span className="chat-trace-model-val">{runDetailStatus(snapshot, "writes")}</span>
+          <span className="chat-trace-model-name">Write boundary</span>
+          <span className="chat-trace-model-val">{snapshot.contract?.writes ?? "No automatic writes"}</span>
         </div>
       </div>
     </>
@@ -293,23 +322,6 @@ function artifactBadge(item: AgentRailItem): string {
   return "ctx";
 }
 
-function agentDotColor(status: AgentRailStatus | undefined, index: number): string {
-  if (status === "running") return "var(--rd-accent)";
-  if (status === "blocked") return "var(--rd-amber)";
-  const colors = ["var(--rd-accent)", "var(--rd-green)", "#60a5fa", "#a78bfa", "var(--rd-ink-soft)"];
-  return colors[index % colors.length] ?? "var(--rd-ink-soft)";
-}
-
-function agentRoleLabel(item: AgentRailItem): string {
-  const id = item.id.toLowerCase();
-  if (id.includes("coordinator")) return "orchestrator";
-  if (id.includes("memory") || id.includes("graph")) return "retrieval";
-  if (id.includes("source") || id.includes("verify")) return "analyst";
-  if (id.includes("notebook")) return "worker";
-  if (id.includes("judge")) return "eval";
-  return item.status ?? "agent";
-}
-
 function metricValue(snapshot: AgentRailSnapshot, label: string, fallback: string): string {
   return snapshot.metrics?.find((metric) => metric.label.toLowerCase() === label)?.value ?? fallback;
 }
@@ -328,27 +340,6 @@ function traceName(item: AgentRailItem): string {
     .replace(/^graph-context$/, "Graph context")
     .replace(/^graph-packet$/, "Graph packet")
     .replace(/-/g, " ");
-}
-
-function traceMeta(item: AgentRailItem): string {
-  if (item.detail?.includes(" - ")) return item.detail.split(" - ")[0].slice(0, 28);
-  return item.detail?.slice(0, 28) || item.label.slice(0, 28);
-}
-
-function traceDuration(item: AgentRailItem, index: number): string {
-  const detail = `${item.detail ?? ""} ${item.meta ?? ""}`;
-  const explicit = detail.match(/\b\d+(?:\.\d+)?(?:ms|s)\b/i)?.[0];
-  if (explicit) return explicit;
-  if (item.status === "running") return "live";
-  if (item.status === "queued" || item.status === "idle") return "queued";
-  return `${Math.max(120, 180 + index * 140)}ms`;
-}
-
-function traceBarWidth(item: AgentRailItem, index: number): number {
-  if (item.status === "queued" || item.status === "idle") return 12;
-  if (item.status === "running") return 58;
-  if (item.status === "blocked") return 38;
-  return Math.min(100, 28 + index * 11);
 }
 
 function traceIconClass(item: AgentRailItem): string {
@@ -373,10 +364,6 @@ function traceLatencyFallback(snapshot: AgentRailSnapshot): string {
 function runDetailValue(snapshot: AgentRailSnapshot, id: string): string {
   const detail = snapshot.runDetails.find((item) => item.id === id);
   return detail?.detail?.slice(0, 24) ?? "pending";
-}
-
-function runDetailStatus(snapshot: AgentRailSnapshot, id: string): string {
-  return snapshot.runDetails.find((item) => item.id === id)?.status ?? "idle";
 }
 
 function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLoading: boolean): AgentRailSnapshot {

--- a/src/features/redesign/components/TopNav.tsx
+++ b/src/features/redesign/components/TopNav.tsx
@@ -253,6 +253,7 @@ export function TopNav({
         <button
           type="button"
           onClick={onToggleWideMode}
+          data-rd-wide-toggle
           aria-pressed={wideMode}
           aria-label={wideMode ? "Use standard width" : "Use wide mode"}
           title={wideMode ? "Use standard width (W)" : "Use wide mode (W)"}
@@ -312,6 +313,7 @@ export function TopNav({
 
         {showAccountSlot && isLoading ? (
           <div
+            data-rd-account-slot
             aria-hidden="true"
             style={{
               width: 34,
@@ -323,6 +325,7 @@ export function TopNav({
         ) : showAccountSlot && initials ? (
           <button
             type="button"
+            data-rd-account-slot
             aria-label="Account menu"
             className="rd-btn rd-btn--quiet"
             style={{
@@ -345,6 +348,7 @@ export function TopNav({
         ) : showAccountSlot ? (
           <button
             type="button"
+            data-rd-account-slot
             onClick={onSignIn}
             className="rd-btn rd-btn--primary rd-btn--sm"
             style={{

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2835,10 +2835,17 @@
 
 @media (max-width: 640px) {
   [data-redesign] [data-rd-topnav] {
-    gap: 8px !important;
-    padding: 8px 10px !important;
-    overflow-x: auto;
+    gap: 2px !important;
+    padding: 8px 6px !important;
+    overflow: hidden;
   }
+
+  [data-redesign] [data-rd-topnav] > button:first-of-type,
+  [data-redesign] [data-rd-wide-toggle],
+  [data-redesign] [data-rd-account-slot] { display: none !important; }
+
+  [data-redesign] [data-rd-topnav] nav { flex: 1; justify-content: space-between; min-width: 0; }
+  [data-redesign] [data-rd-topnav] nav .rd-btn { min-height: 32px !important; padding: 6px 8px !important; font-size: 11.5px !important; }
 
   [data-redesign] [data-rd-topnav-search] {
     display: none !important;
@@ -12223,6 +12230,122 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   height: 100%;
   border-radius: 2px;
   background: var(--rd-accent);
+}
+
+/* First-class agent workspace: one runtime contract, then progressive detail. */
+[data-redesign] .rd-agent-workspace-head {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid var(--rd-line);
+  border-left: 3px solid var(--rd-line-strong);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+}
+
+[data-redesign] .rd-agent-workspace-head[data-status="thinking"] { border-left-color: var(--rd-accent); }
+[data-redesign] .rd-agent-workspace-head[data-status="ok"] { border-left-color: var(--rd-green); }
+[data-redesign] .rd-agent-workspace-head[data-status="error"] { border-left-color: var(--rd-amber); }
+
+[data-redesign] .rd-agent-workspace-head__primary,
+[data-redesign] .rd-agent-workspace-head__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+[data-redesign] .rd-agent-workspace-head__eyebrow {
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 720;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-agent-workspace-head h1 {
+  max-width: 64ch;
+  margin: 3px 0 0;
+  color: var(--rd-ink-strong);
+  font-size: 15px;
+  font-weight: 680;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-agent-workspace-head__state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  color: var(--rd-ink-mute);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-agent-workspace-head__state > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--rd-line-strong);
+}
+
+[data-redesign] .rd-agent-workspace-head[data-status="thinking"] .rd-agent-workspace-head__state > span { background: var(--rd-accent); }
+[data-redesign] .rd-agent-workspace-head[data-status="ok"] .rd-agent-workspace-head__state > span { background: var(--rd-green); }
+[data-redesign] .rd-agent-workspace-head[data-status="error"] .rd-agent-workspace-head__state > span { background: var(--rd-amber); }
+
+[data-redesign] .rd-agent-workspace-head__scope {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-block: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-agent-workspace-head__scope > span {
+  min-width: 0;
+  padding: 10px 12px;
+  color: var(--rd-ink-soft);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+[data-redesign] .rd-agent-workspace-head__scope > span + span { border-left: 1px solid var(--rd-line-faint); }
+[data-redesign] .rd-agent-workspace-head__scope b { display: block; margin-bottom: 2px; color: var(--rd-ink-mute); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; }
+[data-redesign] .rd-agent-workspace-head__foot { color: var(--rd-ink-soft); font-family: var(--rd-font-mono); font-size: 10px; }
+[data-redesign] .rd-agent-workspace-head__foot > div { display: flex; align-items: center; gap: 8px; }
+[data-redesign] .rd-agent-workspace-head__foot button,
+[data-redesign] .chat-run-handoff a {
+  border: 0;
+  background: transparent;
+  color: var(--rd-accent-strong);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 680;
+  text-decoration: none;
+}
+
+[data-redesign] .chat-run-contract { padding: 16px; border-bottom: 1px solid var(--rd-line-faint); }
+[data-redesign] .chat-run-contract__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+[data-redesign] .chat-run-contract__head .chat-ctx-label { margin-bottom: 3px; }
+[data-redesign] .chat-run-contract strong { color: var(--rd-ink-strong); font-size: 13px; line-height: 1.35; }
+[data-redesign] .chat-run-contract p { margin: 8px 0 0; color: var(--rd-ink-mute); font-size: 11.5px; line-height: 1.5; }
+[data-redesign] .chat-run-contract code { display: block; margin-top: 7px; color: var(--rd-ink-soft); font: 10px var(--rd-font-mono); }
+[data-redesign] .chat-run-scope { display: grid; gap: 9px; margin: 0; }
+[data-redesign] .chat-run-scope > div { display: grid; grid-template-columns: 42px minmax(0, 1fr); gap: 8px; }
+[data-redesign] .chat-run-scope dt { color: var(--rd-ink-soft); font-size: 9px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+[data-redesign] .chat-run-scope dd { margin: 0; color: var(--rd-ink-mute); font-size: 10.5px; line-height: 1.45; }
+[data-redesign] .chat-run-handoff { display: grid; gap: 3px; padding: 14px 16px; }
+[data-redesign] .chat-run-handoff small { color: var(--rd-ink-soft); font-size: 10px; line-height: 1.4; }
+[data-redesign] .chat-trace-item-meta { min-width: 0; flex-direction: column; gap: 2px; line-height: 1.35; }
+[data-redesign] .chat-trace-item-meta span:last-child { overflow-wrap: anywhere; color: var(--rd-ink-soft); }
+
+@media (max-width: 760px) {
+  [data-redesign] .rd-shell--chat-v3 .rd-pane--right.chat-context { display: none; }
+  [data-redesign] .rd-agent-workspace-head { padding: 14px; }
+  [data-redesign] .rd-agent-workspace-head__primary { align-items: flex-start; }
+  [data-redesign] .rd-agent-workspace-head__scope { grid-template-columns: 1fr; }
+  [data-redesign] .rd-agent-workspace-head__scope > span { padding-inline: 0; }
+  [data-redesign] .rd-agent-workspace-head__scope > span + span { border-left: 0; border-top: 1px solid var(--rd-line-faint); }
+  [data-redesign] .rd-agent-workspace-head__foot { align-items: flex-start; flex-direction: column; }
 }
 
 [data-redesign] .chat-trace-model {

--- a/src/features/redesign/surfaces/AgentWorkspaceHonesty.guard.test.ts
+++ b/src/features/redesign/surfaces/AgentWorkspaceHonesty.guard.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("first-class agent workspace honesty contract", () => {
+  const chat = read("src/features/redesign/surfaces/ChatSurface.tsx");
+  const inspector = read("src/features/redesign/components/RightInspector.tsx");
+  const shell = read("src/features/redesign/RedesignShell.tsx");
+
+  it("exposes one runtime-grounded read, write, and verification contract", () => {
+    expect(chat).toContain("AgentWorkspaceHeader");
+    expect(chat).toContain('writes: "Review mode · no automatic shared writes"');
+    expect(chat).toContain("runtimeContextPacket.selectedContext.length");
+    expect(chat).toContain("blockedClaimCount");
+    expect(inspector).toContain('title="Scope"');
+    expect(inspector).toContain("Open review workspace");
+  });
+
+  it("does not simulate execution or advertise toast-only work controls", () => {
+    expect(chat).not.toContain("Tick the live batch counters so it feels alive");
+    expect(chat).not.toContain("spentUsd + inc");
+    expect(chat).not.toContain("batch_${target.universeId}");
+    expect(chat).not.toContain("Scroll to bottom on mount");
+    expect(chat).not.toContain('>Track updates<');
+    expect(chat).not.toContain('>Export<');
+    expect(inspector).not.toContain("traceBarWidth");
+    expect(inspector).not.toContain("traceDuration");
+    expect(inspector).not.toContain('title="Agents"');
+    expect(shell).toContain('surface !== "chat"');
+  });
+});

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -9,7 +9,7 @@
 
 import React, { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
-import { UniversalComposer, DEFAULT_TIERS, type RouterTier, type BatchTarget } from "../components/UniversalComposer";
+import { UniversalComposer, DEFAULT_TIERS, type RouterTier } from "../components/UniversalComposer";
 import { Pill } from "../components/Pill";
 import type { AgentRailItem, AgentRailSnapshot, AgentRailStatus } from "../components/RightInspector";
 import { StreamingMarkdown } from "../components/StreamingMarkdown";
@@ -660,6 +660,23 @@ function buildChatAgentRailSnapshot(args: {
       { label: "graph", value: graphPacket ? String(graphPacket.packedNodes) : "0", tone: "accent" },
       { label: "cost", value: formatRailUsd(estimatedCost), tone: estimatedCost > 0 ? "amber" : "green" },
     ],
+    contract: {
+      objective: lastUserPrompt ?? (liveDetail ? `Work from ${liveDetail.title}.` : "Waiting for a request."),
+      reads: runtimeContextPacket?.hasContext
+        ? `${runtimeContextPacket.selectedContext.length} selected context items · ${runtimeContextPacket.sourceRefs.length} source refs`
+        : liveDetail
+          ? `${liveDetail.title} · ${liveDetail.sourceCount} attached source${liveDetail.sourceCount === 1 ? "" : "s"}`
+          : "Prompt only · no report context attached",
+      writes: "Review mode · no automatic shared writes",
+      verification: blockedClaimCount > 0
+        ? `${blockedClaimCount} unsupported source${blockedClaimCount === 1 ? "" : "s"} blocking review`
+        : claimChecks.length > 0
+          ? `${verifiedSourceCount} verified · ${softWarningSourceCount} limited · ${sourceCount} total`
+          : isRunning ? "Checks pending" : "No claim checks recorded",
+      reviewHref: liveDetail
+        ? `/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=sources`
+        : undefined,
+    },
   };
 }
 
@@ -944,21 +961,6 @@ export function ChatSurface({
   useEffect(() => {
     onActiveContextChange?.(liveDetail ?? null);
   }, [liveDetail, onActiveContextChange]);
-  const batchTargets = useMemo<BatchTarget[]>(() => {
-    if (liveArtifacts.reports.length === 0) return [];
-    return [
-      {
-        universeId: "live-artifacts",
-        universeName: "Current live artifacts",
-        entityCount: liveArtifacts.reports.length,
-      },
-      ...liveArtifacts.reports.slice(0, 5).map((report) => ({
-        universeId: report.id,
-        universeName: `${report.entity} review set`,
-        entityCount: Math.max(1, report.claims + report.followUps),
-      })),
-    ];
-  }, [liveArtifacts.reports]);
   const liveSeedKey = liveDetail?.id ?? (liveArtifacts.isLoading ? "loading" : "empty");
   const openQuestions = useMemo(
     () => (liveDetail ? liveOpenQuestions(liveDetail) : []),
@@ -990,12 +992,8 @@ export function ChatSurface({
   };
   const [ctx, setCtx] = useState(contextLabel);
   const [tier, setTier] = useState<RouterTier>("auto");
-  // Sprint S2: optional live batch monitor. Supporting telemetry is isolated
-  // so it cannot collapse the primary research surface.
   const [liveBatch, setLiveBatch] = useState<ActiveBatchRun | null>(null);
-  const [overrideBatch, setOverrideBatch] = useState<ActiveBatchRun | null>(null);
-  const batch = overrideBatch ?? liveBatch;
-  const setBatch = setOverrideBatch;
+  const batch = liveBatch;
 
   // Sprint 4 P1.6 — pinned items carried into the next turn's context.
   const [pinned, setPinned] = useState<Array<{ id: string; label: string; tier: RouterTier; sourceCount: number }>>([]);
@@ -1368,54 +1366,6 @@ export function ChatSurface({
     setCtx(`Branched from message ${turnId}`);
   };
 
-  const runOnList = (text: string, _t: RouterTier, target: BatchTarget) => {
-    setHasUserInteracted(true);
-    const totalEntities = Math.max(1, target.entityCount);
-    const recentSteps = liveArtifacts.reports.slice(0, 5).map((report, index) => ({
-      entity: report.entity,
-      status: index === 0 ? "running" as const : "queued" as const,
-      durationMs: index === 0 ? 0 : undefined,
-      paidCalls: 0,
-    }));
-    setBatch({
-      id: `batch_${target.universeId}_${Date.now()}`,
-      universeId: target.universeId,
-      universeName: target.universeName,
-      styleId: "user.inferred",
-      styleName: "Founder / banker lens · v3",
-      rubric: "Live artifact review",
-      totalEntities,
-      doneCount: 0,
-      reviewCount: 0,
-      etaSeconds: totalEntities * 4,
-      spentUsd: 0,
-      recentSteps,
-    });
-    setTurns((prev) => [
-      ...prev,
-      { id: `u${prev.length}`, role: "user", text: `${text}  ·  on live set: ${target.universeName} (${totalEntities} entities)` },
-    ]);
-  };
-
-  // Tick the live batch counters so it feels alive
-  useEffect(() => {
-    if (!batch) return;
-    const t = window.setInterval(() => {
-      setBatch((cur) => {
-        if (!cur) return null;
-        if (cur.doneCount >= cur.totalEntities) return cur;
-        const inc = Math.min(2, cur.totalEntities - cur.doneCount);
-        return {
-          ...cur,
-          doneCount: cur.doneCount + inc,
-          spentUsd: +(cur.spentUsd + inc * 0.005).toFixed(3),
-          etaSeconds: Math.max(0, cur.etaSeconds - 4),
-        };
-      });
-    }, 2000);
-    return () => window.clearInterval(t);
-  }, [batch?.id]);
-
   // Scroll-to-bottom button: visible when user has scrolled up + auto-scroll on new turn
   const scrollRef = useRef<HTMLDivElement>(null);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
@@ -1431,11 +1381,6 @@ export function ChatSurface({
     el.addEventListener("scroll", onScroll, { passive: true });
     onScroll();
     return () => el.removeEventListener("scroll", onScroll);
-  }, []);
-  // Scroll to bottom on mount so the latest content is visible above the composer dock
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
   }, []);
   // Auto-scroll on new turn unless user is reading higher in the thread
   useEffect(() => {
@@ -1459,41 +1404,19 @@ export function ChatSurface({
         <BatchLiveBridge onBatch={setLiveBatch} />
       </BatchLiveBoundary>
       <div ref={scrollRef} className="rd-stack rd-chat-scroll-area" style={{ flex: 1, overflow: "auto", padding: "24px 40px 160px", gap: 18, maxWidth: 920, width: "100%", margin: "0 auto" }}>
-        {batch && <BatchMonitorCell batch={batch} onCancel={() => setBatch(null)} />}
+        {batch && <BatchMonitorCell batch={batch} />}
 
-        <ChatV2ReportBanner
-          liveDetail={liveDetail}
-          turns={turns}
-          isLive={liveArtifacts.isLive}
-          paidEligible={chatRun.state.paidEligible}
-          runStatus={chatRun.state.run?.status}
-          onOpenReport={openCurrentReport}
-          onExport={() => showToast({ tone: "info", message: "Export preview stays approval-gated until a final answer packet exists." })}
-          onTrack={() => showToast({ tone: "success", message: liveDetail ? `${liveDetail.title} is already attached as the active report context.` : "Track updates after selecting or creating a report context." })}
-        />
-        <ChatV2CheckpointStrip
-          liveDetail={liveDetail}
-          turns={turns}
-          toolCallCount={chatRun.state.run?.toolCalls.length ?? 0}
-          runStatus={chatRun.state.run?.status}
-          authReady={!authLoading}
-          isAuthenticated={isAuthenticated}
-        />
-
-        {/* Compact thread header — no marketing copy. Just status + thread context. */}
-        <header className="rd-chat-thread-head">
-          <div className="rd-row" style={{ gap: 8, flexWrap: "wrap", flex: 1 }}>
-            <Pill tone="green"><span className="rd-dot rd-dot--live" />{liveArtifacts.isLive ? "Memory ready" : "Memory warming"}</Pill>
-            <span className="rd-mono" style={{ fontSize: 11, color: "var(--rd-ink-soft)" }}>
-              {liveDetail ? `Thread - ${liveDetail.title} - ${liveDetail.sourceCount} source${liveDetail.sourceCount === 1 ? "" : "s"} - no external refresh` : "Thread - no report selected - no external refresh"}
-            </span>
-          </div>
+        <AgentWorkspaceHeader
+          snapshot={agentRailSnapshot}
+          memoryReady={liveArtifacts.isLive}
+          onOpenReview={liveDetail ? openCurrentReport : undefined}
+        >
           {openQuestions.length > 0 && !oqOpen && (
             <button type="button" className="rd-open-q__inline-toggle" onClick={() => setOqOpen(true)} aria-label="Show open questions">
               <span className="rd-open-q__count">{openQuestions.length}</span> open questions
             </button>
           )}
-        </header>
+        </AgentWorkspaceHeader>
 
         {/* Sprint 3 P2.11 — open-questions tray (only rendered when explicitly opened) */}
         <OpenQuestionsTray questions={openQuestions} open={oqOpen} onToggle={() => setOqOpen(false)} />
@@ -1589,7 +1512,6 @@ export function ChatSurface({
           disabled={turns.some((t) => t.thinking || t.streaming)}
           onOpenReport={openCurrentReport}
           onPrompt={(prompt) => sendMessage(prompt, tier)}
-          onExport={() => showToast({ tone: "info", message: "Export will use the final sourced answer packet, not an unsourced draft." })}
         />
       </div>
 
@@ -1656,8 +1578,6 @@ export function ChatSurface({
               ? `Adding to: ${liveDetail?.title ?? "current report"}`
               : `Asking about: ${liveDetail?.title ?? "current context"}`)}
             onSubmit={sendMessage}
-            onRunOnList={runOnList}
-            batchTargets={batchTargets}
             tier={tier}
             onTierChange={setTier}
             placeholder="Ask anything · type / for commands · @ to mention an entity"
@@ -1770,83 +1690,45 @@ export function ChatSurface({
  * Today: fixture from OPEN_QUESTIONS. Once chat is live-wired, replace
  * with `useAgentRunFeedback` query filtered to flagged + unresolved items.
  */
-function ChatV2ReportBanner({
-  liveDetail,
-  turns,
-  isLive,
-  paidEligible,
-  runStatus,
-  onOpenReport,
-  onExport,
-  onTrack,
+function AgentWorkspaceHeader({
+  snapshot,
+  memoryReady,
+  onOpenReview,
+  children,
 }: {
-  liveDetail?: LiveArtifactDetail | null;
-  turns: Turn[];
-  isLive: boolean;
-  paidEligible: boolean;
-  runStatus?: string;
-  onOpenReport: () => void;
-  onExport: () => void;
-  onTrack: () => void;
+  snapshot: AgentRailSnapshot;
+  memoryReady: boolean;
+  onOpenReview?: () => void;
+  children?: ReactNode;
 }) {
-  const savedLabel = liveDetail ? `Saved to ${liveDetail.title}` : "Ready for a live report packet";
-  const meta = liveDetail
-    ? `${liveDetail.sections.length} sections · ${liveDetail.claimCount} claims · ${liveDetail.sourceCount} sources · notebook context loaded`
-    : `${turns.length} messages · ${isLive ? "memory hot" : "memory warming"} · ${paidEligible ? "paid eligible" : "free-first"} · ${runStatus ?? "idle"}`;
+  const contract = snapshot.contract;
+  const stateLabel = snapshot.status === "thinking"
+    ? "Running"
+    : snapshot.status === "ok"
+      ? "Ready for review"
+      : snapshot.status === "error"
+        ? "Needs attention"
+        : "Ready";
 
   return (
-    <section className="rd-v2-saved-banner" aria-label="Current chat work packet">
-      <strong>{savedLabel}</strong>
-      <span>{meta}</span>
-      <button type="button" onClick={onOpenReport}>{liveDetail ? "Open notebook" : "Open reports"}</button>
-      <button type="button" onClick={onExport}>Export</button>
-      <button type="button" onClick={onTrack}>Track updates</button>
-    </section>
-  );
-}
-
-function ChatV2CheckpointStrip({
-  liveDetail,
-  turns,
-  toolCallCount,
-  runStatus,
-  authReady,
-  isAuthenticated,
-}: {
-  liveDetail?: LiveArtifactDetail | null;
-  turns: Turn[];
-  toolCallCount: number;
-  runStatus?: string;
-  authReady: boolean;
-  isAuthenticated: boolean;
-}) {
-  const hasUserTurn = turns.some((turn) => turn.role === "user");
-  const hasPacket = turns.some((turn) => turn.packet?.shortAnswer);
-  const hasFollowUp = turns.some((turn) => turn.markdown || turn.packet?.nextAction);
-  const running = runStatus === "running" || runStatus === "queued" || turns.some((turn) => turn.thinking || turn.streaming);
-  const checkpoints: Array<{ icon: string; text: string; done: boolean }> = [
-    { icon: "⚙", text: liveDetail ? "Report context loaded" : authReady ? "Memory checked" : "Resolving session", done: Boolean(liveDetail) || authReady },
-    { icon: "◉", text: "Prompt captured", done: hasUserTurn },
-    { icon: running && toolCallCount === 0 ? "↻" : "✓", text: `${toolCallCount} tool calls`, done: toolCallCount > 0 || running },
-    { icon: running && !hasPacket ? "↻" : "✓", text: "Answer packet", done: hasPacket || running },
-    { icon: hasFollowUp ? "✓" : "○", text: "Notebook / follow-up", done: hasFollowUp },
-    { icon: isAuthenticated ? "✓" : "○", text: isAuthenticated ? "Telemetry persisted" : "Guest telemetry local", done: isAuthenticated },
-  ];
-
-  return (
-    <div className="rd-v2-chat-center">
-      <h1>{liveDetail ? `${liveDetail.title} workspace chat` : "Ask NodeBench to work the live packet"}</h1>
-      <p className="rd-v2-muted-line">
-        {runStatus ? `Run ${runStatus}` : "Idle"} · {turns.length} messages
-      </p>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 10px", marginTop: 4 }}>
-        {checkpoints.filter((c) => c.done).map((c) => (
-          <span key={c.text} className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
-            {c.icon} {c.text}
-          </span>
-        ))}
+    <section className="rd-agent-workspace-head" data-status={snapshot.status} aria-label="Current agent run">
+      <div className="rd-agent-workspace-head__primary">
+        <div>
+          <span className="rd-agent-workspace-head__eyebrow">Agent workspace</span>
+          <h1>{contract?.objective ?? snapshot.subtitle ?? "Start a traceable run"}</h1>
+        </div>
+        <span className="rd-agent-workspace-head__state"><span aria-hidden="true" />{stateLabel}</span>
       </div>
-    </div>
+      <div className="rd-agent-workspace-head__scope">
+        <span><b>Reads</b>{contract?.reads ?? "No context recorded"}</span>
+        <span><b>Writes</b>{contract?.writes ?? "No automatic writes"}</span>
+        <span><b>Checks</b>{contract?.verification ?? "Not started"}</span>
+      </div>
+      <div className="rd-agent-workspace-head__foot">
+        <span>{memoryReady ? "Memory available" : "Memory loading"}{snapshot.runId ? ` · run ${snapshot.runId}` : " · no active run"}</span>
+        <div>{children}{onOpenReview && <button type="button" onClick={onOpenReview}>Open review workspace</button>}</div>
+      </div>
+    </section>
   );
 }
 
@@ -1855,13 +1737,11 @@ function ChatV2NextActions({
   disabled,
   onOpenReport,
   onPrompt,
-  onExport,
 }: {
   liveDetail?: LiveArtifactDetail | null;
   disabled: boolean;
   onOpenReport: () => void;
   onPrompt: (prompt: string) => void;
-  onExport: () => void;
 }) {
   const title = liveDetail?.title ?? "current context";
   const actions = [
@@ -1869,7 +1749,6 @@ function ChatV2NextActions({
     ["Draft memo", () => onPrompt(`Draft a concise sourced memo for ${title}. Include answer, evidence, risks, and next action.`)],
     ["Verify claims", () => onPrompt(`Verify the open claims for ${title}. Use memory first and list citation gaps explicitly.`)],
     ["Compare", () => onPrompt(`Compare ${title} against the closest related reports already in memory.`)],
-    ["Export", onExport],
   ] as const;
 
   return (
@@ -2287,7 +2166,7 @@ function ABCompareModal({
   );
 }
 
-function BatchMonitorCell({ batch, onCancel }: { batch: ActiveBatchRun; onCancel: () => void }) {
+function BatchMonitorCell({ batch }: { batch: ActiveBatchRun }) {
   const pct = Math.round((batch.doneCount / batch.totalEntities) * 100);
   const eta = batch.etaSeconds < 60
     ? `${batch.etaSeconds}s`
@@ -2329,10 +2208,6 @@ function BatchMonitorCell({ batch, onCancel }: { batch: ActiveBatchRun; onCancel
             ))}
           </div>
         )}
-      </div>
-      <div className="rd-action-chips" style={{ flexDirection: "column", alignItems: "flex-end" }}>
-        <button className="rd-action-chip">Pause</button>
-        <button className="rd-action-chip" onClick={onCancel}>Cancel</button>
       </div>
     </article>
   );


### PR DESCRIPTION
## Outcome
Moves the primary redesigned Chat route from stacked status chrome to one governed agent run contract.

## What changed
- runtime-grounded objective, read scope, review-only write boundary, checks, and Workspace handoff
- Run/Evidence inspector with fabricated trace timing, inferred background-agent claims, and decorative bars removed
- toast-only Export/Track and simulated batch execution removed
- mobile Chat now uses the same real run tree as desktop, with initial-scroll, inspector-row, composer reachability, and five-tab nav overflow fixed

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex/tsconfig.json --noEmit --pretty false
- 13 focused Vitest assertions
- npm run build
- six viewport/theme captures: 1440x1000, 1024x768, 390x844 in light and dark
- agent-native linter audited; it reports the existing 65 repo-wide baseline findings and no new finding from this slice

No out-of-band Convex deploy was performed.