### PR TITLE
feat(agent-workspace): make runtime lifecycle durable

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -68,6 +68,13 @@ Server Error) for an unknown slug.
 
 ## Hand-offs (built + ready for the other agent to call)
 
+- **2026-07-16 - Codex `/root` -> frontend/runtime agents** - additive optional
+  `redesignChatRuns.clientRequestId/provider/runtimeReceiptId/cancelRequestedAt/cancelledAt` fields;
+  `startChat({ ..., clientRequestId? })` dedupes by owner + request key;
+  `getLatestOwnedRun({})` restores the newest owned run;
+  `cancelRun({ runId? | clientRequestId? })` records request-bound cooperative cancellation.
+  Shipped through CI on `feat/agent-workspace-depth`; no out-of-band Convex deploy.
+
 - **2026-07-15 · Codex pipeline truth-isolation candidate →** `pipelineRuns`
   adds only optional `attemptKey`, `workflowExecutionKey`, and
   `executionGeneration`; `pipelineRunStreams` adds only optional

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -180,7 +180,12 @@ async function assertRunReadable(ctx: any, runId: string): Promise<any> {
 
 function redactSharedRun(row: any): any {
   if (!row) return null;
-  const { userId: _userId, ...safeRow } = row;
+  const {
+    userId: _userId,
+    clientRequestId: _clientRequestId,
+    cancelRequestedAt: _cancelRequestedAt,
+    ...safeRow
+  } = row;
   return safeRow;
 }
 
@@ -808,6 +813,8 @@ function parseMemo(text: string): ParsedMemo {
 export const startChat = mutation({
   args: {
     prompt: v.string(),
+    /** Stable per user submission. Replays return the original run. */
+    clientRequestId: v.optional(v.string()),
     tier: v.union(
       v.literal("free"),
       v.literal("fast"),
@@ -836,15 +843,28 @@ export const startChat = mutation({
       throw new Error("Prompt too short — write at least a 3-character question.");
     }
     const userId = await requirePaidChatUserId(ctx);
+    const clientRequestId = args.clientRequestId?.trim().slice(0, 160);
+    if (clientRequestId) {
+      const existing = await ctx.db
+        .query("redesignChatRuns")
+        .withIndex("by_user_client_request", (q) =>
+          q.eq("userId", userId).eq("clientRequestId", clientRequestId),
+        )
+        .first();
+      if (existing) return existing.runId;
+    }
     const normalizedTier = normalizeChatTier(args.tier);
     const model = modelForTier(normalizedTier);
     const runId = generateRunId();
     await ctx.db.insert("redesignChatRuns", {
       runId,
+      ...(clientRequestId ? { clientRequestId } : {}),
       userId,
       prompt,
       tier: normalizedTier,
       model,
+      provider: "google-gemini",
+      runtimeReceiptId: `redesign-chat:${runId}`,
       status: "pending",
       createdAt: Date.now(),
     });
@@ -904,6 +924,8 @@ export const probeRun = mutation({
       prompt: orig.prompt,
       tier: normalizedTier,
       model,
+      provider: "google-gemini",
+      runtimeReceiptId: `redesign-chat:${runId}`,
       status: "pending",
       createdAt: Date.now(),
     });
@@ -945,6 +967,58 @@ export const getRun = query({
   },
 });
 
+/** Recover the owner's newest durable run after a reload. */
+export const getLatestOwnedRun = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+    return await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_user_created", (q) => q.eq("userId", userId))
+      .order("desc")
+      .first();
+  },
+});
+
+/**
+ * Request cooperative cancellation. Pending work is stopped before a paid call;
+ * running streams observe this flag and abort at the next chunk boundary.
+ */
+export const cancelRun = mutation({
+  args: {
+    runId: v.optional(v.string()),
+    clientRequestId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requirePaidChatUserId(ctx);
+    if (!args.runId && !args.clientRequestId) throw new Error("A run or request id is required.");
+    const row = args.runId
+      ? await ctx.db
+          .query("redesignChatRuns")
+          .withIndex("by_runId", (q) => q.eq("runId", args.runId!))
+          .first()
+      : await ctx.db
+          .query("redesignChatRuns")
+          .withIndex("by_user_client_request", (q) =>
+            q.eq("userId", userId).eq("clientRequestId", args.clientRequestId!),
+          )
+          .first();
+    if (!row || row.userId !== userId) return { status: "unavailable", alreadyTerminal: false };
+    if (row.status === "complete" || row.status === "error" || row.status === "cancelled") {
+      return { status: row.status ?? "error", alreadyTerminal: true };
+    }
+    const now = Date.now();
+    await ctx.db.patch(row._id, {
+      status: "cancelled",
+      cancelRequestedAt: now,
+      cancelledAt: now,
+      completedAt: now,
+    });
+    return { status: "cancelled", alreadyTerminal: false };
+  },
+});
+
 /** Public query: get an immutable run by hash for the /r/{hash} share route. */
 export const getByHash = query({
   args: { hash: v.string() },
@@ -983,6 +1057,17 @@ export const appendEvent = internalMutation({
   },
 });
 
+export const getRunControl = internalQuery({
+  args: { runId: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .first();
+    return row ? { status: row.status, cancelRequestedAt: row.cancelRequestedAt } : null;
+  },
+});
+
 export const setRunRunning = internalMutation({
   args: { runId: v.string() },
   handler: async (ctx, args) => {
@@ -990,7 +1075,7 @@ export const setRunRunning = internalMutation({
       .query("redesignChatRuns")
       .withIndex("by_runId", (q) => q.eq("runId", args.runId))
       .first();
-    if (row) await ctx.db.patch(row._id, { status: "running" });
+    if (row && row.status !== "cancelled") await ctx.db.patch(row._id, { status: "running" });
   },
 });
 
@@ -1008,7 +1093,7 @@ export const finalizeRun = internalMutation({
       .query("redesignChatRuns")
       .withIndex("by_runId", (q) => q.eq("runId", args.runId))
       .first();
-    if (row) {
+    if (row && row.status !== "cancelled") {
       await ctx.db.patch(row._id, {
         status: "complete",
         hash: args.hash,
@@ -1029,7 +1114,7 @@ export const failRun = internalMutation({
       .query("redesignChatRuns")
       .withIndex("by_runId", (q) => q.eq("runId", args.runId))
       .first();
-    if (row) {
+    if (row && row.status !== "cancelled") {
       await ctx.db.patch(row._id, {
         status: "error",
         errorMessage: args.errorMessage,
@@ -1069,10 +1154,21 @@ export const runStreamingChat = internalAction({
         eventType,
         payload: payload as any,
       });
+    const isCancelled = async () => {
+      const control = await ctx.runQuery(
+        internal.domains.redesign.chatRuns.getRunControl,
+        { runId: args.runId },
+      );
+      return control?.status === "cancelled" || Boolean(control?.cancelRequestedAt);
+    };
+    const assertNotCancelled = async () => {
+      if (await isCancelled()) throw new Error("RUN_CANCELLED");
+    };
 
     try {
       if (!apiKey) throw new Error("GEMINI_API_KEY not configured in Convex env");
 
+      await assertNotCancelled();
       await ctx.runMutation(internal.domains.redesign.chatRuns.setRunRunning, { runId: args.runId });
 
       // Stage 1 — classify
@@ -1168,6 +1264,7 @@ export const runStreamingChat = internalAction({
       });
 
       // Stage 3 — Gemini streaming with grounding
+      await assertNotCancelled();
       const t3 = Date.now();
       // Phase 5 — pinned claims carry-forward as hard context
       const pinnedSection = args.pinnedClaims && args.pinnedClaims.length > 0
@@ -1244,6 +1341,11 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
         let buf = "";
         const seenChunkUris = new Set<string>();
         while (true) {
+          if (await isCancelled()) {
+            controller.abort();
+            await reader.cancel();
+            throw new Error("RUN_CANCELLED");
+          }
           const { done, value } = await reader.read();
           if (done) break;
           buf += decoder.decode(value, { stream: true });
@@ -1305,6 +1407,9 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
         await append("tool_call", tr3);
       } catch (err: any) {
         clearTimeout(timeoutId);
+        if ((err?.message || String(err)) === "RUN_CANCELLED" || await isCancelled()) {
+          throw new Error("RUN_CANCELLED");
+        }
         const detail = err.name === "AbortError" ? "request_timeout" : (err.message || String(err));
         const tr3 = { step: "Gemini synthesis", detail, status: "error" as const, durationMs: Date.now() - t3 };
         trace.push(tr3);
@@ -1467,6 +1572,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
         runtime,
       };
 
+      await assertNotCancelled();
       await ctx.runMutation(internal.domains.redesign.chatRuns.finalizeRun, {
         runId: args.runId,
         hash,
@@ -1501,6 +1607,9 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
         });
       }
     } catch (err: any) {
+      if ((err?.message || String(err)) === "RUN_CANCELLED" || await isCancelled()) {
+        return;
+      }
       const errorMessage = (err?.message || String(err)).slice(0, 280);
       await append("error", { errorMessage });
       await ctx.runMutation(internal.domains.redesign.chatRuns.failRun, {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15997,11 +15997,13 @@ export default defineSchema({
    * with the link. Same packet → same hash → same URL across deploys.
    *
    * runId is unique per run; hash is unique per {prompt, tier, model,
-   * shortAnswer, sortedEvidenceUrls} combination — same input → same cached
-   * run, idempotent re-runs collapse onto the same row.
+   * shortAnswer, sortedEvidenceUrls} combination. Paid submission retries
+   * collapse by owner + clientRequestId before a second run is scheduled.
    */
   redesignChatRuns: defineTable({
     runId: v.string(),
+    /** Client-generated idempotency key. Optional for backwards compatibility. */
+    clientRequestId: v.optional(v.string()),
     hash: v.optional(v.string()),
     userId: v.optional(v.id("users")),
     prompt: v.string(),
@@ -16021,11 +16023,17 @@ export default defineSchema({
     totalLatencyMs: v.optional(v.number()),
     totalTokens: v.optional(v.number()),
     estimatedCostUsd: v.optional(v.number()),
+    /** Honest runtime receipt metadata; no provider response id is inferred. */
+    provider: v.optional(v.string()),
+    runtimeReceiptId: v.optional(v.string()),
+    cancelRequestedAt: v.optional(v.number()),
+    cancelledAt: v.optional(v.number()),
     createdAt: v.number(),
     completedAt: v.optional(v.number()),
   })
     .index("by_runId", ["runId"])
     .index("by_hash", ["hash"])
+    .index("by_user_client_request", ["userId", "clientRequestId"])
     .index("by_user_created", ["userId", "createdAt"]),
 
   /**

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -230,10 +230,12 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   const [showDocumentSelector, setShowDocumentSelector] = useState(false);
 
   // Contextual-open handling (FastAgentContext.openWithContext)
-  const lastHandledOpenRequestIdRef = useRef<string | null>(null);
+  const handledOpenRequestIdsRef = useRef<Set<string>>(new Set());
   const [pendingAutoSend, setPendingAutoSend] = useState<null | { requestId: string; message: string }>(null);
   // Guard against duplicate auto-sends
-  const lastAutoSentRequestIdRef = useRef<string | null>(null);
+  const autoSentRequestIdsRef = useRef<Set<string>>(new Set());
+  const autoSendInFlightRequestIdsRef = useRef<Set<string>>(new Set());
+  const autoSendFailedRequestIdsRef = useRef<Set<string>>(new Set());
   // Guard against duplicate manual sends (rapid clicks)
   const lastSentMessageRef = useRef<{ text: string; timestamp: number } | null>(null);
   // Forward-ref for stableSendMessage (avoids TDZ in scheduled messages useEffect)
@@ -566,7 +568,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
 
   // Ref-based callback pattern for stable handleSendMessage reference
   // This prevents re-renders when callback dependencies change
-  const handleSendMessageRef = useRef<(content?: string) => Promise<void>>(undefined);
+  const handleSendMessageRef = useRef<(content?: string) => Promise<boolean>>(undefined);
 
   // Track auto-created documents to avoid duplicates (by agentThreadId) and processed message IDs
   const autoDocCreatedThreadIdsRef = useRef<Set<string>>(new Set());
@@ -584,15 +586,6 @@ export const FastAgentPanel = memo(function FastAgentPanel({
       setActiveThreadId(initialThreadId);
     }
   }, [initialThreadId, activeThreadId]);
-
-  // In desktop layouts both sidebar and overlay variants can be mounted simultaneously
-  // (one hidden via CSS). Only the viewport-active variant should consume contextual
-  // openOptions to avoid duplicate autosend requests.
-  const isViewportActiveVariant = useCallback(() => {
-    if (typeof window === "undefined") return true;
-    const isDesktop = window.matchMedia("(min-width: 1024px)").matches;
-    return variant === "sidebar" ? isDesktop : !isDesktop;
-  }, [variant]);
 
   // Cross-surface agent unification: when the user is on an entity page,
   // agent responses can be saved directly into that entity's notebook.
@@ -637,12 +630,11 @@ export const FastAgentPanel = memo(function FastAgentPanel({
 
   // Apply openOptions once per requestId, and optionally auto-send.
   useEffect(() => {
-    if (!isViewportActiveVariant()) return;
     if (!isOpen) return;
     const requestId = openOptions?.requestId;
     if (!requestId) return;
-    if (lastHandledOpenRequestIdRef.current === requestId) return;
-    lastHandledOpenRequestIdRef.current = requestId;
+    if (handledOpenRequestIdsRef.current.has(requestId)) return;
+    handledOpenRequestIdsRef.current.add(requestId);
 
     const contextDocIds = (openOptions?.contextDocumentIds ?? []).map(String).filter(Boolean);
     if (contextDocIds.length > 0) {
@@ -700,7 +692,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     lastAnnouncedChatModeRef.current = "agent-streaming";
     setChatMode("agent-streaming");
     setPendingAutoSend({ requestId, message });
-  }, [isOpen, onOptionsConsumed, openOptions, isViewportActiveVariant, showsNotebookWorkspaceTabs]);
+  }, [isOpen, onOptionsConsumed, openOptions, showsNotebookWorkspaceTabs]);
 
   useEffect(() => {
     if (showsNotebookWorkspaceTabs) {
@@ -1218,10 +1210,10 @@ export const FastAgentPanel = memo(function FastAgentPanel({
   }, [activeThreadId, anonymousSession.sessionId, threads, chatMode, deleteAgentThread, deleteStreamingThread, isProductConversationMode]);
 
   const handleSendMessage = useCallback(async (content?: string) => {
-    if (isBusy) return;
+    if (isBusy) return false;
     if (!runtimeOwnerReady) {
       toast.info("Preparing secure session. Try again in a moment.");
-      return;
+      return false;
     }
 
     const preparedSubmission = prepareFastAgentSubmission({
@@ -1244,7 +1236,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
           description: 'Wait for at least one document to finish before sending.',
         });
       }
-      return;
+      return false;
     }
 
     const { messageContent, text } = preparedSubmission;
@@ -1255,10 +1247,8 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     if (lastSentMessageRef.current &&
         lastSentMessageRef.current.text === text &&
         now - lastSentMessageRef.current.timestamp < DEDUPE_WINDOW_MS) {
-      return;
+      return false;
     }
-    lastSentMessageRef.current = { text, timestamp: now };
-
     // Check if anonymous user has exceeded their daily limit
     if (anonymousSession.isAnonymous && !anonymousSession.canSendMessage) {
       toast.error(
@@ -1267,8 +1257,9 @@ export const FastAgentPanel = memo(function FastAgentPanel({
           <div className="text-xs">{FAST_AGENT_SIGN_IN_BENEFIT_COPY}</div>
         </div>
       );
-      return;
+      return false;
     }
+    lastSentMessageRef.current = { text, timestamp: now };
 
     const documentCreationTopic = getAuthenticatedDocumentCreationTopic({
       chatMode,
@@ -1334,12 +1325,13 @@ export const FastAgentPanel = memo(function FastAgentPanel({
         );
 
         setIsStreaming(false);
-        return;
+        return true;
       } catch (error) {
         console.error("Failed to create document:", error);
         toast.error("Failed to create document");
         setIsStreaming(false);
-        return;
+        lastSentMessageRef.current = null;
+        return false;
       }
     }
 
@@ -1457,10 +1449,13 @@ export const FastAgentPanel = memo(function FastAgentPanel({
           });
         }
       }
+      return true;
     } catch (error) {
       console.error("Failed to send message:", error);
       toast.error("Failed to send message");
       setIsStreaming(false);
+      lastSentMessageRef.current = null;
+      return false;
     }
   }, [
     input,
@@ -1495,17 +1490,17 @@ export const FastAgentPanel = memo(function FastAgentPanel({
 
   // Stable callback wrapper - never changes reference, always calls latest implementation
   const stableSendMessage = useCallback((content?: string) => {
-    return handleSendMessageRef.current?.(content);
+    return handleSendMessageRef.current?.(content) ?? Promise.resolve(false);
   }, []);
   stableSendMessageRef.current = stableSendMessage;
 
   // Auto-send contextual open prompt once streaming mode is active.
   useEffect(() => {
-    if (!isViewportActiveVariant()) return;
     if (!isOpen) return;
     if (!pendingAutoSend) return;
     if (chatMode !== "agent-streaming") return;
     if (isBusy) return;
+    if (!runtimeOwnerReady) return;
     if (anonymousSession.isAnonymous && anonymousSession.isLoading) return;
 
     if (anonymousSession.isAnonymous && !anonymousSession.canSendMessage) {
@@ -1524,14 +1519,25 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     if (openOptions?.requestId && openOptions.requestId !== requestId) return;
 
     // ⚡ CRITICAL GUARD: Prevent duplicate auto-sends
-    if (lastAutoSentRequestIdRef.current === requestId) {
+    if (
+      autoSentRequestIdsRef.current.has(requestId)
+      || autoSendInFlightRequestIdsRef.current.has(requestId)
+      || autoSendFailedRequestIdsRef.current.has(requestId)
+    ) {
       return;
     }
-    lastAutoSentRequestIdRef.current = requestId;
-
-    stableSendMessage(message);
-    setPendingAutoSend(null);
-    onOptionsConsumed?.();
+    autoSendInFlightRequestIdsRef.current.add(requestId);
+    void stableSendMessage(message).then((accepted) => {
+      autoSendInFlightRequestIdsRef.current.delete(requestId);
+      if (!accepted) {
+        autoSendFailedRequestIdsRef.current.add(requestId);
+        setInput(message);
+        return;
+      }
+      autoSentRequestIdsRef.current.add(requestId);
+      setPendingAutoSend((current) => current?.requestId === requestId ? null : current);
+      onOptionsConsumed?.();
+    });
   }, [
     isOpen,
     pendingAutoSend,
@@ -1540,7 +1546,7 @@ export const FastAgentPanel = memo(function FastAgentPanel({
     openOptions?.requestId,
     stableSendMessage,
     onOptionsConsumed,
-    isViewportActiveVariant,
+    runtimeOwnerReady,
     anonymousSession.isAnonymous,
     anonymousSession.isLoading,
     anonymousSession.canSendMessage,

--- a/src/features/agents/components/FastAgentPanel/__tests__/FastAgentDeclutter.guard.test.ts
+++ b/src/features/agents/components/FastAgentPanel/__tests__/FastAgentDeclutter.guard.test.ts
@@ -95,6 +95,50 @@ describe("FastAgent declutter guards", () => {
     expect(panel).toContain("href={isProductConversationMode ? '#product-intake-query' : '#fa-chat-input'}");
   });
 
+  it("processes contextual opens once on every viewport and waits for a runtime owner", () => {
+    const panel = source("src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx");
+    const contextualOpen = panel.slice(
+      panel.indexOf("// Apply openOptions once per requestId"),
+      panel.indexOf("// Persist dossier context"),
+    );
+    const autoSend = panel.slice(
+      panel.indexOf("// Auto-send contextual open prompt"),
+      panel.indexOf("// No client heuristics"),
+    );
+
+    // CockpitLayout owns one responsive slide-over, so no CSS-breakpoint branch may
+    // prevent its mounted panel from consuming the request on mobile or tablet.
+    expect(contextualOpen).not.toContain("matchMedia");
+    expect(contextualOpen).not.toContain("isViewportActiveVariant");
+    expect(autoSend).not.toContain("matchMedia");
+    expect(autoSend).not.toContain("isViewportActiveVariant");
+
+    // A set preserves exactly-once semantics even if an old request id reappears
+    // after a different request, instead of remembering only the immediately prior id.
+    expect(panel).toContain("const handledOpenRequestIdsRef = useRef<Set<string>>(new Set());");
+    expect(panel).toContain("const autoSentRequestIdsRef = useRef<Set<string>>(new Set());");
+    expect(panel).toContain("const autoSendInFlightRequestIdsRef = useRef<Set<string>>(new Set());");
+    expect(panel).toContain("const autoSendFailedRequestIdsRef = useRef<Set<string>>(new Set());");
+    expect(contextualOpen).toContain("handledOpenRequestIdsRef.current.has(requestId)");
+    expect(contextualOpen).toContain("handledOpenRequestIdsRef.current.add(requestId)");
+    expect(autoSend).toContain("autoSentRequestIdsRef.current.has(requestId)");
+    expect(autoSend).toContain("autoSentRequestIdsRef.current.add(requestId)");
+    expect(autoSend).toContain("autoSendFailedRequestIdsRef.current.add(requestId)");
+    expect(autoSend).toContain("setInput(message)");
+    expect(autoSend.indexOf("stableSendMessage(message)")).toBeLessThan(autoSend.indexOf("autoSentRequestIdsRef.current.add(requestId)"));
+    const acceptedDispatch = autoSend.slice(autoSend.indexOf("autoSentRequestIdsRef.current.add(requestId)"));
+    expect(acceptedDispatch.indexOf("autoSentRequestIdsRef.current.add(requestId)")).toBeLessThan(acceptedDispatch.indexOf("onOptionsConsumed?.()"));
+
+    // Readiness must be checked before reserving the id, dispatching, or consuming
+    // the options; otherwise the send handler rejects it and the prompt is lost.
+    const readyGuard = autoSend.indexOf("if (!runtimeOwnerReady) return;");
+    expect(readyGuard).toBeGreaterThan(-1);
+    expect(readyGuard).toBeLessThan(autoSend.indexOf("autoSentRequestIdsRef.current.add(requestId)"));
+    expect(readyGuard).toBeLessThan(autoSend.indexOf("stableSendMessage(message)"));
+    expect(readyGuard).toBeLessThan(autoSend.indexOf("onOptionsConsumed?.()"));
+    expect(autoSend).toContain("runtimeOwnerReady,");
+  });
+
   it("migrates removed legacy chat mode instead of restoring dead actions", () => {
     const panel = source("src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx");
 

--- a/src/features/redesign/agent-workspace.css
+++ b/src/features/redesign/agent-workspace.css
@@ -87,7 +87,7 @@
 [data-redesign] .rd-run-scope {
   margin: 0 4px 8px;
   color: var(--rd-ink-mute);
-  font-size: 11px;
+  font-size: 12px;
 }
 
 [data-redesign] .rd-run-scope > summary {
@@ -138,7 +138,7 @@
   flex: 1;
   flex-direction: column;
   justify-content: center;
-  width: min(100%, 700px);
+  width: min(100%, 840px);
   min-height: 0;
   height: 100%;
   margin: auto;
@@ -149,9 +149,21 @@
   margin-bottom: 24px;
 }
 
+[data-redesign] .rd-chat-empty__h {
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+[data-redesign] .rd-chat-empty__sub {
+  max-width: 58ch;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
 [data-redesign] .rd-chat-empty__chips {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
+  max-width: none;
 }
 
 [data-redesign] .rd-chat-empty__chip {
@@ -161,7 +173,13 @@
 }
 
 [data-redesign] .rd-chat-empty__chip-title {
+  font-size: 14px;
+  line-height: 1.4;
   overflow-wrap: anywhere;
+}
+
+[data-redesign] .rd-chat-empty__chip-hint {
+  font-size: 12px;
 }
 
 @media (max-width: 760px) {

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -54,7 +54,7 @@ interface UniversalComposerProps {
   batchTargets?: BatchTarget[];
   /**
    * Default submit (Enter, ⌘↵, or "Run research" button). Mode = "research" by default.
-   * Mirrors live nodebenchai.com — research saves to Reports; chat is ephemeral.
+   * Research creates a durable runtime run; explicit promotion controls save artifacts elsewhere.
    */
   onSubmit?: (text: string, tier: RouterTier, mode: ComposerMode) => void;
   /**
@@ -219,7 +219,7 @@ export function UniversalComposer({
 
   const handleSubmit = (mode: ComposerMode = "research") => {
     const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!trimmed || streaming) return;
     if (mode === "chat" && onChatNow) {
       onChatNow(trimmed, tier);
     } else {
@@ -677,8 +677,8 @@ export function UniversalComposer({
             <button
               type="button"
               onClick={onStop}
-              aria-label="Stop generation"
-              title="Stop generation (Esc)"
+              aria-label="Cancel active run"
+              title="Cancel active run (Esc)"
               className="rd-btn rd-btn--sm"
               style={{
                 gap: 6,
@@ -698,7 +698,7 @@ export function UniversalComposer({
               onClick={() => handleSubmit("research")}
               disabled={!text.trim()}
               aria-label="Run research"
-              title="Run research (Enter) — saves to Reports"
+              title="Run research (Enter)"
               className="rd-btn rd-btn--primary rd-btn--sm"
               style={{
                 opacity: text.trim() ? 1 : 0.55,

--- a/src/features/redesign/hooks/useRedesignChatRun.test.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPartialChatAnswer,
+  createChatClientRequestId,
   isPaidChatEligibleUser,
   normalizeRouterTierForChatRun,
   resolveRuntimeArtifacts,
 } from "./useRedesignChatRun";
+
+describe("durable run request identity", () => {
+  it("creates a distinct non-empty idempotency key per submission", () => {
+    const first = createChatClientRequestId();
+    const second = createChatClientRequestId();
+    expect(first.length).toBeGreaterThan(8);
+    expect(second).not.toBe(first);
+  });
+});
 
 describe("normalizeRouterTierForChatRun", () => {
   it("maps UI-only tiers to Convex chat run tiers", () => {

--- a/src/features/redesign/hooks/useRedesignChatRun.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.ts
@@ -14,7 +14,7 @@
  * stopped client-side before the mutation call; Convex enforces the same
  * policy server-side so anonymous sessions cannot start paid work either.
  */
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import type { ChatAnswer as BaseChatAnswer } from "../fixtures";
@@ -22,6 +22,13 @@ import type { RouterTier } from "../components/UniversalComposer";
 import type { LiveGroundingDecision } from "shared/redesign/contextRuntimePolicy";
 
 export type ChatRunTier = "free" | "fast" | "auto" | "deep";
+
+export function createChatClientRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
 
 export function normalizeRouterTierForChatRun(tier: RouterTier): ChatRunTier {
   if (tier === "answer") return "fast";
@@ -51,6 +58,11 @@ export interface PlannerArtifact {
 
 export interface RuntimeMetrics {
   runId?: string;
+  model?: string;
+  provider?: string;
+  runtimeReceiptId?: string;
+  createdAt?: number;
+  completedAt?: number;
   totalLatencyMs?: number;
   totalTokens?: number;
   estimatedCostUsd?: number;
@@ -189,11 +201,18 @@ export function buildPartialChatAnswer({
 
 export interface RealChatRun {
   runId: string;
+  prompt?: string;
+  tier?: string;
   hash?: string;
   packet: ChatAnswer;
   totalLatencyMs?: number;
   totalTokens?: number;
   estimatedCostUsd?: number;
+  model?: string;
+  provider?: string;
+  runtimeReceiptId?: string;
+  createdAt?: number;
+  completedAt?: number;
   /** Live working-notes scratchpad (concatenated streamed chunks). */
   scratchpad: string;
   /** Per-stage tool-call cards as they fire. */
@@ -202,7 +221,7 @@ export interface RealChatRun {
   groundingChunks: EvidenceRow[];
   /** Board-state, routing, tool-decision, claim-check, and metric artifacts. */
   runtime: RuntimeTrace;
-  status: "pending" | "running" | "complete" | "error";
+  status: "pending" | "running" | "complete" | "error" | "cancelled";
   errorMessage?: string;
 }
 
@@ -219,6 +238,8 @@ export interface ChatRunState {
   userLoading: boolean;
 }
 
+export type CancelRunResult = "recorded" | "queued" | "unavailable";
+
 export function isPaidChatEligibleUser(user: unknown): boolean {
   if (!user || typeof user !== "object") return false;
   const record = user as Record<string, unknown>;
@@ -229,6 +250,7 @@ export function isPaidChatEligibleUser(user: unknown): boolean {
 export function useRedesignChatRun() {
   const { isLoading: authLoading, isAuthenticated } = useConvexAuth();
   const startChat = useMutation(api.domains.redesign.chatRuns.startChat);
+  const cancelRun = useMutation(api.domains.redesign.chatRuns.cancelRun);
   const user = useQuery(
     api.domains.auth.auth.loggedInUser,
     isAuthenticated ? {} : "skip",
@@ -236,6 +258,8 @@ export function useRedesignChatRun() {
 
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const pendingSubmissionRef = useRef<{ fingerprint: string; requestId: string } | null>(null);
+  const pendingCancellationRef = useRef<{ requestId: string } | null>(null);
   // BUG FIX (2026-07-01): `useQuery` returns `undefined` while `loggedInUser` is still resolving,
   // and `isPaidChatEligibleUser(undefined)` collapses that into "not eligible" — so a fully
   // authenticated, properly-linked user who sends a message right after page load was shown the
@@ -244,6 +268,16 @@ export function useRedesignChatRun() {
   // See docs/LIVE-USER-BENCHMARK-FINDING.md.
   const userLoading = isAuthenticated && user === undefined;
   const paidEligible = isPaidChatEligibleUser(user);
+  const latestOwnedRun = useQuery(
+    api.domains.redesign.chatRuns.getLatestOwnedRun,
+    paidEligible ? {} : "skip",
+  );
+
+  useEffect(() => {
+    if (!activeRunId && latestOwnedRun?.runId) {
+      setActiveRunId(latestOwnedRun.runId);
+    }
+  }, [activeRunId, latestOwnedRun?.runId]);
 
   const events = useQuery(
     api.domains.redesign.chatRuns.streamEventsForRun,
@@ -349,12 +383,24 @@ export function useRedesignChatRun() {
       ? (runRow.packet as ChatAnswer)
       : partial;
     const resolvedArtifacts = resolveRuntimeArtifacts({ contextCandidates, toolDecisions, claimChecks });
+    const persistedMetrics: RuntimeMetrics = {
+      ...metrics,
+      runId: activeRunId,
+      model: runRow?.model,
+      provider: runRow?.provider,
+      runtimeReceiptId: runRow?.runtimeReceiptId,
+      createdAt: runRow?.createdAt,
+      completedAt: runRow?.completedAt,
+      totalLatencyMs: runRow?.totalLatencyMs ?? metrics?.totalLatencyMs,
+      totalTokens: runRow?.totalTokens ?? metrics?.totalTokens,
+      estimatedCostUsd: runRow?.estimatedCostUsd ?? metrics?.estimatedCostUsd,
+    };
     const runtime: RuntimeTrace = {
       boardState,
       contextCandidates: resolvedArtifacts.contextCandidates,
       toolDecisions: resolvedArtifacts.toolDecisions,
       claimChecks: resolvedArtifacts.claimChecks,
-      metrics,
+      metrics: persistedMetrics,
       contextPacket: contextPacket ?? (finalPacket.runtime as RuntimeTrace | undefined)?.contextPacket,
       liveGroundingDecision: liveGroundingDecision ?? (finalPacket.runtime as RuntimeTrace | undefined)?.liveGroundingDecision,
     };
@@ -365,11 +411,18 @@ export function useRedesignChatRun() {
 
     return {
       runId: activeRunId,
+      prompt: runRow?.prompt,
+      tier: runRow?.tier,
       hash: runRow?.hash ?? undefined,
       packet,
       totalLatencyMs: runRow?.totalLatencyMs,
       totalTokens: runRow?.totalTokens,
       estimatedCostUsd: runRow?.estimatedCostUsd,
+      model: runRow?.model,
+      provider: runRow?.provider,
+      runtimeReceiptId: runRow?.runtimeReceiptId,
+      createdAt: runRow?.createdAt,
+      completedAt: runRow?.completedAt,
       scratchpad,
       toolCalls,
       groundingChunks,
@@ -382,6 +435,9 @@ export function useRedesignChatRun() {
   useEffect(() => {
     if (projected?.status === "error" && projected.errorMessage) {
       setError(projected.errorMessage);
+    }
+    if (projected?.status === "complete" || projected?.status === "error" || projected?.status === "cancelled") {
+      pendingSubmissionRef.current = null;
     }
   }, [projected?.status, projected?.errorMessage]);
 
@@ -405,11 +461,50 @@ export function useRedesignChatRun() {
         return null;
       }
       setError(null);
+      const normalizedTier = normalizeRouterTierForChatRun(tier);
+      const fingerprint = JSON.stringify({ prompt: prompt.trim(), tier: normalizedTier, contextRef, pinnedClaims });
+      const existingRequest = pendingSubmissionRef.current;
+      const clientRequestId = existingRequest?.fingerprint === fingerprint
+        ? existingRequest.requestId
+        : createChatClientRequestId();
+      const staleCancellation = pendingCancellationRef.current;
+      if (staleCancellation && staleCancellation.requestId !== clientRequestId) {
+        try {
+          await cancelRun({ clientRequestId: staleCancellation.requestId });
+          pendingCancellationRef.current = null;
+        } catch {
+          setError("The prior cancellation could not be confirmed. Retry before starting unrelated work.");
+          return null;
+        }
+      }
+      pendingSubmissionRef.current = { fingerprint, requestId: clientRequestId };
       try {
-        const runId = await startChat({ prompt, tier: normalizeRouterTierForChatRun(tier), contextRef, pinnedClaims });
+        const runId = await startChat({
+          prompt,
+          tier: normalizedTier,
+          contextRef,
+          pinnedClaims,
+          clientRequestId,
+        });
         setActiveRunId(runId);
+        if (pendingCancellationRef.current?.requestId === clientRequestId) {
+          const cancellation = await cancelRun({ runId });
+          if (cancellation.status === "cancelled" || cancellation.alreadyTerminal) {
+            pendingCancellationRef.current = null;
+          }
+        }
         return runId;
       } catch (err: any) {
+        if (pendingCancellationRef.current?.requestId === clientRequestId) {
+          try {
+            const cancellation = await cancelRun({ clientRequestId });
+            if (cancellation.status === "cancelled" || cancellation.status === "unavailable" || cancellation.alreadyTerminal) {
+              pendingCancellationRef.current = null;
+            }
+          } catch {
+            // Keep the request-bound cancellation for an explicit retry.
+          }
+        }
         const raw = (err?.message ?? String(err)).slice(0, 280);
         const msg = /server error|not authenticated|anonymous|sign in|account/i.test(raw)
           ? "Sign in with an email-backed account before running live research."
@@ -418,13 +513,28 @@ export function useRedesignChatRun() {
         return null;
       }
     },
-    [authLoading, isAuthenticated, paidEligible, startChat],
+    [authLoading, cancelRun, isAuthenticated, paidEligible, startChat],
   );
 
   const reset = useCallback(() => {
     setActiveRunId(null);
     setError(null);
   }, []);
+
+  const cancel = useCallback(async (targetRunId: string | null): Promise<CancelRunResult> => {
+    if (!targetRunId) {
+      if (!pendingSubmissionRef.current) return "unavailable";
+      pendingCancellationRef.current = { requestId: pendingSubmissionRef.current.requestId };
+      return "queued";
+    }
+    try {
+      const result = await cancelRun({ runId: targetRunId });
+      return result.status === "cancelled" && !result.alreadyTerminal ? "recorded" : "unavailable";
+    } catch (err: any) {
+      setError((err?.message ?? String(err)).slice(0, 280));
+      return "unavailable";
+    }
+  }, [cancelRun]);
 
   /**
    * Phase 5 — point the hook at an existing runId (e.g. one returned
@@ -441,6 +551,7 @@ export function useRedesignChatRun() {
     error ? "error"
     : !activeRunId ? "idle"
     : projected?.status === "complete" ? "ok"
+    : projected?.status === "cancelled" ? "idle"
     : projected?.status === "error" ? "error"
     : "thinking";
 
@@ -454,6 +565,7 @@ export function useRedesignChatRun() {
       userLoading,
     } as ChatRunState,
     submit,
+    cancel,
     reset,
     subscribeTo,
     hash: projected?.hash ?? null,

--- a/src/features/redesign/surfaces/ChatRunLifecycle.guard.test.ts
+++ b/src/features/redesign/surfaces/ChatRunLifecycle.guard.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("durable chat run lifecycle contract", () => {
+  const backend = read("convex/domains/redesign/chatRuns.ts");
+  const schema = read("convex/schema.ts");
+  const hook = read("src/features/redesign/hooks/useRedesignChatRun.ts");
+  const chat = read("src/features/redesign/surfaces/ChatSurface.tsx");
+  const composer = read("src/features/redesign/components/UniversalComposer.tsx");
+
+  it("deduplicates paid submissions by owner and client request id", () => {
+    expect(schema).toContain('.index("by_user_client_request", ["userId", "clientRequestId"])');
+    expect(backend).toContain('q.eq("userId", userId).eq("clientRequestId", clientRequestId)');
+    expect(hook).toContain("pendingSubmissionRef.current = { fingerprint, requestId: clientRequestId }");
+    expect(hook).toContain("clientRequestId,");
+    expect(composer).toContain("if (!trimmed || streaming) return;");
+  });
+
+  it("recovers the newest owned run and reconstructs its conversation pair", () => {
+    expect(backend).toContain("export const getLatestOwnedRun = query");
+    expect(hook).toContain("latestOwnedRun?.runId");
+    expect(chat).toContain("Rebuild the newest owned conversation pair from the durable run after reload");
+  });
+
+  it("records cooperative cancellation and never presents a local-only stop", () => {
+    expect(backend).toContain("export const cancelRun = mutation");
+    expect(backend).toContain('throw new Error("RUN_CANCELLED")');
+    expect(chat).toContain("chatRun.cancel(targetTurn.chatRunId ?? null)");
+    expect(hook).toContain('return "queued"');
+    expect(hook).toContain("await cancelRun({ runId });");
+    expect(hook).toContain("await cancelRun({ clientRequestId });");
+    expect(composer).toContain('aria-label="Cancel active run"');
+    expect(composer).not.toContain("Stop generation");
+  });
+
+  it("surfaces stored provider, model, token, cost, and receipt metadata", () => {
+    expect(schema).toContain("runtimeReceiptId: v.optional(v.string())");
+    expect(hook).toContain("runtimeReceiptId: runRow?.runtimeReceiptId");
+    expect(chat).toContain('<RuntimeMetric label="Receipt"');
+  });
+});

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -786,6 +786,7 @@ export function ChatSurface({
     ];
   }, [liveDetail]);
   const [turns, setTurns] = useState<Turn[]>([]);
+  const recoveredRunIdRef = useRef<string | null>(null);
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
   const consumedInitialPromptRef = useRef<string | null>(null);
   const hasInitialPrompt = Boolean(initialPrompt?.trim());
@@ -798,6 +799,33 @@ export function ChatSurface({
   const [tier, setTier] = useState<RouterTier>("auto");
   const [liveBatch, setLiveBatch] = useState<ActiveBatchRun | null>(null);
   const batch = liveBatch;
+
+  // Rebuild the newest owned conversation pair from the durable run after reload.
+  useEffect(() => {
+    const real = chatRun.state.run;
+    if (!real?.prompt || turns.length > 0 || recoveredRunIdRef.current === real.runId) return;
+    recoveredRunIdRef.current = real.runId;
+    const createdAt = real.createdAt ?? Date.now();
+    const terminalMarkdown = real.status === "cancelled"
+      ? liveChatUnavailableMarkdown("This run was cancelled before a final answer packet was available.", liveDetail)
+      : real.status === "error"
+        ? liveChatUnavailableMarkdown(real.errorMessage ?? "The recovered run failed before producing a final packet.", liveDetail)
+        : undefined;
+    setTurns([
+      { id: nextTurnId("u"), role: "user", text: real.prompt, createdAt },
+      {
+        id: nextTurnId("a"),
+        role: "assistant",
+        chatRunId: real.runId,
+        thinking: real.status === "pending" || real.status === "running",
+        packet: real.status === "complete" ? real.packet : undefined,
+        runHash: real.hash,
+        markdown: terminalMarkdown,
+        tier: (real.tier ?? "auto") as RouterTier,
+        createdAt: createdAt + 1,
+      },
+    ]);
+  }, [chatRun.state.run, liveDetail, turns.length]);
 
   // Sprint 4 P1.6 — pinned items carried into the next turn's context.
   const [pinned, setPinned] = useState<Array<{ id: string; label: string; tier: RouterTier; sourceCount: number }>>([]);
@@ -958,6 +986,16 @@ export function ChatSurface({
         out[idx] = next;
         return out;
       }
+      if (real.status === "cancelled") {
+        const out = [...prev];
+        out[idx] = {
+          ...live,
+          thinking: false,
+          streaming: false,
+          markdown: liveChatUnavailableMarkdown("Run cancelled. Any in-flight provider stream was aborted at the next cooperative checkpoint.", liveDetail),
+        };
+        return out;
+      }
       if (real.packet?.runtime) {
         live.packet = real.packet;
       }
@@ -1070,14 +1108,8 @@ export function ChatSurface({
       });
       return;
     }
-    showToast({
-      tone: "info",
-      message: _skipLiveSeed
-        ? "Live chat was not started because fresh=1 disables the run path."
-        : !isAuthenticated
-          ? "Sign in to run live research. Public memory stays available until then."
-          : "Live chat was not started. The research runtime is still preparing.",
-    });
+    // The assistant turn already renders the durable unavailable reason inline.
+    // A second toast obscured the user's prompt on mobile without adding recovery value.
   };
 
   useEffect(() => {
@@ -1307,19 +1339,32 @@ export function ChatSurface({
             placeholder="Ask anything · type / for commands"
             streaming={turns.some((t) => t.thinking || t.streaming)}
             onStop={() => {
-              setTurns((prev) => prev.map((t) =>
-                t.thinking || t.streaming
-                  ? {
-                      ...t,
-                      thinking: false,
-                      streaming: false,
-                      markdown: t.markdown
-                        ? `${t.markdown}\n\n_(stopped by user)_`
-                        : liveChatUnavailableMarkdown("Stopped before a live answer packet was available.", liveDetail),
-                      packet: t.packet,
-                    }
-                  : t,
-              ));
+              const targetTurn = [...turns].reverse().find((turn) => turn.thinking || turn.streaming);
+              if (!targetTurn) return;
+              void chatRun.cancel(targetTurn.chatRunId ?? null).then((result) => {
+                showToast({
+                  tone: result === "unavailable" ? "warning" : "info",
+                  message: result === "recorded"
+                    ? "Cancellation recorded. The active stream will abort at its next checkpoint."
+                    : result === "queued"
+                      ? "Cancellation queued. It will be applied as soon as the run is registered."
+                      : "The selected run was already terminal or unavailable.",
+                });
+                if (result === "unavailable") return;
+                setTurns((prev) => prev.map((t) =>
+                  t.id === targetTurn.id
+                    ? {
+                        ...t,
+                        thinking: false,
+                        streaming: false,
+                        markdown: t.markdown
+                          ? `${t.markdown}\n\n_(cancellation requested)_`
+                          : liveChatUnavailableMarkdown("Cancellation requested before a live answer packet was available.", liveDetail),
+                        packet: t.packet,
+                      }
+                    : t,
+                ));
+              });
             }}
           />
         </div>
@@ -2288,7 +2333,11 @@ function RuntimeBoard({ runtime }: { runtime?: ChatAnswer["runtime"] }) {
           <RuntimeMetric label="Entity" value={entity} />
           <RuntimeMetric label="Target" value={targetReport} />
           <RuntimeMetric label="Cost" value={formatUsd(metrics?.estimatedCostUsd)} />
+          <RuntimeMetric label="Tokens" value={typeof metrics?.totalTokens === "number" ? metrics.totalTokens.toLocaleString() : "pending"} />
           <RuntimeMetric label="Latency" value={formatMs(metrics?.totalLatencyMs ?? metrics?.timeToFinalMs)} />
+          <RuntimeMetric label="Model" value={metrics?.model ?? "pending"} />
+          <RuntimeMetric label="Provider" value={metrics?.provider ?? "pending"} />
+          <RuntimeMetric label="Receipt" value={compactRunId(metrics?.runtimeReceiptId) ?? "pending"} />
           <RuntimeMetric label="Memory hit" value={formatPct(metrics?.memoryHitRate)} />
           <RuntimeMetric label="Live search" value={liveGroundingDecision ? liveGroundingDecision.useLiveGrounding ? "on" : "skipped" : `${metrics?.liveSearchCalls ?? 0}`} />
         </div>


### PR DESCRIPTION
## Summary
- make redesign chat submissions idempotent, recoverable after reload, and cooperatively cancellable
- surface recorded model/provider/token/cost/receipt provenance without inference
- repair contextual FastAgent autosend across viewports, delayed runtime ownership, and failed-send manual retry
- remove duplicate mobile failure toast and tighten Chat-scoped type/edge rhythm

## Verification
- `npx tsc --noEmit --pretty false`
- `npx vitest run src/features/agents/components/FastAgentPanel` (251 passed)
- focused lifecycle/honesty tests (39 passed)
- `npm run test:design`
- `npm run lint:design` (0 high; existing repo debt remains)
- `npm run build`
- agentic-ui-qa pixel matrix: desktop/tablet/mobile, light/dark/degraded; no overflow, mojibake, or console errors
- independent P0/P1 audit: clean after fixes

No out-of-band Convex deploy was run.