### PR TITLE
fix(redesign): harden live agent chat contracts

### DIFF
--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyDeterministicResponsePolicy,
+  detectRequestedResponseShape,
+  modelForTier,
+  pricingForModel,
+  type ParsedMemo,
+} from "./chatRuns";
+
+const memo: ParsedMemo = {
+  shortAnswer: "Acme is the strongest supported claim in the current packet. [1]",
+  whyItMatters: "Its launch changes the competitive baseline.",
+  risks: ["The rollout date may change."],
+  nextAction: "Pin the strongest claim into the report.",
+};
+
+describe("redesign chat runtime response policy", () => {
+  it("uses the official stable Gemini 3.5 Flash id for paid fast and auto runs", () => {
+    expect(modelForTier("fast")).toBe("gemini-3.5-flash");
+    expect(modelForTier("auto")).toBe("gemini-3.5-flash");
+    expect(modelForTier("free")).toBe("gemini-3.1-flash-lite");
+    expect(modelForTier("deep")).toBe("gemini-3.1-pro-preview");
+    expect(pricingForModel("gemini-3.5-flash")).toEqual({ inputUsdPer1m: 1.5, outputUsdPer1m: 9 });
+  });
+
+  it("detects title-only and exact numeric or word-count bullet requests", () => {
+    expect(detectRequestedResponseShape("Return only the title.")).toEqual({ kind: "title_only" });
+    expect(detectRequestedResponseShape("Answer in exactly 3 bullets.")).toEqual({ kind: "bullets", count: 3 });
+    expect(detectRequestedResponseShape("Give me exactly four concise bullet points.")).toEqual({ kind: "bullets", count: 4 });
+    expect(detectRequestedResponseShape("Research Acme's market position.")).toEqual({ kind: "memo" });
+  });
+
+  it("returns one plain title line while omitting memo-only fields", () => {
+    const shaped = applyDeterministicResponsePolicy(
+      "Provide a title only",
+      memo,
+      [{ source: "https://example.com/acme", quote: "Acme launched a new product." }],
+    );
+
+    expect(shaped.shortAnswer).not.toContain("\n");
+    expect(shaped.shortAnswer).not.toMatch(/\[\d+\]/);
+    expect(shaped.whyItMatters).toBe("");
+    expect(shaped.risks).toEqual([]);
+    expect(shaped.nextAction).toBe("");
+  });
+
+  it("returns exactly the requested number of bullet lines", () => {
+    const shaped = applyDeterministicResponsePolicy(
+      "Answer in exactly 3 bullets",
+      memo,
+      [{ source: "https://example.com/acme", quote: "Acme launched a new product." }],
+    );
+    const bullets = shaped.shortAnswer.split("\n");
+
+    expect(bullets).toHaveLength(3);
+    expect(bullets.every((line) => line.startsWith("- "))).toBe(true);
+    expect(shaped.whyItMatters).toBe("");
+    expect(shaped.risks).toEqual([]);
+    expect(shaped.nextAction).toBe("");
+  });
+
+  it("emits a source-needed limitation and removes unsupported strength claims without a URL", () => {
+    const shaped = applyDeterministicResponsePolicy(
+      "Give me exactly two bullets",
+      memo,
+      [{ source: "cached memory", quote: "An uncited cached observation." }],
+    );
+
+    expect(shaped.shortAnswer.split("\n")).toHaveLength(2);
+    expect(shaped.shortAnswer).toContain("Source needed:");
+    expect(shaped.shortAnswer.toLowerCase()).not.toMatch(/\b(?:best|strongest)\s+(?:supported\s+)?(?:source|claim|evidence)\b/);
+
+    const defaultMemo = applyDeterministicResponsePolicy("Analyze Acme", memo, []);
+    expect(defaultMemo.risks.at(-1)).toContain("Source needed:");
+    expect(defaultMemo.nextAction).toContain("Add a supported source URL");
+    expect(defaultMemo.shortAnswer.toLowerCase()).not.toContain("strongest supported claim");
+  });
+
+  it("does not treat a blocked or unsupported URL as supporting evidence", () => {
+    for (const evidence of [
+      [{ source: "https://example.com/rejected", quote: "Rejected quote", verificationState: "unsupported" as const }],
+      [{ source: "https://example.com/blocked", quote: "Blocked quote", verificationState: "fetch_blocked" as const }],
+      [{ source: "https://example.com/blocking", quote: "Blocking quote", blocking: true }],
+    ]) {
+      const shaped = applyDeterministicResponsePolicy("Analyze Acme", memo, evidence);
+      expect(shaped.risks.at(-1)).toContain("Source needed:");
+      expect(shaped.shortAnswer.toLowerCase()).not.toContain("strongest supported claim");
+      expect(shaped.nextAction).toContain("Add a supported source URL");
+    }
+  });
+});

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -144,8 +144,6 @@ type RuntimeContextPacket = {
 
 const MAX_PROMPT_CHARS = 4_000;
 const TIMEOUT_MS = 45_000;
-const GEMINI_INPUT_USD_PER_1M_TOKENS = 0.075;
-const GEMINI_OUTPUT_USD_PER_1M_TOKENS = 0.30;
 const FALLBACK_SOURCE_TIMEOUT_MS = 12_000;
 const FALLBACK_SOURCE_LIMIT = 5;
 
@@ -224,11 +222,19 @@ function normalizeChatTier(tier: string): NormalizedChatTier {
   return "auto";
 }
 
-function modelForTier(tier: string): string {
+export function modelForTier(tier: string): string {
   const normalized = normalizeChatTier(tier);
   if (normalized === "deep") return "gemini-3.1-pro-preview";
-  if (normalized === "free") return "gemini-3.1-flash-lite-preview";
-  return "gemini-3-flash-preview";
+  if (normalized === "free") return "gemini-3.1-flash-lite";
+  return "gemini-3.5-flash";
+}
+
+export function pricingForModel(model: string): { inputUsdPer1m: number; outputUsdPer1m: number } {
+  if (model === "gemini-3.5-flash") return { inputUsdPer1m: 1.5, outputUsdPer1m: 9 };
+  if (model === "gemini-3.1-pro-preview") return { inputUsdPer1m: 2, outputUsdPer1m: 12 };
+  if (model === "gemini-3.1-flash-lite") return { inputUsdPer1m: 0.25, outputUsdPer1m: 1.5 };
+  // Unknown models must not inherit a misleading paid estimate.
+  return { inputUsdPer1m: 0, outputUsdPer1m: 0 };
 }
 
 type FallbackSourceSnippet = {
@@ -769,11 +775,167 @@ function buildBoardState(args: {
   };
 }
 
-interface ParsedMemo {
+export interface ParsedMemo {
   shortAnswer: string;
   whyItMatters: string;
   risks: string[];
   nextAction: string;
+}
+
+export type RequestedResponseShape =
+  | { kind: "memo" }
+  | { kind: "title_only" }
+  | { kind: "bullets"; count: number };
+
+const RESPONSE_COUNT_WORDS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+};
+
+const SOURCE_NEEDED_LIMITATION =
+  "Source needed: no supported URL is available, so source-strength and claim-strength comparisons are unverified.";
+
+function parseRequestedCount(value: string): number | null {
+  const count = /^\d+$/.test(value) ? Number(value) : RESPONSE_COUNT_WORDS[value.toLowerCase()];
+  return Number.isInteger(count) && count >= 1 && count <= 12 ? count : null;
+}
+
+export function detectRequestedResponseShape(prompt: string): RequestedResponseShape {
+  const normalized = prompt.replace(/\s+/g, " ").trim().toLowerCase();
+  if (
+    /\btitle[- ]only\b/.test(normalized)
+    || /\b(?:only|just) (?:give|return|output|provide|write|respond with)?\s*(?:me )?(?:a |the )?title\b/.test(normalized)
+    || /\b(?:give|return|output|provide|write|respond with) (?:me )?(?:a |the )?title only\b/.test(normalized)
+  ) {
+    return { kind: "title_only" };
+  }
+
+  const bulletMatch = normalized.match(
+    /\b(?:exactly|in|as|using|give(?: me)?|return|output|provide|write)\s+(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:concise\s+|short\s+)?(?:bullet(?:\s+points?)?|bullets)\b/,
+  );
+  const count = bulletMatch ? parseRequestedCount(bulletMatch[1]) : null;
+  return count ? { kind: "bullets", count } : { kind: "memo" };
+}
+
+function sourceUrl(source: string): string | null {
+  const match = source.match(/https?:\/\/[^\s)>\]]+/i);
+  if (!match) return null;
+  try {
+    const url = new URL(match[0].replace(/[.,;:]+$/, ""));
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeUnsupportedSuperlatives(text: string): string {
+  return text.replace(
+    /\b(?:best|strongest)\s+(?:(?:supported|grounded|available)\s+)?(?:source|claim|evidence)\b/gi,
+    "source or claim requiring verification",
+  );
+}
+
+function compactResponseUnit(text: string, stripCitations = false): string {
+  const compact = text
+    .replace(/^\s*(?:#{1,6}|[-*•]|\d+[.)])\s*/, "")
+    .replace(/^\*\*(.+?)\*\*:?$/, "$1")
+    .replace(stripCitations ? /\s*\[\d+\]/g : /$^/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return compact.replace(/[.!?]+$/, "").slice(0, 240);
+}
+
+function responseUnits(parsed: ParsedMemo, evidence: Array<{ quote?: string }>): string[] {
+  const values = [
+    parsed.shortAnswer,
+    parsed.whyItMatters,
+    ...evidence.map((row) => row.quote ?? ""),
+    ...parsed.risks,
+    parsed.nextAction,
+  ];
+  const seen = new Set<string>();
+  const units: string[] = [];
+  for (const value of values) {
+    for (const part of value.split(/\n+|(?<=[.!?])\s+/)) {
+      const unit = compactResponseUnit(part);
+      const key = unit.toLowerCase();
+      if (!unit || seen.has(key)) continue;
+      seen.add(key);
+      units.push(unit);
+    }
+  }
+  return units;
+}
+
+export function applyDeterministicResponsePolicy(
+  prompt: string,
+  parsed: ParsedMemo,
+  evidence: Array<{
+    source: string;
+    quote?: string;
+    blocking?: boolean;
+    verificationState?: EvidenceVerificationState;
+  }>,
+): ParsedMemo {
+  const hasSupportedUrl = evidence.some((row) =>
+    sourceUrl(row.source) !== null
+    && row.blocking !== true
+    && row.verificationState !== "unsupported"
+    && row.verificationState !== "fetch_blocked",
+  );
+  const honest: ParsedMemo = hasSupportedUrl
+    ? parsed
+    : {
+        shortAnswer: sanitizeUnsupportedSuperlatives(parsed.shortAnswer),
+        whyItMatters: sanitizeUnsupportedSuperlatives(parsed.whyItMatters),
+        risks: [
+          ...parsed.risks.map(sanitizeUnsupportedSuperlatives).filter((risk) => risk !== SOURCE_NEEDED_LIMITATION),
+          SOURCE_NEEDED_LIMITATION,
+        ],
+        nextAction: "Add a supported source URL before selecting or promoting any claim.",
+      };
+
+  const shape = detectRequestedResponseShape(prompt);
+  if (shape.kind === "memo") return honest;
+
+  if (shape.kind === "title_only") {
+    const title = compactResponseUnit(honest.shortAnswer || honest.whyItMatters, true) || "Evidence review";
+    return {
+      shortAnswer: hasSupportedUrl ? title : `Source needed: ${title}`.slice(0, 240),
+      whyItMatters: "",
+      risks: [],
+      nextAction: "",
+    };
+  }
+
+  const candidates = responseUnits(honest, evidence)
+    .filter((unit) => unit !== SOURCE_NEEDED_LIMITATION);
+  const bullets = hasSupportedUrl
+    ? candidates.slice(0, shape.count)
+    : candidates.slice(0, Math.max(0, shape.count - 1));
+  while (bullets.length < shape.count - (hasSupportedUrl ? 0 : 1)) {
+    bullets.push(`Additional supported detail ${bullets.length + 1} was not available in this run`);
+  }
+  if (!hasSupportedUrl) bullets.push(SOURCE_NEEDED_LIMITATION);
+  while (bullets.length < shape.count) {
+    bullets.push(`Additional supported detail ${bullets.length + 1} was not available in this run`);
+  }
+  return {
+    shortAnswer: bullets.slice(0, shape.count).map((bullet) => `- ${bullet}`).join("\n"),
+    whyItMatters: "",
+    risks: [],
+    nextAction: "",
+  };
 }
 
 function parseMemo(text: string): ParsedMemo {
@@ -799,7 +961,7 @@ function parseMemo(text: string): ParsedMemo {
   const risks = sections.risks.length > 0
     ? sections.risks.slice(0, 4)
     : ["Grounded sources may not reflect the very latest events — re-run before any irreversible action."];
-  const nextAction = sections.next[0] || "Review evidence rows; pin the strongest claim into the active report.";
+  const nextAction = sections.next[0] || "Review the evidence rows before promoting a claim into the active report.";
   return { shortAnswer, whyItMatters, risks, nextAction };
 }
 
@@ -1281,20 +1443,34 @@ export const runStreamingChat = internalAction({
       const verifiedCalculationSection = bankReconciliationFact
         ? `\n\nA server-side VERIFIED_CALCULATION is available in the context packet's "verifiedCalculation" field: ${bankReconciliationFact.fact} This arithmetic has already been computed and checked for you. State it verbatim (the exact numbers and the tie/no-tie conclusion) inside "Why it matters" instead of recomputing or restating different numbers.`
         : "";
-      const systemPrompt = `You are NodeBench's evidence-first analyst. Produce a banker-style memo. Do not include To, From, Date, or Subject headers. Use exactly these markdown section headings:
+      const requestedResponseShape = detectRequestedResponseShape(args.prompt);
+      const responseShapeInstruction = requestedResponseShape.kind === "title_only"
+        ? "The user requested a title-only response. Output exactly one plain-text title line with no heading, label, bullets, explanation, or memo sections."
+        : requestedResponseShape.kind === "bullets"
+          ? `The user requested exactly ${requestedResponseShape.count} bullets. Output exactly ${requestedResponseShape.count} Markdown bullet lines beginning with \"- \" and no heading, preamble, conclusion, or memo sections.`
+          : `Produce a banker-style memo. Do not include To, From, Date, or Subject headers. Use exactly these markdown section headings:
 1. Short answer (one sentence with citation markers like [1] [2])
 2. Why it matters (one paragraph with citation markers)
 3. Evidence (3-5 bullets, each citing a source)
 4. Risks / unknowns (2-3 bullets)
-5. Next action (one imperative sentence)
-
-Use [1], [2], [3] inline cite markers in the prose. ${liveGrounding.useLiveGrounding ? "Keep claims grounded in the web sources you retrieve. Prefer recency." : "Use only the selected memory/context packet and cached source refs; do not imply a fresh web search was performed."} If you can't find grounded evidence, say so explicitly.
-
-If the user's request involves a numeric calculation, reconciliation, balancing check, or explicitly
+5. Next action (one imperative sentence)`;
+      const citationInstruction = requestedResponseShape.kind === "title_only"
+        ? "Do not include citation markers in the title."
+        : "Use [1], [2], [3] inline cite markers when a statement has a supported source URL.";
+      const calculationInstruction = requestedResponseShape.kind === "title_only"
+        ? ""
+        : requestedResponseShape.kind === "bullets"
+          ? "If the request requires a calculation or reconciliation, include the exact derivation and pass/fail conclusion within the requested bullet count."
+          : `If the user's request involves a numeric calculation, reconciliation, balancing check, or explicitly
 asks you to "show your math" / "show your work" / confirm a total: state the actual derivation
 (the specific numbers and operation, e.g. "$X - $Y = $Z") and an explicit pass/fail confirmation
-of what they asked you to verify inside "Why it matters" — do not just assert the conclusion. This
-does not apply to ordinary research/company/market questions.
+of what they asked you to verify inside "Why it matters" - do not just assert the conclusion. This
+does not apply to ordinary research/company/market questions.`;
+      const systemPrompt = `You are NodeBench's evidence-first analyst. ${responseShapeInstruction}
+
+${citationInstruction} ${liveGrounding.useLiveGrounding ? "Keep claims grounded in the web sources you retrieve. Prefer recency." : "Use only the selected memory/context packet and cached source refs; do not imply a fresh web search was performed."} If you can't find grounded evidence, say so explicitly.
+
+${calculationInstruction}
 
 Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifiedCalculationSection}`;
       // Emit a stage event so the UI can show "Probing without [N]" / "Carrying forward N pins"
@@ -1444,7 +1620,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
       }
 
       const t4 = Date.now();
-      const parsed = parseMemo(rawText);
+      let parsed = parseMemo(rawText);
       const geminiEvidence: EvidenceRow[] = groundingChunks.slice(0, 6).map((chunk, i) => {
         const url = chunk.web?.uri ?? "";
         let host = url;
@@ -1480,6 +1656,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
       if (evidence.length > 0 && !/\[\d+\]/.test(parsed.whyItMatters)) {
         parsed.whyItMatters = `${parsed.whyItMatters} [1]`;
       }
+      parsed = applyDeterministicResponsePolicy(args.prompt, parsed, evidence);
       const tr4 = {
         step: "Bind evidence",
         detail: `${evidence.length} citations from ${groundingChunks.length} Gemini chunks + ${fallbackSources.length} fallback sources + ${memoryEvidence.length} cached sources`,
@@ -1507,9 +1684,10 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}${verifi
 
       const totalLatencyMs = Date.now() - t0;
       const totalTokens = inputTokens + outputTokens;
+      const pricing = pricingForModel(args.model);
       const estimatedCostUsd =
-        (inputTokens / 1_000_000) * GEMINI_INPUT_USD_PER_1M_TOKENS +
-        (outputTokens / 1_000_000) * GEMINI_OUTPUT_USD_PER_1M_TOKENS;
+        (inputTokens / 1_000_000) * pricing.inputUsdPer1m +
+        (outputTokens / 1_000_000) * pricing.outputUsdPer1m;
       const hash = answerHash({
         prompt: args.prompt,
         tier: args.tier,

--- a/src/features/redesign/components/UniversalComposer.test.tsx
+++ b/src/features/redesign/components/UniversalComposer.test.tsx
@@ -1,0 +1,93 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CANCEL_ARM_DELAY_MS,
+  DEFAULT_TIERS,
+  UniversalComposer,
+} from "./UniversalComposer";
+
+vi.mock("@/hooks/useVoiceInput", () => ({
+  useVoiceInput: () => ({
+    error: null,
+    isListening: false,
+    isSupported: false,
+    isTranscribing: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+describe("UniversalComposer runtime controls", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("does not let the second click of submit immediately cancel the new run", () => {
+    const onSubmit = vi.fn();
+    const onStop = vi.fn();
+    const props = {
+      contextLabel: "Market review",
+      onStop,
+      onSubmit,
+    };
+    const { rerender } = render(<UniversalComposer {...props} streaming={false} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Review the market" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run research" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // The parent flips streaming after accepting the first click. The control at
+    // the same coordinates is now Stop, but it stays inert through dblclick #2.
+    rerender(<UniversalComposer {...props} streaming />);
+    const stop = screen.getByRole("button", { name: "Cancel active run" });
+    expect(stop).toBeDisabled();
+    fireEvent.click(stop);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onStop).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(CANCEL_ARM_DELAY_MS));
+    expect(stop).toBeEnabled();
+
+    // Escape remains usable even when focus is no longer in the textarea.
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the exact paid provider and model before submission", () => {
+    render(
+      <UniversalComposer
+        contextLabel="Market review"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(DEFAULT_TIERS.find((tier) => tier.id === "auto")).toMatchObject({
+      model: "gemini-3.5-flash",
+      provider: "google-gemini",
+    });
+    expect(DEFAULT_TIERS.find((tier) => tier.id === "answer")).toMatchObject({
+      model: "gemini-3.5-flash",
+      provider: "google-gemini",
+    });
+    expect(screen.getByRole("status", { name: "Paid runtime preflight" })).toHaveTextContent(
+      "Paid live run · provider google-gemini · model gemini-3.5-flash",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Auto/ }));
+    expect(screen.getByRole("option", { name: /Quick answer/ })).toHaveTextContent(
+      "google-gemini / gemini-3.5-flash",
+    );
+    fireEvent.click(screen.getByRole("option", { name: /Deep dive/ }));
+    expect(screen.getByRole("status", { name: "Paid runtime preflight" })).toHaveTextContent(
+      "Paid live run · provider google-gemini · model gemini-3.1-pro-preview",
+    );
+  });
+});

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -24,14 +24,20 @@ export interface RouterTierOption {
   hint: string;
   estimateMs: number;
   paidCall: boolean;
+  /** Exact provider persisted by the chat runtime for this tier. */
+  provider: string;
+  /** Exact provider model id selected by the chat runtime for this tier. */
+  model: string;
 }
 
 export const DEFAULT_TIERS: RouterTierOption[] = [
-  { id: "auto",    label: "Auto",                hint: "Memory-first · NodeBench picks the right engine",  estimateMs: 1800,  paidCall: false },
-  { id: "answer",  label: "Quick answer",        hint: "Fast pass · cached sources only",                  estimateMs: 800,   paidCall: false },
-  { id: "deep",    label: "Deep dive",           hint: "Refresh sources · paid call may be required",      estimateMs: 7500,  paidCall: true  },
-  { id: "compare", label: "Compare across list", hint: "Run on every entity in this view",                 estimateMs: 12000, paidCall: true  },
+  { id: "auto",    label: "Auto",                hint: "Standard live research",            estimateMs: 1800,  paidCall: true, provider: "google-gemini", model: "gemini-3.5-flash" },
+  { id: "answer",  label: "Quick answer",        hint: "Quick live research",               estimateMs: 800,   paidCall: true, provider: "google-gemini", model: "gemini-3.5-flash" },
+  { id: "deep",    label: "Deep dive",           hint: "Deeper live research",              estimateMs: 7500,  paidCall: true, provider: "google-gemini", model: "gemini-3.1-pro-preview" },
+  { id: "compare", label: "Compare across list", hint: "Deep research across every entity", estimateMs: 12000, paidCall: true, provider: "google-gemini", model: "gemini-3.1-pro-preview" },
 ];
+
+export const CANCEL_ARM_DELAY_MS = 400;
 
 export type ComposerMode = "chat" | "research";
 
@@ -156,6 +162,7 @@ export function UniversalComposer({
   const [slashOpen, setSlashOpen] = useState(false);
   const [mentionOpen, setMentionOpen] = useState(false);
   const [mentionQuery, setMentionQuery] = useState("");
+  const [cancelArmed, setCancelArmed] = useState(false);
   const tier = tierProp ?? tierInternal;
   const setTier = (t: RouterTier) => {
     if (tierProp === undefined) setTierInternal(t);
@@ -177,6 +184,18 @@ export function UniversalComposer({
     },
   });
   const recording = voice.isListening || voice.isTranscribing;
+
+  // A submit replaces Run with Stop at the same coordinates. Delay pointer
+  // cancellation so the second click of a double-click cannot cancel the run.
+  useEffect(() => {
+    if (!streaming) {
+      setCancelArmed(false);
+      return;
+    }
+    setCancelArmed(false);
+    const timer = window.setTimeout(() => setCancelArmed(true), CANCEL_ARM_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [streaming]);
 
   useEffect(() => {
     if (!taRef.current) return;
@@ -200,17 +219,22 @@ export function UniversalComposer({
     return () => document.removeEventListener("mousedown", onClick);
   }, [tierMenuOpen, toolsMenuOpen]);
 
-  // Esc dismisses any open popover
+  // Escape remains a keyboard-complete cancel path after the same arming
+  // boundary used by the Stop button.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         setTierMenuOpen(false);
         setToolsMenuOpen(false);
+        if (streaming && cancelArmed && onStop) {
+          e.preventDefault();
+          onStop();
+        }
       }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, []);
+  }, [cancelArmed, onStop, streaming]);
 
   useEffect(() => {
     if (!voice.error) return;
@@ -229,12 +253,6 @@ export function UniversalComposer({
   };
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Esc while streaming → stop generation (highest priority)
-    if (e.key === "Escape" && streaming && onStop) {
-      e.preventDefault();
-      onStop();
-      return;
-    }
     // Esc closes any composer popover
     if (e.key === "Escape") {
       setSlashOpen(false);
@@ -437,6 +455,9 @@ export function UniversalComposer({
                       color: "var(--rd-ink-mute)",
                       lineHeight: 1.4,
                     }}>{t.hint}</span>
+                    <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>
+                      {t.provider} / {t.model}
+                    </span>
                   </button>
                 );
               })}
@@ -446,13 +467,32 @@ export function UniversalComposer({
                 marginTop: 4,
               }}>
                 <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>
-                  Provider names appear in the trace, not here.
+                  Preflight shows the requested runtime. The completed trace confirms what ran.
                 </span>
               </div>
             </div>
           )}
         </div>
       </div>
+
+      {activeTier.paidCall && (
+        <div
+          role="status"
+          aria-label="Paid runtime preflight"
+          className="rd-mono"
+          style={{
+            padding: "5px 8px",
+            border: "1px solid var(--rd-line-faint)",
+            borderRadius: 7,
+            background: "var(--rd-paper-warm)",
+            color: "var(--rd-ink-mute)",
+            fontSize: 10,
+            lineHeight: 1.4,
+          }}
+        >
+          Paid live run · provider {activeTier.provider} · model {activeTier.model}
+        </div>
+      )}
 
       {/* Textarea — focal */}
       <div
@@ -676,15 +716,20 @@ export function UniversalComposer({
           {streaming && onStop ? (
             <button
               type="button"
-              onClick={onStop}
+              onClick={() => {
+                if (cancelArmed) onStop();
+              }}
+              disabled={!cancelArmed}
               aria-label="Cancel active run"
-              title="Cancel active run (Esc)"
+              title={cancelArmed ? "Cancel active run (Esc)" : "Preparing cancel control"}
               className="rd-btn rd-btn--sm"
               style={{
                 gap: 6,
                 background: "var(--rd-amber)",
                 borderColor: "var(--rd-amber)",
                 color: "#fff",
+                opacity: cancelArmed ? 1 : 0.6,
+                cursor: cancelArmed ? "pointer" : "wait",
               }}
             >
               <svg width={11} height={11} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/src/features/redesign/pages/ReproducibleChatPage.tsx
+++ b/src/features/redesign/pages/ReproducibleChatPage.tsx
@@ -76,6 +76,12 @@ export function ReproducibleChatPage({ hash }: ReproducibleChatPageProps) {
   }, [row?.packet?.shortAnswer]);
 
   const packet: ChatAnswer | null = (row?.packet as ChatAnswer | undefined) ?? null;
+  const isCompactResponse = Boolean(
+    packet &&
+    !packet.whyItMatters?.trim() &&
+    packet.risks.length === 0 &&
+    !packet.nextAction?.trim(),
+  );
 
   const evidenceWithCites = useMemo(() => {
     if (!packet?.evidence) return [];
@@ -214,12 +220,12 @@ export function ReproducibleChatPage({ hash }: ReproducibleChatPageProps) {
           </p>
         </section>
 
-        <section>
+        {packet.whyItMatters?.trim() && <section>
           <div className="rd-eyebrow" style={{ marginBottom: 6 }}>Why useful</div>
           <p className="rd-body" style={{ color: "var(--rd-ink-mute)", margin: 0 }}>{packet.whyItMatters}</p>
-        </section>
+        </section>}
 
-        <section>
+        {!isCompactResponse && evidenceWithCites.length > 0 && <section>
           <div className="rd-eyebrow" style={{ marginBottom: 8 }}>Evidence ({evidenceWithCites.length})</div>
           <ol className="rd-stack" style={{ gap: 8, listStyle: "none", padding: 0, margin: 0 }}>
             {evidenceWithCites.map((e) => {
@@ -268,7 +274,7 @@ export function ReproducibleChatPage({ hash }: ReproducibleChatPageProps) {
               );
             })}
           </ol>
-        </section>
+        </section>}
 
         {packet.risks?.length > 0 && (
           <section>

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -12339,7 +12339,27 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .chat-trace-item-meta span:last-child { overflow-wrap: anywhere; color: var(--rd-ink-soft); }
 
 @media (max-width: 760px) {
-  [data-redesign] .rd-shell--chat-v3 .rd-pane--right.chat-context { display: none; }
+  /* Keep this selector more specific than the desktop chat grid in
+     agent-workspace.css, which is imported after this file. Persisted
+     data-wide state must never reserve an inspector column on mobile. */
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main,
+  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* Chat also carries the home shell class for shared chrome. Do not let the
+     home wide-mode gutters push the transcript and composer past the viewport. */
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child,
+  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child {
+    min-width: 0;
+    padding-inline: 0;
+  }
+
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context,
+  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context {
+    display: none;
+    width: 0;
+  }
   [data-redesign] .rd-agent-workspace-head { padding: 14px; }
   [data-redesign] .rd-agent-workspace-head__primary { align-items: flex-start; }
   [data-redesign] .rd-agent-workspace-head__scope { grid-template-columns: 1fr; }

--- a/src/features/redesign/surfaces/AgentWorkspaceResponsiveCss.guard.test.ts
+++ b/src/features/redesign/surfaces/AgentWorkspaceResponsiveCss.guard.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const primitives = readFileSync(
+  resolve(process.cwd(), "src/features/redesign/primitives.css"),
+  "utf8",
+);
+const workspaceCss = readFileSync(
+  resolve(process.cwd(), "src/features/redesign/agent-workspace.css"),
+  "utf8",
+);
+
+const selectorWeight = (selector: string) =>
+  (selector.match(/\[[^\]]+\]|\.[-_a-zA-Z0-9]+/g) ?? []).length;
+
+describe("agent workspace responsive CSS contract", () => {
+  it("out-ranks the later desktop chat grid when persisted wide mode reaches mobile", () => {
+    const desktopSelector = "[data-redesign] .rd-shell--chat-v3 .rd-shell__main";
+    const mobileWideSelector =
+      '[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main';
+    const mobileRuleStart = primitives.indexOf(
+      "[data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main,",
+    );
+    const mobileRuleEnd = primitives.indexOf(
+      "[data-redesign] .rd-agent-workspace-head { padding: 14px; }",
+      mobileRuleStart,
+    );
+
+    expect(mobileRuleStart).toBeGreaterThan(-1);
+    expect(mobileRuleEnd).toBeGreaterThan(mobileRuleStart);
+    expect(
+      primitives.lastIndexOf("@media (max-width: 760px) {", mobileRuleStart),
+    ).toBeGreaterThan(-1);
+    expect(workspaceCss).toContain(`${desktopSelector} {`);
+    expect(selectorWeight(mobileWideSelector)).toBeGreaterThan(
+      selectorWeight(desktopSelector),
+    );
+
+    const mobileChatRules = primitives.slice(mobileRuleStart, mobileRuleEnd);
+    expect(mobileChatRules).toContain(mobileWideSelector);
+    expect(mobileChatRules).toContain("grid-template-columns: minmax(0, 1fr);");
+    expect(mobileChatRules).toContain(
+      '.rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child',
+    );
+    expect(mobileChatRules).toContain("padding-inline: 0;");
+    expect(mobileChatRules).toContain(
+      '[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context',
+    );
+    expect(mobileChatRules).toContain("display: none;");
+    expect(mobileChatRules).toContain("width: 0;");
+    expect(mobileChatRules).not.toContain("!important");
+  });
+});

--- a/src/features/redesign/surfaces/ChatResponseShape.guard.test.ts
+++ b/src/features/redesign/surfaces/ChatResponseShape.guard.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("compact chat response rendering", () => {
+  it("does not re-inflate exact compact answers with empty memo sections", () => {
+    const chat = read("src/features/redesign/surfaces/ChatSurface.tsx");
+    const replay = read("src/features/redesign/pages/ReproducibleChatPage.tsx");
+
+    expect(chat).toContain("packet.whyItMatters.trim() &&");
+    expect(chat).toContain("!isCompactResponse && packet.evidence.length > 0 &&");
+    expect(chat).toContain("packet.risks.length > 0 &&");
+    expect(chat).toContain("packet.nextAction.trim() &&");
+    expect(replay).toContain("packet.whyItMatters?.trim() &&");
+    expect(replay).toContain("!isCompactResponse && evidenceWithCites.length > 0 &&");
+  });
+});

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -1982,6 +1982,10 @@ function AnswerPacket({
   const [traceOpen, setTraceOpen] = useState(false);
   const traceRef = useRef<HTMLDetailsElement | null>(null);
   const researchStages = buildResearchStages(toolCalls ?? packet.trace);
+  const isCompactResponse =
+    !packet.whyItMatters.trim() &&
+    packet.risks.length === 0 &&
+    !packet.nextAction.trim();
 
   // Wire citation interactivity: hover [N] in body → highlight matching source row in evidence list
   const handleCiteEnter = (idx: number) => setHoverCite(idx);
@@ -2103,14 +2107,16 @@ function AnswerPacket({
         </p>
       </section>
 
-      {/* Why useful */}
-      <section>
-        <div className="rd-eyebrow" style={{ marginBottom: 6 }}>Why useful</div>
-        <p className="rd-body" style={{ color: "var(--rd-ink-mute)", margin: 0 }}>{packet.whyItMatters}</p>
-      </section>
+      {/* Compact response shapes intentionally omit memo-only sections. */}
+      {packet.whyItMatters.trim() && (
+        <section>
+          <div className="rd-eyebrow" style={{ marginBottom: 6 }}>Why useful</div>
+          <p className="rd-body" style={{ color: "var(--rd-ink-mute)", margin: 0 }}>{packet.whyItMatters}</p>
+        </section>
+      )}
 
       {/* Evidence — rows highlight when matching [N] in body is hovered */}
-      <section>
+      {!isCompactResponse && packet.evidence.length > 0 && <section>
         <div className="rd-eyebrow" style={{ marginBottom: 8 }}>Evidence ({packet.evidence.length})</div>
         <ol className="rd-stack" style={{ gap: 8, listStyle: "none", padding: 0, margin: 0 }}>
           {packet.evidence.map((e) => {
@@ -2162,10 +2168,10 @@ function AnswerPacket({
             );
           })}
         </ol>
-      </section>
+      </section>}
 
       {/* Risks / unknowns */}
-      <section>
+      {packet.risks.length > 0 && <section>
         <div className="rd-eyebrow" style={{ marginBottom: 8 }}>Risks / unknowns</div>
         <ul className="rd-stack" style={{ gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
           {packet.risks.map((r, i) => (
@@ -2175,10 +2181,10 @@ function AnswerPacket({
             </li>
           ))}
         </ul>
-      </section>
+      </section>}
 
       {/* Next action */}
-      <section className="rd-card" style={{
+      {packet.nextAction.trim() && <section className="rd-card" style={{
         padding: 14,
         background: "var(--rd-accent-tint)",
         borderColor: "var(--rd-accent-ring)",
@@ -2191,7 +2197,7 @@ function AnswerPacket({
           <button type="button" className="rd-action-chip" onClick={onOpenReport}>Open {reportTitle ?? "report"}</button>
           <button type="button" className="rd-action-chip" onClick={onShare}>Export memo</button>
         </div>
-      </section>
+      </section>}
 
       {/* Trace */}
       <details ref={traceRef} open={traceOpen} onToggle={(e) => setTraceOpen((e.currentTarget as HTMLDetailsElement).open)}>


### PR DESCRIPTION
## Outcome
- route Auto and Quick live research through stable Gemini 3.5 Flash with model-aware cost receipts
- disclose the exact paid provider/model before submission and prevent double-click submit from immediately cancelling
- preserve title-only and exact bullet response shapes without losing evidence provenance
- fail closed on unsupported source-strength claims
- eliminate persisted-wide mobile inspector width and inherited home gutter clipping

## Verification
- focused response-shape, composer, and responsive Vitest guards
- npx tsc --noEmit --pretty false
- npm run test:design
- npm run lint:design
- npm run build
- 390px light/dark, 768px light/dark, and 1440px light/dark browser captures

## Release
CI-gated squash merge only. Production Gemini 3.5 Flash dogfood and receipt verification will run after deployment.