### PR TITLE
fix(redesign): preserve compact answer URLs

### DIFF
--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -4,6 +4,7 @@ import {
   applyDeterministicResponsePolicy,
   detectRequestedResponseShape,
   modelForTier,
+  parseMemo,
   pricingForModel,
   type ParsedMemo,
 } from "./chatRuns";
@@ -102,6 +103,14 @@ describe("redesign chat runtime response policy", () => {
     expect(shaped.shortAnswer).not.toContain(redirect);
     expect(shaped.shortAnswer).not.toMatch(/\[1\]/);
     expect(shaped.shortAnswer).toContain("gemini-3.5-flash");
+  });
+
+  it("does not truncate a canonical URL before compact response policy runs", () => {
+    const canonical = "https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash";
+    const parsed = parseMemo(`- ${"Production status detail ".repeat(10)}${canonical}\n- Second detail`);
+
+    expect(parsed.shortAnswer).toContain(canonical);
+    expect(parsed.shortAnswer).not.toMatch(/https:\/\/[^\s]*gemini-$/);
   });
 
   it("emits a source-needed limitation and removes unsupported strength claims without a URL", () => {

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -970,7 +970,7 @@ export function applyDeterministicResponsePolicy(
   };
 }
 
-function parseMemo(text: string): ParsedMemo {
+export function parseMemo(text: string): ParsedMemo {
   const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
   const sections: Record<string, string[]> = { short: [], why: [], evidence: [], risks: [], next: [] };
   let current: keyof typeof sections | null = null;
@@ -988,7 +988,9 @@ function parseMemo(text: string): ParsedMemo {
     if (current) sections[current].push(line.replace(/^[-*•]\s*/, ""));
   }
   const fallbackLines = lines.filter((line) => !/^\*\*(to|from|date|subject):\*\*/i.test(line));
-  const shortAnswer = sections.short.join(" ").trim() || (fallbackLines[0] ?? "").slice(0, 240);
+  // Keep enough of an unheaded compact response to preserve a complete URL.
+  // The response-shape policy applies the final presentation limit later.
+  const shortAnswer = sections.short.join(" ").trim() || (fallbackLines[0] ?? "").slice(0, 800);
   const whyItMatters = sections.why.join(" ").trim() || (fallbackLines[1] ?? "").slice(0, 480);
   const risks = sections.risks.length > 0
     ? sections.risks.slice(0, 4)


### PR DESCRIPTION
## Live finding
The third authenticated production run passed model, exact bullet count, canonical URL, no redirect, no citation marker, and compact-panel checks. It still showed a broken partial URL because the unheaded memo parser truncated the first line before response policy ran.

## Fix
- preserve up to 800 characters at the parser boundary so complete URLs reach deterministic policy
- keep final title-only and compact presentation limits in the downstream policy
- add a parser-boundary regression using a long pre-URL sentence

## Verification
- 9 focused response policy/parser tests
- npx tsc --noEmit --pretty false
- npm run build

CI-gated squash merge only. The production prompt remains unchanged for final proof.