### PR TITLE
fix(redesign): emit one canonical URL per bullet

### DIFF
--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -113,6 +113,27 @@ describe("redesign chat runtime response policy", () => {
     expect(parsed.shortAnswer).not.toMatch(/https:\/\/[^\s]*gemini-$/);
   });
 
+  it("replaces model-emitted partial URLs with exactly one canonical URL per bullet", () => {
+    const canonical = "https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash";
+    const shaped = applyDeterministicResponsePolicy(
+      `Using ${canonical}, return exactly two bullets. Each bullet must include the supported URL.`,
+      {
+        shortAnswer: "Gemini 3.5 Flash is stable (https://ai.google.dev/gemini-api/docs",
+        whyItMatters: "Production ready https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque",
+        risks: [],
+        nextAction: "",
+      },
+      [{ source: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque", quote: "Grounded." }],
+    );
+
+    for (const bullet of shaped.shortAnswer.split("\n")) {
+      expect(bullet.match(/https?:\/\//g)).toHaveLength(1);
+      expect(bullet).toContain(canonical);
+      expect(bullet).not.toContain("grounding-api-redirect");
+      expect(bullet).not.toContain("https://ai.google.dev/gemini-api/docs:");
+    }
+  });
+
   it("emits a source-needed limitation and removes unsupported strength claims without a URL", () => {
     const shaped = applyDeterministicResponsePolicy(
       "Give me exactly two bullets",

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -958,8 +958,11 @@ export function applyDeterministicResponsePolicy(
     bullets.push("The run did not return another clean supported detail; review the source directly");
   }
   const renderedBullets = bullets.slice(0, shape.count).map((bullet) =>
-    mustIncludeUrl && !bullet.includes(primarySupportedUrl)
-      ? `${bullet}: ${primarySupportedUrl}`
+    mustIncludeUrl
+      ? `${bullet
+          .replace(/\s*\(?https?:\/\/[^\s)]+\)?/gi, "")
+          .replace(/\s*[:;,]\s*$/, "")
+          .trim()}: ${primarySupportedUrl}`
       : bullet,
   );
   return {


### PR DESCRIPTION
## Persisted replay finding
The fourth live run showed the malformed partial URL was stored in the backend packet, not introduced by React. Model-emitted URL fragments cannot be trusted for an explicit canonical-URL presentation contract.

## Fix
- strip every model-emitted URL token from compact bullets when the prompt requires a URL in each bullet
- append the supported canonical requested URL exactly once per bullet
- retain provider redirects and verification state in the evidence/trace ledger
- regression covers partial canonical URL plus provider redirect and asserts one URL per bullet

## Verification
- 10 focused response policy/parser tests
- npx tsc --noEmit --pretty false
- npm run build

CI-gated squash merge only. Production acceptance remains unchanged.