### PR TITLE
fix(redesign): preserve compact answer line breaks

### DIFF
--- a/src/features/redesign/pages/ReproducibleChatPage.tsx
+++ b/src/features/redesign/pages/ReproducibleChatPage.tsx
@@ -214,6 +214,7 @@ export function ReproducibleChatPage({ hash }: ReproducibleChatPageProps) {
             lineHeight: 1.4,
             color: "var(--rd-ink-strong)",
             letterSpacing: "-0.18px",
+            whiteSpace: "pre-wrap",
             margin: 0,
           }}>
             {packet.shortAnswer}

--- a/src/features/redesign/surfaces/ChatResponseShape.guard.test.ts
+++ b/src/features/redesign/surfaces/ChatResponseShape.guard.test.ts
@@ -14,5 +14,7 @@ describe("compact chat response rendering", () => {
     expect(chat).toContain("packet.nextAction.trim() &&");
     expect(replay).toContain("packet.whyItMatters?.trim() &&");
     expect(replay).toContain("!isCompactResponse && evidenceWithCites.length > 0 &&");
+    expect(chat).toContain('whiteSpace: "pre-wrap"');
+    expect(replay).toContain('whiteSpace: "pre-wrap"');
   });
 });

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -2101,6 +2101,7 @@ function AnswerPacket({
           lineHeight: 1.4,
           color: "var(--rd-ink-strong)",
           letterSpacing: "-0.18px",
+          whiteSpace: "pre-wrap",
           margin: 0,
         }}>
           {renderInlineWithCites(packet.shortAnswer, packet.evidence, handleCiteEnter, handleCiteLeave, handleCiteContext, maskedIdx)}


### PR DESCRIPTION
## Visual production finding
The final backend/replay packet passed all text assertions, but the screenshot showed both persisted bullet lines rendered as one paragraph because normal CSS whitespace collapsed the newline.

## Fix
- render short answers with pre-wrap in live chat
- render short answers with pre-wrap in reproducible replay
- extend the compact rendering guard for both surfaces

## Verification
- focused response-shape renderer guard
- npx tsc --noEmit --pretty false
- npm run build

CI-gated squash merge only. Final proof will reload the existing production receipt; no additional paid model call is necessary.