### PR TITLE
docs: finalize UI primitive release evidence

### DIFF
--- a/CHANGELOG/components/ui-primitives.md
+++ b/CHANGELOG/components/ui-primitives.md
@@ -16,14 +16,14 @@ outside the generic primitive layer.
 The production-data browser pass also repaired a missing report-menu import and
 made both report rails key repeated display names by their runtime artifact ID.
 
-**PR / canonical main commit**: PENDING #559 MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #559 / `cd46714c`.
 
 **Evidence state**:
-- Source: pending CI-gated merge.
-- Checks: local TypeScript, 31 final migration-focused tests, 297 broader regression tests, design-system tests, design lint, and the post-repair production build passed; exact PR checks pending.
-- Visual proof: local desktop reports/menu and mobile chat captures at `.qa/evidence/2026-07-16-radix-migration/` show zero horizontal overflow and collision-safe controls; exact preview proof pending.
-- Preview: pending exact-head Vercel preview.
-- Production live: pending merge, deployment, and exact-revision verification.
+- Source: merged to `main` through CI-gated squash PR #559.
+- Checks: local TypeScript, 31 final migration-focused tests, 297 broader regression tests, design-system tests, design lint, and post-repair production build passed; required PR Typecheck, Runtime smoke, Build, Tier B, Visual QA, Vercel preflight, ScratchNode, post-deploy, and pipeline-quality checks passed on head `716817ff` (CI `29544548019`, Tier B `29544547997`, Visual QA `29544548037`).
+- Visual proof: private desktop reports/menu and 390x844 mobile chat captures at `.qa/evidence/2026-07-16-radix-migration/` show zero horizontal overflow and collision-safe controls.
+- Preview: exact-head deployment `nodebench-q3fb7mu8a-hshum2018-gmailcoms-projects.vercel.app` reached Ready and passed Tier B.
+- Production live: Vercel deployment `dpl_6cCv7ia2JLipxBm5DSfoWGoJ1SyD` reached Ready for merged SHA `cd46714c` and owns the canonical `www.nodebenchai.com` aliases; its reports route rendered five Radix rail filters, five main filters, six working menu items, zero overflow, and zero console errors.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../pages/redesign-chat.md`](../pages/redesign-chat.md), [`fast-agent-panel.md`](fast-agent-panel.md).


### PR DESCRIPTION
## What changed
Finalizes the append-only UI primitive changelog entry with PR #559's canonical squash SHA, required-check run IDs, exact-head preview, production deployment ID, canonical aliases, and verified live interaction assertions.

## Why
The release record intentionally shipped with pending placeholders until CI, merge, deployment, and exact-revision browser verification were real. This follow-up replaces those placeholders without fabricating evidence.

## Verification
- source-only changelog diff
- `git diff --cached --check` before commit
- all referenced checks and deployments were observed directly