### PR TITLE
feat: make chat the single NodeBench workspace

### DIFF
--- a/CHANGELOG/pages/redesign-chat.md
+++ b/CHANGELOG/pages/redesign-chat.md
@@ -3,6 +3,31 @@
 Append-only lane for the public redesign chat, reproducible answer receipts, and their
 transition into an authenticated live conversation. Newest entries first.
 
+## 2026-07-16 - Contract NodeBench to one decision workspace
+
+NodeBench now has one primary product surface: the runtime-backed conversation at
+`/redesign/chat`. The former Home, Reports, Inbox, Me, Workspace, mobile-shell, command
+palette, and reproducible-answer destinations no longer mount competing application
+trees. Their URLs preserve useful report, artifact, attention, settings, and receipt
+context while replacing into the same conversation and keeping the composer available.
+The old cockpit fallback is also removed from the main site: retired or unknown product
+paths now resolve to the same chat, while read-only delivery routes and the separately
+hosted Workspace keep their bounded contracts.
+Main-site report graph, notebook, cards, sources, map, and brief editor URLs now carry
+their report and artifact into chat instead of mounting another interactive workspace.
+
+The header is reduced to product identity, explicit authentication, and theme. It no
+longer duplicates the composer with global search or exposes wide mode, five peer tabs,
+or ambiguous `Continue` copy. Runtime sources, approvals, exports, follow-ups, receipts,
+provider/model metadata, usage, cost, and failure/retry states remain protected.
+
+**PR / canonical main commit**: pending CI-gated candidate.
+
+**Evidence state**: responsive before/after evidence and the protected function ledger
+remain outside git under `.qa/evidence/2026-07-16-one-surface/`.
+
+**Author**: Homen Shum + Codex.
+
 ## 2026-07-16 - Normalize structured answer typography
 
 Structured answer copy now uses the compact product reading scale instead of an oversized

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,12 @@
-import { Authenticated, Unauthenticated, useConvexAuth } from "convex/react";
+import { useConvexAuth } from "convex/react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
-import { CockpitLayout } from "./layouts/CockpitLayout";
-import { TutorialPage } from "@/features/onboarding/views/TutorialPage";
 import { useState, useEffect, useCallback, lazy, Suspense, useRef } from "react";
-import { Id } from "../convex/_generated/dataModel";
-import { ContextPillsProvider } from "./hooks/contextPills";
-import { FastAgentProvider, useFastAgent } from "@/features/agents/context/FastAgentContext";
-import { SelectionProvider } from "@/features/agents/context/SelectionContext";
-import { FeedbackListener } from "@/shared/hooks/FeedbackListener";
 import { ThemeProvider } from "./contexts/ThemeContext";
-import { OracleSessionProvider } from "./contexts/OracleSessionContext";
-import { SkipLinks } from "./shared/components/SkipLinks";
-import { EvidenceProvider } from "@/features/research/contexts/EvidenceContext";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
 import { ViewSkeleton } from "@/components/skeletons/ViewSkeleton";
 import { useWebMcpProvider } from "./hooks/useWebMcpProvider";
-import { getReportWorkspaceRouteFromPath } from "@/features/reports/lib/reportNotebookRouting";
 import type { MainView } from "@/lib/registry/viewRegistry";
-import { buildCockpitPathForView } from "@/lib/registry/viewRegistry";
 import { initErrorReporting } from "@/lib/errorReporting";
-import { FinancialOperatorOverlay } from "@/features/financialOperator/components/FinancialOperatorOverlay";
-import { WorkspaceModeToggle } from "@/features/financialOperator/components/WorkspaceModeToggle";
-import { WorkspaceModePane } from "@/features/financialOperator/components/WorkspaceModePane";
 
 const RedesignShell = lazy(() => import("@/features/redesign/RedesignShell"));
 const EditionPrintPage = lazy(() =>
@@ -48,16 +33,6 @@ const ShareableMemoView = lazy(() => import("@/features/founder/views/ShareableM
 const PublicEntityShareView = lazy(() => import("@/features/share/views/PublicEntityShareView"));
 const PublicCompanyProfileView = lazy(() => import("@/features/founder/views/PublicCompanyProfileView"));
 const PublicReportView = lazy(() => import("@/features/reports/views/PublicReportView"));
-const ReportNotebookDetail = lazy(() =>
-  import("@/features/reports/views/ReportNotebookDetail").then((m) => ({
-    default: m.ReportNotebookDetail,
-  })),
-);
-const ReportDetailPage = lazy(() =>
-  import("@/features/research/views/ReportDetailPage").then((m) => ({
-    default: m.ReportDetailPage,
-  })),
-);
 const UniversalWorkspacePage = lazy(() =>
   import("@/features/workspace/views/UniversalWorkspacePage").then((m) => ({
     default: m.UniversalWorkspacePage,
@@ -93,45 +68,8 @@ const ScratchnodePrivateBridge = lazy(() =>
 const WikiLandingRoute = lazy(() => import("@/features/me/components/wiki/WikiLandingRoute"));
 const WikiPageDetailRoute = lazy(() => import("@/features/me/components/wiki/WikiPageDetailRoute"));
 
-const FastAgentPanel = lazy(() =>
-  import("@/features/agents/components/FastAgentPanel/FastAgentPanel").then((mod) => ({
-    default: mod.FastAgentPanel,
-  })),
-);
-
-/**
- * GlobalFastAgentPanel - Renders FastAgentPanel connected to FastAgentContext.
- *
- * The cockpit shell owns the in-layout agent panel, so this global overlay only
- * appears when no external handler is registered.
- */
-function GlobalFastAgentPanel() {
-  const { isOpen, close, options, clearOptions, hasExternalHandler } = useFastAgent();
-
-  // Skip when the active shell is handling the panel directly.
-  if (hasExternalHandler) return null;
-
-  const handleClose = () => {
-    close();
-    clearOptions();
-  };
-
-  return (
-    <Suspense fallback={isOpen ? <div className="fixed inset-y-0 right-0 w-96 bg-background border-l border-border/60 flex items-center justify-center text-sm text-muted-foreground">Loading assistant...</div> : null}>
-      <FastAgentPanel
-        isOpen={isOpen}
-        onClose={handleClose}
-        variant="overlay"
-        openOptions={options}
-        onOptionsConsumed={clearOptions}
-      />
-    </Suspense>
-  );
-}
-
 function App() {
   const location = useLocation();
-  const [showTutorial, setShowTutorial] = useState(false);
 
   // Initialize global error tracking once on mount
   const errorInitRef = useRef(false);
@@ -141,14 +79,15 @@ function App() {
       initErrorReporting();
     }
   }, []);
-  const [selectedDocumentId, setSelectedDocumentId] = useState<Id<"documents"> | null>(null);
-
   // WebMCP provider — expose NodeBench tools to browser agents via navigator.modelContext
   const [webmcpEnabled] = useState(() => localStorage.getItem("nodebench_webmcp_provider_enabled") === "true");
   const { isAuthenticated: webmcpIsAuth } = useConvexAuth();
   const nav = useNavigate();
   const handleWebMcpNavigate = useCallback((view: MainView) => {
-    nav(buildCockpitPathForView({ view }));
+    const target = view === "home" || view === "ask" || view === "chat"
+      ? "/redesign/chat"
+      : `/redesign/chat?intent=${encodeURIComponent(view)}`;
+    nav(target);
   }, [nav]);
   useWebMcpProvider({
     enabled: webmcpEnabled,
@@ -157,47 +96,18 @@ function App() {
     onNavigate: handleWebMcpNavigate,
   });
 
-  // Deep link: ?doc=ID auto-opens a shared document
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const docId = params.get('doc');
-    if (docId) {
-      setSelectedDocumentId(docId as Id<"documents">);
-      setShowTutorial(false);
-    }
-  }, [location.search]);
-
-  // Any navigation away from /onboarding dismisses the tutorial
-  useEffect(() => {
-    if (location.pathname.toLowerCase().startsWith("/onboarding")) {
-      setShowTutorial(true);
-    } else {
-      setShowTutorial(false);
-    }
-  }, [location.pathname]);
-
-  const handleGetStarted = () => {
-    setShowTutorial(false);
-  };
-
-  const handleDocumentSelect = (documentId: string) => {
-    setSelectedDocumentId(documentId as Id<"documents">);
-    setShowTutorial(false);
-  };
-
   const workspaceHostname =
     typeof window !== "undefined" ? window.location.hostname.toLowerCase() : "";
   const isWorkspaceHost =
     workspaceHostname === "nodebench.workspace" ||
     workspaceHostname === "workspace.nodebenchai.com" ||
     workspaceHostname === "nodebench-workspace.vercel.app";
-  const isStandaloneWorkspaceRoute =
-    location.pathname === "/workspace" ||
-    location.pathname.startsWith("/workspace/") ||
-    (isWorkspaceHost &&
-      (location.pathname === "/" ||
-        location.pathname.startsWith("/w/") ||
-        location.pathname.startsWith("/share/")));
+  const isStandaloneWorkspaceRoute = isWorkspaceHost &&
+    (location.pathname === "/" ||
+      location.pathname === "/workspace" ||
+      location.pathname.startsWith("/workspace/") ||
+      location.pathname.startsWith("/w/") ||
+      location.pathname.startsWith("/share/"));
   if (isStandaloneWorkspaceRoute) {
     return (
       <ThemeProvider>
@@ -214,29 +124,38 @@ function App() {
 
   const rootParams = new URLSearchParams(location.search);
   const rootSurface = rootParams.get("surface");
-  // QA fix (2026-05-08): the / → /redesign redirect (PR #260) broke mobile
-  // because mobile clients lost the legacy MobileHomeSurface — which the
-  // audit (NODEBENCH_DESIGN_PRINCIPLES_AUDIT.md) explicitly called out as
-  // the closest existing thing to the Daily Intelligence Pulse vision.
-  // Detect mobile via UA + viewport so mobile / continues to render
-  // HomeLanding → MobileHomeSurface, restoring the smoke contract
-  // (live-smoke-mobile.spec.ts:35,273) without losing the redesign route
-  // for desktop users who actively prefer it.
-  const isMobileViewport = typeof window !== "undefined" && (
-    window.matchMedia?.("(max-width: 767px)").matches ||
-    /Android|iPhone|iPad|iPod|Mobile/i.test(window.navigator.userAgent)
-  );
-  const shouldUseRedesignLanding =
-    location.pathname === "/" &&
-    !isMobileViewport &&
-    (rootSurface === null || rootSurface === "home") &&
-    !rootParams.has("doc") &&
-    !rootParams.has("session") &&
-    !rootParams.has("reportId");
+  // The root is a compatibility entry point into the one decision workspace.
+  // Preserve useful legacy context while removing device-specific product trees.
+  const shouldUseRedesignLanding = location.pathname === "/";
   if (shouldUseRedesignLanding) {
+    const legacySurface = rootSurface;
     rootParams.delete("surface");
+
+    const legacyReportId = rootParams.get("reportId");
+    if (legacyReportId && !rootParams.has("report")) {
+      rootParams.set("report", legacyReportId);
+      rootParams.delete("reportId");
+    }
+
+    if (
+      legacySurface &&
+      legacySurface !== "home" &&
+      legacySurface !== "ask" &&
+      legacySurface !== "chat" &&
+      legacySurface !== "workspace"
+    ) {
+      const intent = legacySurface === "packets" || legacySurface === "reports"
+        ? "reports"
+        : legacySurface === "history" || legacySurface === "inbox"
+          ? "attention"
+          : legacySurface === "me"
+            ? "account"
+            : legacySurface;
+      rootParams.set("intent", intent);
+    }
+
     const nextSearch = rootParams.toString();
-    return <Navigate to={`/redesign${nextSearch ? `?${nextSearch}` : ""}`} replace />;
+    return <Navigate to={`/redesign/chat${nextSearch ? `?${nextSearch}` : ""}`} replace />;
   }
 
   // Phase 7c — print-friendly edition route at /redesign/edition/print.
@@ -369,72 +288,30 @@ function App() {
     );
   }
 
-  // Standalone route: /reports/:reportId/graph renders the canonical
-  // entity graph workspace. Must match BEFORE the /report/ startsWith
-  // check below (which would also match /reports/).
-  const graphRouteMatch = location.pathname.match(
-    /^\/reports\/([^/]+)\/graph\/?$/,
+  // Retired main-site report editors are context aliases, not peer surfaces.
+  // Recursive report editing remains available only on the Workspace host.
+  const reportWorkspaceRouteMatch = location.pathname.match(
+    /^\/reports\/([^/]+)(?:\/(brief|cards|notebook|sources|graph|map))?\/?$/,
   );
-  if (graphRouteMatch) {
-    return (
-      <ThemeProvider>
-        <ErrorBoundary title="Something went wrong">
-          <Suspense fallback={<ViewSkeleton />}>
-            <div
-              key={`report-graph-${graphRouteMatch[1]}`}
-              className="route-fade-in h-screen"
-            >
-              <ReportDetailPage />
-            </div>
-          </Suspense>
-        </ErrorBoundary>
-      </ThemeProvider>
-    );
+  if (reportWorkspaceRouteMatch && !isWorkspaceHost) {
+    let reportId = reportWorkspaceRouteMatch[1] ?? "";
+    try {
+      reportId = decodeURIComponent(reportId);
+    } catch {
+      // Invalid HTTP percent escapes are rejected before React in production;
+      // keep this in-memory route boundary total for tests and BrowserRouter.
+    }
+    const artifact = reportWorkspaceRouteMatch[2] === "graph"
+      ? "map"
+      : reportWorkspaceRouteMatch[2] ?? "brief";
+    const nextParams = new URLSearchParams(location.search);
+    nextParams.set("report", reportId);
+    nextParams.set("artifact", artifact);
+    nextParams.delete("tab");
+    return <Navigate to={`/redesign/chat?${nextParams.toString()}`} replace />;
   }
 
-  // without any cockpit shell — the workspace owns its own header.
-  // Lightweight web report notebook. This stays on nodebenchai.com for quick
-  // memo cleanup while full recursive work remains in Workspace.
-  const reportNotebookRouteMatch = location.pathname.match(
-    /^\/reports\/([^/]+)\/notebook\/?$/,
-  );
-  if (reportNotebookRouteMatch) {
-    return (
-      <ThemeProvider>
-        <ErrorBoundary title="Something went wrong">
-          <Suspense fallback={<ViewSkeleton />}>
-            <div
-              key={`report-notebook-${reportNotebookRouteMatch[1]}`}
-              className="route-fade-in"
-            >
-              <ReportNotebookDetail />
-            </div>
-          </Suspense>
-        </ErrorBoundary>
-      </ThemeProvider>
-    );
-  }
-
-  const reportWorkspaceRouteMatch = getReportWorkspaceRouteFromPath(
-    location.pathname,
-  );
-  if (reportWorkspaceRouteMatch) {
-    return (
-      <ThemeProvider>
-        <ErrorBoundary title="Something went wrong">
-          <Suspense fallback={<ViewSkeleton />}>
-            <div
-              key={`report-workspace-${reportWorkspaceRouteMatch.reportId}-${reportWorkspaceRouteMatch.tab}`}
-              className="route-fade-in h-screen"
-            >
-              <ReportDetailPage />
-            </div>
-          </Suspense>
-        </ErrorBoundary>
-      </ThemeProvider>
-    );
-  }
-
+  // Singular /report/:id is a bounded public delivery route for guests.
   const isReportRoute = location.pathname.startsWith("/report/");
   if (isReportRoute) {
     if (webmcpIsAuth) {
@@ -595,75 +472,11 @@ function App() {
     );
   }
 
-  return (
-    <ThemeProvider>
-      <EvidenceProvider>
-        <SkipLinks />
-        <main
-          id="main-content"
-          className="h-screen bg-surface text-content"
-          data-app-id="nodebench-ai"
-          data-app-shell="main"
-          data-agent-surface="app"
-          data-mcp-compat="webmcp chrome-devtools-mcp"
-          data-webmcp-enabled={webmcpEnabled ? "true" : "false"}
-        >
-          <FinancialOperatorOverlay />
-          <WorkspaceModeToggle />
-          <WorkspaceModePane />
-          <Unauthenticated>
-            <FastAgentProvider>
-              <SelectionProvider>
-                <OracleSessionProvider>
-                <ContextPillsProvider>
-                  <ErrorBoundary title="Something went wrong">
-                    <Suspense fallback={<ViewSkeleton />}>
-                      <CockpitLayout
-                        selectedDocumentId={null}
-                        onDocumentSelect={() => { }}
-                      />
-                    </Suspense>
-                  </ErrorBoundary>
-                  {/* Global Fast Agent Panel for guests */}
-                  <GlobalFastAgentPanel />
-                </ContextPillsProvider>
-                </OracleSessionProvider>
-              </SelectionProvider>
-            </FastAgentProvider>
-          </Unauthenticated>
-          <Authenticated>
-            <FastAgentProvider>
-              <SelectionProvider>
-                <OracleSessionProvider>
-                <ContextPillsProvider>
-                  <ErrorBoundary title="Something went wrong">
-                    <Suspense fallback={<ViewSkeleton />}>
-                      {showTutorial ? (
-                        <TutorialPage
-                          onGetStarted={handleGetStarted}
-                          onDocumentSelect={handleDocumentSelect}
-                        />
-                      ) : (
-                        <CockpitLayout
-                          selectedDocumentId={selectedDocumentId}
-                          onDocumentSelect={setSelectedDocumentId}
-                        />
-                      )}
-                    </Suspense>
-                  </ErrorBoundary>
-                  {/* Global Fast Agent Panel - controlled via context */}
-                  <GlobalFastAgentPanel />
-                  {/* Global Feedback Listener for audio/visual cues */}
-                  <FeedbackListener />
-                </ContextPillsProvider>
-                </OracleSessionProvider>
-              </SelectionProvider>
-            </FastAgentProvider>
-          </Authenticated>
-        </main>
-      </EvidenceProvider>
-    </ThemeProvider>
-  );
+  // The main site has no default cockpit. Any retired or unknown product path
+  // contracts into the same decision workspace. Purpose-built read-only
+  // delivery routes above, plus the dedicated Workspace hostname, retain their
+  // separate runtime contracts without becoming peer application surfaces.
+  return <Navigate to="/redesign/chat" replace />;
 }
 
 export default App;

--- a/src/design/designSystem.ts
+++ b/src/design/designSystem.ts
@@ -350,7 +350,7 @@ export function getNodeBenchAiDesignManifest(): AiDesignManifest {
         "no primitive drives a live stream — Convex hooks remain the data source (honesty contract)",
         "success-green is reserved for completed state and never used for selection",
         "source-merged, visual-proof-complete, and production-live-verified are distinct evidence states",
-        "web navigation remains Home - Reports - Chat - Inbox - Me; Workspace remains a separate deployed surface",
+        "NodeBench exposes one canonical decision workspace; reports, attention, settings, and receipts remain contextual states of that conversation",
       ],
     },
   };

--- a/src/features/redesign/README.md
+++ b/src/features/redesign/README.md
@@ -1,6 +1,6 @@
 # `src/features/redesign/`
 
-> Current NodeBench redesign surface mounted at `/redesign`. It is route-distinct from the ExactKit cockpit at `/?surface=...` and from ScratchNode's event room at `scratchnode.live`.
+> NodeBench's canonical decision workspace, mounted at `/redesign/chat`. Every primary NodeBench entry point resolves to this same runtime-backed conversation; saved reports, attention, settings, artifacts, and receipts are contextual states rather than peer destinations.
 >
 > Read [docs/architecture/REDESIGN_ROADMAP.md](../../../docs/architecture/REDESIGN_ROADMAP.md) for the full architecture and journey. This README is the developer-facing inventory + extension cookbook.
 >
@@ -12,16 +12,19 @@
 
 ```bash
 npm run dev
-# Open http://localhost:5200/redesign
-# Toggle the floating "Phone" FAB (bottom-right) to preview the mobile shell
-# Toggle the "◐" FAB next to it to switch light/dark mode
+# Open http://localhost:5200/redesign/chat
 ```
 
-All redesign code is scoped to `[data-redesign]`. It shares live Convex runtime primitives with the product, but route ownership is explicit: `/redesign/*` is the current redesign, `/?surface=*` is the ExactKit cockpit, and `scratchnode.live/e/:slug` is the ScratchNode event room.
+All redesign code is scoped to `[data-redesign]`. The active shell shares the live Convex runtime primitives with the product. Legacy `/redesign/*` paths preserve useful URL context, while retired or unknown main-site product paths replace into `/redesign/chat`; none mount the old cockpit. Purpose-built read-only delivery routes remain available, and Workspace stays isolated on its dedicated hostname rather than appearing as another main-site surface.
 
 ---
 
 ## File map
+
+The active runtime tree is `RedesignShell` → `TopNav` + `ChatSurface` + the conditional
+`RightInspector`. The remaining historical surface modules are retained only as
+unmounted migration references while their reusable runtime fragments are folded into
+the conversation; adding them back to `RedesignShell` violates the one-surface guard.
 
 ```
 src/features/redesign/
@@ -54,22 +57,19 @@ src/features/redesign/
 
 | Path | Renders |
 |---|---|
-| `/redesign` | HomeSurface |
-| `/redesign/reports` | ReportsSurface |
-| `/redesign/chat` | ChatSurface (with `RightInspector` Agent Runtime Inspector on desktop) |
-| `/redesign/inbox` | InboxSurface |
-| `/redesign/me` | MeSurface |
-| `/redesign/workspace` | WorkspaceSurface (6-tab — Brief default) |
+| `/redesign/chat` | The canonical `ChatSurface`, with a contextual runtime inspector after a run starts |
+| `/redesign/chat/r/:hash` | The same conversation with an immutable receipt loaded as context and the composer still available |
+| `/redesign`, `/redesign/reports/*`, `/redesign/inbox`, `/redesign/me`, `/redesign/workspace` | Context-preserving replace into `/redesign/chat` |
+| Main-site `/reports/:id` and its brief/cards/notebook/sources/graph/map tabs | Report and artifact context in `/redesign/chat`; recursive editing stays on the Workspace hostname |
+| Other retired or unknown main-site product paths | Replace into `/redesign/chat` without mounting the old cockpit |
+
+Compatibility aliases accept valid URL-encoded paths. Invalid percent-encoded HTTP
+request targets are rejected with `400` by the hosting boundary before React runs;
+NodeBench does not present those invalid targets as application deep links.
 
 Wired in [src/App.tsx](../../App.tsx) as a standalone route check before `/memo` — bypasses the cockpit entirely.
 
-Important route split:
-
-| Route | Do not confuse with |
-|---|---|
-| `/redesign/chat` | `/?surface=chat` ExactKit cockpit |
-| `/redesign/reports` | `/?surface=reports` ExactKit cockpit |
-| `scratchnode.live/e/:slug` | NodeBench redesign or cockpit routes |
+ScratchNode's `scratchnode.live/e/:slug` event room remains a separate product and runtime contract.
 
 ---
 

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -1,512 +1,113 @@
 /**
- * RedesignShell — top-level container for the /redesign showcase.
+ * RedesignShell — NodeBench's single canonical decision workspace.
  *
- * Mounts tokens.css + primitives.css, owns the URL-driven surface state,
- * lays out the rail + main + (optional) right rail.
- *
- * Routes (parsed from useLocation, no nested router needed):
- *   /redesign                  → Home
- *   /redesign/reports          → Reports
- *   /redesign/chat             → Chat
- *   /redesign/inbox            → Inbox
- *   /redesign/me               → Me
- *   /redesign/workspace[/...]  → Workspace (separate full-height surface)
+ * Every primary NodeBench entry point resolves to the same live ChatSurface.
+ * Saved reports, attention queues, settings, and reproducible receipts are
+ * contextual states of the conversation rather than competing destinations.
  */
 
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useConvexAuth } from "convex/react";
-
-import { useViewportMobile } from "@/hooks/useViewportMobile";
 
 import "./tokens.css";
 import "./primitives.css";
 import "./agent-workspace.css";
 
 import { RightInspector, type AgentRailSnapshot } from "./components/RightInspector";
-import { MobileShell } from "./components/MobileShell";
 import { TopNav } from "./components/TopNav";
-import { ReportNotebookView } from "./components/ReportNotebookView";
-import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
-import { ShortcutsOverlay } from "./components/ShortcutsOverlay";
-import {
-  HomeV2BriefingRail,
-  HomeV2EditionRail,
-  HomeV2Surface,
-  PrototypeV2Center,
-  PrototypeV2LeftRail,
-  PrototypeV2RightRail,
-  type PrototypeSurface,
-} from "./surfaces/HomeV2PrototypeSurface";
-import { ReportsSurface } from "./surfaces/ReportsSurface";
 import { ChatSurface } from "./surfaces/ChatSurface";
-import { InboxSurface } from "./surfaces/InboxSurface";
-import { MeSurface } from "./surfaces/MeSurface";
-import { WorkspaceSurface } from "./surfaces/WorkspaceSurface";
-import { ReproducibleChatPage } from "./pages/ReproducibleChatPage";
-import { useLiveArtifacts, type LiveArtifactDetail } from "./hooks/useLiveArtifacts";
-import type { ReportCardData, SurfaceId } from "./fixtures";
+import type { LiveArtifactDetail } from "./hooks/useLiveArtifacts";
 import { parseChatLaunchParams } from "./lib/chatContinuation";
+import { canonicalRedesignChatTarget, pathToChatHash } from "./lib/oneSurfaceRouting";
 
-const PATH_TO_SURFACE: Record<string, SurfaceId | "workspace"> = {
-  "": "home",
-  "/": "home",
-  "reports": "reports",
-  "chat": "chat",
-  "inbox": "inbox",
-  "me": "me",
-  "workspace": "workspace",
-};
-
-function pathToSurface(pathname: string): SurfaceId | "workspace" {
-  const rest = pathname.replace(/^\/redesign\/?/, "").split("/")[0] ?? "";
-  return (PATH_TO_SURFACE[rest] ?? "home") as SurfaceId | "workspace";
-}
-
-function pathToReportId(pathname: string): string | null {
-  // /redesign/reports/<id> → <id>
-  const match = pathname.match(/^\/redesign\/reports\/([^/]+)/);
-  return match?.[1] ?? null;
-}
-
-function pathToChatHash(pathname: string): string | null {
-  // /redesign/chat/r/<hash> → <hash> (Phase 3 reproducibility URL)
-  const match = pathname.match(/^\/redesign\/chat\/r\/([A-Za-z0-9_-]+)/);
-  return match?.[1] ?? null;
-}
-
-function normalizeEntityKey(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
-}
-
-type WorkspaceTab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
-
-function workspaceParams(search: string): { reportId?: string; tab: WorkspaceTab } {
-  const params = new URLSearchParams(search);
-  const reportId = params.get("report") || undefined;
-  const tab = params.get("tab");
-  const workspaceTab: WorkspaceTab =
-    tab === "cards" || tab === "notebook" || tab === "sources" || tab === "chat" || tab === "map"
-      ? tab
-      : "brief";
-  return { reportId, tab: workspaceTab };
+function readInitialTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.localStorage.getItem("nodebench:redesign:theme") === "dark" ? "dark" : "light";
 }
 
 export default function RedesignShell() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [theme, setTheme] = useState<"light" | "dark">("light");
-  const [forceMobile, setForceMobile] = useState(false);
-  const [wideMode, setWideMode] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem("nodebench:redesign:wide-mode") === "1";
-  });
-  // Phase 7d preserves the redesign-specific 760px phone breakpoint.
-  // The shared hook is parameterized so other call-sites (CockpitLayout,
-  // ExactKit) can opt into their own breakpoint without forking.
-  const isMobile = useViewportMobile("(max-width: 760px)") || forceMobile;
-  const showQaChrome = useQaChromeFlag(location.search);
-  const cmdk = useCommandPalette();
-
-  const surface = useMemo(() => pathToSurface(location.pathname), [location.pathname]);
-  const reportId = useMemo(() => pathToReportId(location.pathname), [location.pathname]);
-  const chatHash = useMemo(() => pathToChatHash(location.pathname), [location.pathname]);
-  const workspace = useMemo(() => workspaceParams(location.search), [location.search]);
-  const chatLaunch = useMemo(() => parseChatLaunchParams(location.search), [location.search]);
-  const focusHomeComposer = useMemo(
-    () => new URLSearchParams(location.search).get("focus") === "home-composer",
-    [location.search],
-  );
-  const isPrototypeKit = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get("qa") === "home-v2-implementation";
-  }, [location.search]);
-  // BUG FIX (2026-07-01): the "me" right rail's guestSafe used to be hardcoded to
-  // `surface === "me"`, so a fully signed-in user's own real session was always shown as
-  // "Sign in to sync" with locked stats and a dead "Connect account" button. Derive it from
-  // the real Convex auth state instead — see docs/LIVE-USER-BENCHMARK-FINDING.md.
-  const { isAuthenticated: isRedesignAuthenticated } = useConvexAuth();
-  const shellLiveArtifacts = useLiveArtifacts(24, { enabled: !isPrototypeKit });
-  const [selectedReport, setSelectedReport] = useState<ReportCardData | null>(null);
-  const [prototypeEntity, setPrototypeEntity] = useState("Anthropic");
-  const [reportsRailEntityMode, setReportsRailEntityMode] = useState(false);
+  const [theme, setTheme] = useState<"light" | "dark">(readInitialTheme);
   const [activeChatDetail, setActiveChatDetail] = useState<LiveArtifactDetail | null>(null);
   const [activeChatAgentRail, setActiveChatAgentRail] = useState<AgentRailSnapshot | null>(null);
-  const goSurface = (id: SurfaceId) => {
-    if (id !== "reports") {
-      setSelectedReport(null);
-      setReportsRailEntityMode(false);
-    }
-    const path = id === "home" ? "/redesign" : `/redesign/${id}`;
-    navigate(isPrototypeKit ? `${path}?qa=home-v2-implementation` : path);
-  };
-  const sendPromptToChat = (prompt: string, context?: { reportId?: string; artifactKey?: string }) => {
-    const params = new URLSearchParams();
-    if (isPrototypeKit) params.set("qa", "home-v2-implementation");
-    params.set("q", prompt);
-    if (context?.reportId) params.set("report", context.reportId);
-    if (context?.artifactKey) params.set("artifact", context.artifactKey);
-    const query = params.toString();
-    navigate(`/redesign/chat?${query}`);
-  };
-  const openTouchedReports = (reportId?: string) => {
-    if (reportId && !isPrototypeKit) {
-      navigate(`/redesign/reports/${encodeURIComponent(reportId)}`);
-      return;
-    }
-    navigate(isPrototypeKit ? "/redesign/reports?qa=home-v2-implementation" : "/redesign/reports");
-  };
-  const selectPrototypeRailEntity = (entity: string) => {
-    setPrototypeEntity(entity);
-    if (!isPrototypeKit && surface === "reports") {
-      setSelectedReport(null);
-      setReportsRailEntityMode(true);
-    }
-  };
-  const selectLiveReport = (report: ReportCardData | null) => {
-    setReportsRailEntityMode(false);
-    setSelectedReport(report);
-    if (report) setPrototypeEntity(report.entity);
-  };
-  const routeReport = surface === "reports" && reportId
-    ? shellLiveArtifacts.reports.find((report) => report.id === reportId) ?? null
-    : null;
-  const selectedRailReport =
-    surface === "reports" && !reportsRailEntityMode
-      ? routeReport ??
-        (selectedReport && normalizeEntityKey(selectedReport.entity) === normalizeEntityKey(prototypeEntity)
-          ? selectedReport
-          : null)
-      : null;
 
-  // Optionally lock body scroll while shell is mounted
+  const canonicalTarget = useMemo(
+    () => canonicalRedesignChatTarget(location.pathname, location.search),
+    [location.pathname, location.search],
+  );
+  const chatLaunch = useMemo(() => parseChatLaunchParams(location.search), [location.search]);
+  const routeChatHash = useMemo(() => pathToChatHash(location.pathname), [location.pathname]);
+  const continuationHash = chatLaunch.continuationHash ?? routeChatHash ?? undefined;
+  const showChatInspector = Boolean(activeChatAgentRail?.hasIntent);
+
   useEffect(() => {
-    const prev = document.body.style.overflow;
+    if (canonicalTarget) navigate(canonicalTarget, { replace: true });
+  }, [canonicalTarget, navigate]);
+
+  useEffect(() => {
+    const previous = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = prev;
+      document.body.style.overflow = previous;
     };
   }, []);
 
   useEffect(() => {
-    window.localStorage.setItem("nodebench:redesign:wide-mode", wideMode ? "1" : "0");
-  }, [wideMode]);
-
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-      if (event.key.toLowerCase() !== "w") return;
-      const target = event.target as HTMLElement | null;
-      if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable) return;
-      event.preventDefault();
-      setWideMode((current) => !current);
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
-
-  // Phase 7d (2026-05-08): editorial is the default at /redesign on
-  // both mobile + desktop.  Legacy is opt-out via `?classic=1`
-  // (canonical) or `?edition=0` (back-compat).  Per
-  // docs/architecture/HOME_EDITORIAL_REDESIGN.md §3 Variant C
-  // ("mobile and desktop are identical"), the editorial single-column
-  // layout bypasses MobileShell at the home surface so it stays
-  // responsive at any width.
-  const isEditionFlag =
-    typeof window === "undefined" ||
-    (() => {
-      const params = new URLSearchParams(location.search);
-      if (params.get("classic") === "1") return false;
-      if (params.get("edition") === "0") return false;
-      return true;
-    })();
-
-  // Chat keeps the canonical runtime-backed workspace at every breakpoint.
-  // The former MobileShell chat was a separate static tree with no submit/run
-  // contract, so it could not honestly represent or continue an agent run.
-  if (isMobile && surface !== "workspace" && surface !== "chat" && !isPrototypeKit) {
-    const mobileSurface: SurfaceId = (surface === "workspace" ? "reports" : surface) as SurfaceId;
-    // Edition flag bypasses MobileShell at the home surface so the
-    // single-column editorial layout stays responsive at any width.
-    if (isEditionFlag && mobileSurface === "home") {
-      return (
-        <div data-redesign data-redesign-theme={theme} style={{ minHeight: "100dvh", overflow: "auto" }}>
-          <HomeV2Surface
-            onAsk={sendPromptToChat}
-            onOpenReports={openTouchedReports}
-            liveArtifacts={shellLiveArtifacts}
-            focusComposer={focusHomeComposer}
-          />
-          {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
-          {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
-          <NavBanner pathname={location.pathname} />
-          <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
-          <ShortcutsOverlay />
-        </div>
-      );
-    }
-    return (
-      <div data-redesign data-redesign-theme={theme} style={{ height: "100dvh", overflow: "hidden" }}>
-        <MobileShell active={mobileSurface} onChange={(id) => goSurface(id)} />
-        {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
-        {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
-        <NavBanner pathname={location.pathname} />
-        <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
-        <ShortcutsOverlay />
-      </div>
-    );
-  }
-
-  if (surface === "workspace") {
-    return (
-      <div data-redesign data-redesign-theme={theme} style={{ height: "100vh", overflow: "hidden" }}>
-        <main id="main-content" data-main-content className="rd-pane rd-workspace-standalone">
-          <WorkspaceSurface reportId={workspace.reportId} initialTab={workspace.tab} />
-        </main>
-        {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
-        <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
-        <ShortcutsOverlay />
-      </div>
-    );
-  }
-
-  // Phase 3 chat hashes and report detail pages own the full width. Other
-  // desktop surfaces keep a right-side agent rail so the center can stay calm.
-  const prototypeSurface = surface as PrototypeSurface;
-  const isHomeV2 = surface === "home" || isPrototypeKit;
-  const usesV2Canvas =
-    surface === "home" ||
-    surface === "reports" ||
-    surface === "chat" ||
-    surface === "inbox" ||
-    surface === "me" ||
-    isPrototypeKit;
-  const suppressRightRail =
-    !isPrototypeKit &&
-    surface === "chat" &&
-    Boolean(chatHash);
-  const showChatInspector = surface === "chat" && Boolean(activeChatAgentRail?.hasIntent);
+    window.localStorage.setItem("nodebench:redesign:theme", theme);
+  }, [theme]);
 
   return (
     <div
       data-redesign
       data-redesign-theme={theme}
-      data-wide={wideMode ? "true" : undefined}
+      data-product-surface="decision-workspace"
       style={{
-        height: "100vh",
+        height: "100dvh",
         overflow: "hidden",
         display: "flex",
         flexDirection: "column",
       }}
     >
       <TopNav
-        active={surface as SurfaceId}
-        onChange={(id) => goSurface(id)}
-        onOpenPalette={() => cmdk.setOpen(true)}
         theme={theme}
-        onToggleTheme={() => setTheme(theme === "light" ? "dark" : "light")}
-        wideMode={wideMode}
-        onToggleWideMode={() => setWideMode((current) => !current)}
-        prototypeMode={isPrototypeKit}
+        onToggleTheme={() => setTheme((current) => current === "light" ? "dark" : "light")}
       />
+
       <div
-        className={`rd-shell ${usesV2Canvas ? "rd-shell--home-v2" : ""} ${surface === "chat" && !isPrototypeKit ? "rd-shell--chat-v3 rd-shell--chat-focus" : ""} ${surface === "chat" && !showChatInspector ? "rd-shell--chat-no-inspector" : ""} ${surface === "reports" ? "rd-shell--reports-v3" : ""} ${suppressRightRail ? "rd-shell--single" : ""}`}
+        className={`rd-shell rd-shell--home-v2 rd-shell--chat-v3 rd-shell--chat-focus ${showChatInspector ? "" : "rd-shell--chat-no-inspector"}`}
         style={{ flex: 1, minHeight: 0 }}
       >
-        {surface === "chat" && !isPrototypeKit ? null : isPrototypeKit ? (
-          <PrototypeV2LeftRail
-            surface={prototypeSurface}
-            selectedEntity={prototypeEntity}
-            onSelectEntity={setPrototypeEntity}
-          />
-        ) : isHomeV2 ? (
-          <HomeV2EditionRail liveArtifacts={shellLiveArtifacts} onAsk={sendPromptToChat} />
-        ) : (
-          <PrototypeV2LeftRail
-            surface={prototypeSurface}
-            selectedEntity={prototypeEntity}
-            onSelectEntity={selectPrototypeRailEntity}
-            guestSafe={surface === "me" && !isRedesignAuthenticated}
-            liveArtifacts={shellLiveArtifacts}
-          />
-        )}
-
-        {suppressRightRail ? (
-          <main id="main-content" data-main-content className="rd-pane" style={{ borderRight: "none" }}>
-            {surface === "chat" && chatHash && <ReproducibleChatPage hash={chatHash} />}
-            {surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
+        <div className="rd-shell__main">
+          <main id="main-content" data-main-content className="rd-pane">
+            <div className="rd-surface-content" data-testid="one-surface-workspace">
+              <ChatSurface
+                initialPrompt={chatLaunch.prompt}
+                continuationHash={continuationHash}
+                onActiveContextChange={setActiveChatDetail}
+                onAgentRailChange={setActiveChatAgentRail}
+              />
+            </div>
           </main>
-        ) : (
-          <div className="rd-shell__main">
-            <main id="main-content" data-main-content className="rd-pane">
-              {/* Keyed wrapper forces React to remount on surface change,
-                  triggering the rd-surface-enter CSS animation reliably. */}
-              <div key={isPrototypeKit ? `proto-${prototypeSurface}` : `${surface}${reportId ? `-${reportId}` : ""}`} className="rd-surface-content">
-              {isPrototypeKit && (
-                <PrototypeV2Center
-                  surface={prototypeSurface}
-                  onAsk={sendPromptToChat}
-                  selectedEntity={prototypeEntity}
-                  onSelectEntity={setPrototypeEntity}
-                />
-              )}
-              {!isPrototypeKit && surface === "chat" && (
-                <ChatSurface
-                  initialPrompt={chatLaunch.prompt}
-                  continuationHash={chatLaunch.continuationHash}
-                  onActiveContextChange={setActiveChatDetail}
-                  onAgentRailChange={setActiveChatAgentRail}
-                />
-              )}
-              {!isPrototypeKit && surface === "home" && (
-                <HomeV2Surface
-                  onAsk={sendPromptToChat}
-                  onOpenReports={openTouchedReports}
-                  liveArtifacts={shellLiveArtifacts}
-                  focusComposer={focusHomeComposer}
-                />
-              )}
-            {!isPrototypeKit && surface === "reports" && !reportId && (
-              <ReportsSurface
-                onOpen={(id, tab) => {
-                  if (tab === "brief") navigate(`/redesign/reports/${id}`);
-                  else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
-                }}
-                inspectedReportId={reportsRailEntityMode ? "__rail_entity_override__" : selectedReport?.id ?? null}
-                onSelectReport={selectLiveReport}
-                onRunBatch={sendPromptToChat}
-              />
-            )}
-            {!isPrototypeKit && surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
-            {!isPrototypeKit && surface === "inbox" && <InboxSurface />}
-            {!isPrototypeKit && surface === "me" && <MeSurface />}
-              </div>
-            </main>
-            {isPrototypeKit ? (
-              <PrototypeV2RightRail
-                surface={prototypeSurface}
-                onAsk={sendPromptToChat}
-                selectedEntity={prototypeEntity}
-                onSelectEntity={setPrototypeEntity}
-              />
-            ) : surface === "home" ? (
-              <HomeV2BriefingRail
-                onAsk={sendPromptToChat}
-                onOpenReports={openTouchedReports}
-                liveArtifacts={shellLiveArtifacts}
-              />
-            ) : surface === "chat" && showChatInspector ? (
-              <RightInspector
-                activeLiveArtifactDetail={activeChatDetail ?? undefined}
-                agentSnapshot={activeChatAgentRail}
-              />
-            ) : surface === "chat" ? (
-              null
-            ) : (
-              <PrototypeV2RightRail
-                surface={prototypeSurface}
-                onAsk={sendPromptToChat}
-                selectedEntity={surface === "reports" ? prototypeEntity : undefined}
-                selectedReport={selectedRailReport}
-                onSelectEntity={selectPrototypeRailEntity}
-                guestSafe={surface === "me" && !isRedesignAuthenticated}
-                liveArtifacts={shellLiveArtifacts}
-              />
-            )}
-          </div>
-        )}
+
+          {showChatInspector && (
+            <RightInspector
+              activeLiveArtifactDetail={activeChatDetail ?? undefined}
+              agentSnapshot={activeChatAgentRail}
+            />
+          )}
+        </div>
       </div>
 
-      {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
-      {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
-      <NavBanner pathname={location.pathname} />
-
-      {/* Cross-surface primitives — Cmd+K palette, ? shortcuts, toasts */}
-      <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
-      <ShortcutsOverlay />
-    </div>
-  );
-}
-
-function ReportDetailRoute({ reportId }: { reportId: string }) {
-  const liveArtifacts = useLiveArtifacts(60);
-  const liveDetail = liveArtifacts.details.find((detail) => detail.id === reportId);
-  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar={false} />;
-}
-
-function useQaChromeFlag(search: string): boolean {
-  return useMemo(() => {
-    const params = new URLSearchParams(search);
-    if (params.get("qaChrome") === "1" || params.get("debugUi") === "1") return true;
-    try {
-      return window.localStorage.getItem("nodebench-redesign-qa-chrome") === "1";
-    } catch {
-      return false;
-    }
-  }, [search]);
-}
-
-function ViewportFab({ forceMobile, setForceMobile }: { forceMobile: boolean; setForceMobile: (v: boolean) => void }) {
-  return (
-    <button
-      type="button"
-      onClick={() => setForceMobile(!forceMobile)}
-      aria-label="Toggle mobile preview"
-      title={forceMobile ? "Switch to desktop view" : "Preview on phone"}
-      className="rd-btn rd-btn--ghost"
-      style={{
-        position: "fixed",
-        bottom: 18,
-        right: 64,
-        height: 36,
-        padding: "0 12px",
-        borderRadius: "var(--rd-r-pill)",
-        boxShadow: "var(--rd-shadow-md)",
-        zIndex: 50,
-        fontSize: 11,
-        fontWeight: 590,
-      }}
-    >
-      {forceMobile ? "Desktop" : "Phone"}
-    </button>
-  );
-}
-
-function ThemeFab({ theme, setTheme }: { theme: "light" | "dark"; setTheme: (t: "light" | "dark") => void }) {
-  return (
-    <button
-      type="button"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-      aria-label="Toggle theme"
-      title="Toggle light / dark"
-      className="rd-btn rd-btn--ghost"
-      style={{
-        position: "fixed",
-        bottom: 18,
-        right: 18,
-        width: 36,
-        height: 36,
-        padding: 0,
-        borderRadius: "50%",
-        boxShadow: "var(--rd-shadow-md)",
-        zIndex: 50,
-      }}
-    >
-      {theme === "light" ? "◐" : "◑"}
-    </button>
-  );
-}
-
-function NavBanner({ pathname }: { pathname: string }) {
-  // Visual signal: which redesign surface is mounted (in-DOM signal for live verification)
-  return (
-    <div
-      data-testid="redesign-active"
-      data-redesign-surface={pathname}
-      style={{ position: "absolute", left: -9999, top: -9999, opacity: 0 }}
-      aria-hidden="true"
-    >
-      NodeBench redesign · {pathname}
+      <div
+        data-testid="redesign-active"
+        data-redesign-surface="/redesign/chat"
+        data-legacy-entry={location.pathname === "/redesign/chat" ? undefined : location.pathname}
+        style={{ position: "absolute", left: -9999, top: -9999, opacity: 0 }}
+        aria-hidden="true"
+      >
+        NodeBench decision workspace · /redesign/chat
+      </div>
     </div>
   );
 }

--- a/src/features/redesign/agent-workspace.css
+++ b/src/features/redesign/agent-workspace.css
@@ -5,16 +5,11 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
-[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-focus {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 [data-redesign] .rd-shell--chat-v3 .rd-shell__main {
   grid-template-columns: minmax(0, 1fr) 320px;
 }
 
-[data-redesign] .rd-shell--chat-v3.rd-shell--chat-no-inspector .rd-shell__main,
-[data-redesign][data-wide="true"] .rd-shell--chat-v3.rd-shell--chat-no-inspector .rd-shell__main {
+[data-redesign] .rd-shell--chat-v3.rd-shell--chat-no-inspector .rd-shell__main {
   grid-template-columns: minmax(0, 1fr);
 }
 
@@ -140,6 +135,60 @@
   margin: 0 auto;
 }
 
+.rd-account-trigger {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-family: var(--rd-font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.rd-account-trigger:focus-visible {
+  outline: 2px solid var(--rd-accent);
+  outline-offset: 2px;
+}
+
+.rd-account-menu {
+  min-width: 170px;
+  border-color: var(--rd-line);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  font-family: var(--rd-font-sans);
+}
+
+[data-redesign] .rd-launch-context {
+  display: grid;
+  gap: 4px;
+  width: min(100%, 840px);
+  margin: 0 auto 12px;
+  padding: 11px 13px;
+  border: 1px solid var(--rd-line-faint);
+  border-left: 2px solid var(--rd-accent);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-paper-warm);
+}
+
+[data-redesign] .rd-launch-context strong {
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-launch-context p {
+  margin: 0;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 [data-redesign] .rd-run-scope {
   margin: 0 4px 8px;
   color: var(--rd-ink-mute);
@@ -247,9 +296,19 @@
     gap: 8px;
   }
 
-  [data-redesign] .rd-run-scope > summary span:nth-of-type(2),
+  [data-redesign] .rd-run-scope > summary span:nth-of-type(2) {
+    display: block;
+    min-width: 0;
+    flex: 1;
+    max-width: none;
+  }
+
   [data-redesign] .rd-run-scope > summary span:nth-of-type(3) {
     display: none;
+  }
+
+  [data-redesign] .rd-run-scope > summary span:nth-of-type(4) {
+    flex: 0 0 auto;
   }
 
   [data-redesign] .rd-chat-transcript__content {

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -185,7 +185,7 @@ function SessionContextPanel({ snapshot }: { snapshot: AgentRailSnapshot }) {
 
       {contract.reviewHref && (
         <div className="chat-run-handoff">
-          <a href={contract.reviewHref}>Open review workspace <span aria-hidden="true">→</span></a>
+          <a href={contract.reviewHref}>Review sources here <span aria-hidden="true">→</span></a>
           <small>Inspect sources and proposed changes before any shared write.</small>
         </div>
       )}
@@ -426,8 +426,8 @@ function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLo
     ],
     artifacts: hasDetail
       ? [
-          { id: "artifact", label: detail.title, status: "done", detail: detail.kind, href: `/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=brief` },
-          { id: "notebook", label: "Notebook handoff", status: detail.notebookHtml ? "done" : "queued", detail: detail.notebookHtml ? "Draft available" : "No notebook draft yet", href: `/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=notebook` },
+          { id: "artifact", label: detail.title, status: "done", detail: detail.kind, href: `/redesign/chat?report=${encodeURIComponent(detail.id)}&artifact=brief` },
+          { id: "notebook", label: "Notebook handoff", status: detail.notebookHtml ? "done" : "queued", detail: detail.notebookHtml ? "Draft available" : "No notebook draft yet", href: `/redesign/chat?report=${encodeURIComponent(detail.id)}&artifact=notebook` },
         ]
       : [{ id: "empty", label: "No artifacts yet", status: "queued", detail: "Start with a question, source, or report." }],
     backgroundAgents: [
@@ -623,10 +623,10 @@ function GraphPanel({ detail, nodes }: { detail?: LiveArtifactDetail; nodes: Arr
         {detail ? (
           <a
             className="rd-btn rd-btn--quiet rd-btn--sm"
-            href={`/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=map`}
+            href={`/redesign/chat?report=${encodeURIComponent(detail.id)}&artifact=map`}
             style={{ padding: "1px 6px", fontSize: 10, textDecoration: "none" }}
           >
-            Open Map
+            Use map context
           </a>
         ) : (
           <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>No map yet</span>
@@ -705,17 +705,17 @@ function ThreadsPanel({ detail }: { detail?: LiveArtifactDetail }) {
     {
       title: detail ? `Review ${detail.kind.toLowerCase()} claims` : "Start a research thread",
       when: detail?.updatedAt ?? "now",
-      href: detail ? `/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=chat` : "/redesign/chat",
+      href: detail ? `/redesign/chat?report=${encodeURIComponent(detail.id)}` : "/redesign/chat",
     },
     {
-      title: detail ? "Open notebook handoff" : "Attach sources",
+      title: detail ? "Use notebook context" : "Attach sources",
       when: "next",
-      href: detail ? `/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=notebook` : "/redesign/workspace?tab=sources",
+      href: detail ? `/redesign/chat?report=${encodeURIComponent(detail.id)}&artifact=notebook` : "/redesign/chat?intent=sources",
     },
     {
-      title: detail ? "Export reusable memory" : "Create report",
+      title: detail ? "Use brief context" : "Find saved research",
       when: "later",
-      href: detail ? `/redesign/workspace?report=${encodeURIComponent(detail.id)}&tab=brief` : "/redesign/reports",
+      href: detail ? `/redesign/chat?report=${encodeURIComponent(detail.id)}&artifact=brief` : "/redesign/chat?intent=reports",
     },
   ];
 

--- a/src/features/redesign/components/TopNav.test.tsx
+++ b/src/features/redesign/components/TopNav.test.tsx
@@ -1,111 +1,64 @@
-/**
- * TopNav — unified top horizontal navigation scenarios.
- *
- * Scenario: Returning user navigating /redesign expects parity with cockpit
- *
- * Who:     A returning NodeBench user who has been working in the main
- *          cockpit (which has a sticky top horizontal nav: brand · 5 tabs
- *          · search · theme · profile).  They land on /redesign and
- *          expect the same affordances — without leaving the redesign's
- *          editorial token system.
- * What:    They expect to see (a) the brand mark, (b) all 5 surface tabs
- *          with the active one highlighted, (c) a search chip with the
- *          Ctrl K keyboard hint, (d) a theme toggle, (e) a profile/sign-in
- *          slot.  They expect aria-current on the active tab and Alt+1..5
- *          to jump between surfaces.
- * Scale:   Single-component render.  At production scale this nav
- *          mounts on every desktop /redesign view that isn't the
- *          standalone workspace; correctness here is rendered on
- *          every page load.
- * Duration: Short-running.  No state accumulation.
- * Failure mode covered: missing tab, wrong active state, missing Ctrl K
- *          shortcut chip, palette-trigger callback silently dropped.
- */
-import { describe, expect, it, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+
 import { TopNav } from "./TopNav";
 
-// The TopNav reaches into Convex auth (account CTA + auth state).
-// In the test environment we stub these to a deterministic guest state.
+const authMocks = vi.hoisted(() => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  state: { isAuthenticated: false, isLoading: false },
+}));
+
 vi.mock("@convex-dev/auth/react", () => ({
-  useAuthActions: () => ({ signIn: vi.fn() }),
+  useAuthActions: () => ({ signIn: authMocks.signIn, signOut: authMocks.signOut }),
 }));
 
 vi.mock("convex/react", () => ({
-  useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
+  useConvexAuth: () => authMocks.state,
 }));
 
-function renderTopNav(overrides: Partial<React.ComponentProps<typeof TopNav>> = {}) {
-  const props: React.ComponentProps<typeof TopNav> = {
-    active: "home",
-    onChange: vi.fn(),
-    onOpenPalette: vi.fn(),
-    theme: "light",
-    onToggleTheme: vi.fn(),
-    ...overrides,
-  };
-  const utils = render(
-    <MemoryRouter>
-      <div data-redesign data-redesign-theme="light">
-        <TopNav {...props} />
-      </div>
-    </MemoryRouter>,
-  );
-  return { ...utils, props };
-}
-
-describe("TopNav — unified top horizontal nav (Bug 2)", () => {
-  it("renders all 5 primary nav items in order", () => {
-    const { getByRole } = renderTopNav();
-    const nav = getByRole("navigation", { name: /primary navigation/i });
-    const tabs = nav.querySelectorAll("button");
-    expect(tabs.length).toBe(5);
-    expect(Array.from(tabs).map((b) => b.textContent?.trim())).toEqual([
-      "Home",
-      "Reports",
-      "Chat",
-      "Inbox",
-      "Me",
-    ]);
+describe("TopNav — single-surface header", () => {
+  beforeEach(() => {
+    authMocks.signIn.mockReset();
+    authMocks.signOut.mockReset();
+    authMocks.state.isAuthenticated = false;
+    authMocks.state.isLoading = false;
   });
 
-  it("marks the active item with aria-current=page", () => {
-    const { getByRole } = renderTopNav({ active: "reports" });
-    const nav = getByRole("navigation", { name: /primary navigation/i });
-    const current = nav.querySelectorAll('[aria-current="page"]');
-    expect(current.length).toBe(1);
-    expect(current[0].textContent?.trim()).toBe("Reports");
-  });
-
-  it("exposes the Ctrl K shortcut chip on the search button", () => {
-    const { container } = renderTopNav();
-    const searchBtn = container.querySelector(
-      "[data-rd-topnav-search]",
-    ) as HTMLButtonElement | null;
-    expect(searchBtn).not.toBeNull();
-    expect(searchBtn?.getAttribute("aria-keyshortcuts")).toMatch(/K/);
-    const kbd = container.querySelector("[data-rd-topnav-kbd]");
-    expect(kbd?.textContent?.trim()).toBe("Ctrl K");
-  });
-
-  it("invokes onOpenPalette when the search button is clicked", () => {
-    const { container, props } = renderTopNav();
-    const searchBtn = container.querySelector(
-      "[data-rd-topnav-search]",
-    ) as HTMLButtonElement;
-    fireEvent.click(searchBtn);
-    expect(props.onOpenPalette).toHaveBeenCalledTimes(1);
-  });
-
-  it("invokes onChange when a tab is clicked", () => {
-    const { getByRole, props } = renderTopNav();
-    const nav = getByRole("navigation", { name: /primary navigation/i });
-    const inboxTab = Array.from(nav.querySelectorAll("button")).find(
-      (b) => b.textContent?.trim() === "Inbox",
+  it("keeps identity and utilities without advertising another product surface", () => {
+    const { getByRole, getByText, queryByRole, queryByText } = render(
+      <TopNav theme="light" onToggleTheme={vi.fn()} />,
     );
-    expect(inboxTab).toBeDefined();
-    fireEvent.click(inboxTab!);
-    expect(props.onChange).toHaveBeenCalledWith("inbox");
+
+    expect(getByRole("banner")).toBeTruthy();
+    expect(getByRole("link", { name: "NodeBench decision workspace" })).toHaveAttribute("href", "/redesign/chat");
+    expect(getByText("Decision workspace")).toBeTruthy();
+    expect(getByRole("button", { name: "Sign in" })).toBeTruthy();
+    expect(getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+    expect(queryByRole("navigation")).toBeNull();
+    expect(queryByText("Home")).toBeNull();
+    expect(queryByText("Reports")).toBeNull();
+    expect(queryByText("Inbox")).toBeNull();
+    expect(queryByText("Me")).toBeNull();
+  });
+
+  it("keeps theme switching explicit and keyboard reachable", () => {
+    const onToggleTheme = vi.fn();
+    const { getByRole } = render(<TopNav theme="light" onToggleTheme={onToggleTheme} />);
+    fireEvent.click(getByRole("button", { name: "Switch to dark mode" }));
+    expect(onToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels authentication honestly", () => {
+    const { getByRole } = render(<TopNav theme="light" onToggleTheme={vi.fn()} />);
+    fireEvent.click(getByRole("button", { name: "Sign in" }));
+    expect(authMocks.signIn).toHaveBeenCalledWith("google", expect.objectContaining({ redirectTo: expect.any(String) }));
+  });
+
+  it("gives signed-in users a keyboard-reachable account menu", () => {
+    authMocks.state.isAuthenticated = true;
+    const { getByRole } = render(<TopNav theme="light" onToggleTheme={vi.fn()} />);
+
+    expect(getByRole("button", { name: "Account menu" })).toHaveAttribute("aria-haspopup", "menu");
   });
 });

--- a/src/features/redesign/components/TopNav.tsx
+++ b/src/features/redesign/components/TopNav.tsx
@@ -1,295 +1,127 @@
 /**
- * TopNav — unified top horizontal bar for /redesign.
- *
- * Mirrors the affordances of src/layouts/ProductTopNav.tsx (the cockpit's
- * top nav) but lives in the redesign token namespace (--rd-*) so it does
- * not pull cockpit Tailwind classes into the isolated shell.
- *
- * Slots:
- *   left   — brand mark `N` + "NodeBench AI" wordmark, links to /redesign
- *   center — 5 nav tabs (Home / Reports / Chat / Inbox / Me) with active
- *            state, aria-current, Alt+1..Alt+5 shortcuts
- *   right  — search button (opens CommandPalette via passed callback)
- *            + theme toggle + profile chip (initials / "Sign in")
- *
- * A11y:
- *   - <header><nav aria-label="Primary navigation">
- *   - aria-current="page" on active tab
- *   - aria-keyshortcuts on each tab ("Alt+N")
- *   - Focus rings via existing rd-btn :focus-visible
- *   - Respects prefers-reduced-motion (no transitions added beyond the
- *     token-scoped defaults)
- *
- * Mounted in: RedesignShell.tsx (above the rd-shell grid on desktop;
- * not mounted on mobile — MobileShell already owns its own top bar).
+ * The single-surface header intentionally contains no product navigation.
+ * The composer is NodeBench's only command surface; the header retains only
+ * identity, explicit authentication, and theme preference.
  */
 
-import { useEffect, useMemo } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useConvexAuth } from "convex/react";
-import type { SurfaceId } from "../fixtures";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ai-ui/dropdown-menu";
 
 interface TopNavProps {
-  active: SurfaceId;
-  onChange: (id: SurfaceId) => void;
-  onOpenPalette: () => void;
   theme: "light" | "dark";
   onToggleTheme: () => void;
-  wideMode?: boolean;
-  onToggleWideMode?: () => void;
-  prototypeMode?: boolean;
 }
 
-interface NavItem {
-  id: SurfaceId;
-  label: string;
-  /** 1-based slot for Alt+N keyboard shortcut. */
-  slot: 1 | 2 | 3 | 4 | 5;
-}
-
-const NAV: NavItem[] = [
-  { id: "home", label: "Home", slot: 1 },
-  { id: "reports", label: "Reports", slot: 2 },
-  { id: "chat", label: "Chat", slot: 3 },
-  { id: "inbox", label: "Inbox", slot: 4 },
-  { id: "me", label: "Me", slot: 5 },
-];
-
-export function TopNav({
-  active,
-  onChange,
-  onOpenPalette,
-  theme,
-  onToggleTheme,
-  wideMode = false,
-  onToggleWideMode,
-  prototypeMode = false,
-}: TopNavProps) {
+export function TopNav({ theme, onToggleTheme }: TopNavProps) {
   const { isAuthenticated, isLoading } = useConvexAuth();
-  const { signIn } = useAuthActions();
-
-  // Alt+1..Alt+5 surface jumps (matches the cockpit's pattern).
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
-      const slot = Number(e.key);
-      if (!Number.isInteger(slot) || slot < 1 || slot > NAV.length) return;
-      const target = NAV.find((item) => item.slot === slot);
-      if (!target) return;
-      // Don't steal Alt+N when a field is focused — let the browser handle.
-      const t = e.target as HTMLElement | null;
-      if (t?.tagName === "INPUT" || t?.tagName === "TEXTAREA" || t?.isContentEditable) {
-        return;
-      }
-      e.preventDefault();
-      onChange(target.id);
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [onChange]);
-
-  const initials = useMemo(() => {
-    if (!isAuthenticated) return null;
-    // We don't have access to user profile here in v1; show a neutral chip.
-    // RightInspector / MeSurface own the full identity story.
-    return "NB";
-  }, [isAuthenticated]);
-  const showAccountSlot = !prototypeMode && active !== "home";
+  const { signIn, signOut } = useAuthActions();
 
   const onSignIn = () => {
-    void signIn("google", {
-      redirectTo: typeof window !== "undefined" ? window.location.href : "/redesign",
-    }).catch(() => undefined);
+    void Promise.resolve(
+      signIn("google", {
+        redirectTo: typeof window !== "undefined" ? window.location.href : "/redesign/chat",
+      }),
+    ).catch(() => undefined);
+  };
+
+  const onSignOut = () => {
+    void Promise.resolve(signOut()).catch(() => undefined);
   };
 
   return (
     <header
       data-rd-topnav
+      data-testid="one-surface-header"
       role="banner"
       style={{
         display: "flex",
         alignItems: "center",
-        gap: 16,
-        padding: "8px 28px",
-        height: 52,
+        gap: 12,
+        padding: "7px clamp(14px, 2.2vw, 28px)",
+        minHeight: 48,
         borderBottom: "1px solid var(--rd-line-faint)",
         background: "var(--rd-paper)",
         flexShrink: 0,
         zIndex: 20,
       }}
     >
-      <button
-        type="button"
-        onClick={() => onChange("home")}
-        aria-label="NodeBench home"
-        className="rd-btn rd-btn--quiet"
+      <a
+        href="/redesign/chat"
+        aria-label="NodeBench decision workspace"
         style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 0,
-          padding: 0,
-          minWidth: 0,
-          flexShrink: 0,
-          background: "transparent",
+          color: "var(--rd-ink-strong)",
+          fontSize: 15,
+          fontWeight: 700,
+          letterSpacing: "-0.3px",
+          textDecoration: "none",
+          whiteSpace: "nowrap",
         }}
       >
-        <span
-          style={{
-            fontSize: 15,
-            fontWeight: 700,
-            letterSpacing: "-0.3px",
-            color: "var(--rd-ink-strong)",
-            whiteSpace: "nowrap",
-          }}
-        >
-          Node<span style={{ color: "var(--rd-accent)" }}>Bench</span>
-        </span>
-      </button>
+        Node<span style={{ color: "var(--rd-accent)" }}>Bench</span>
+      </a>
 
-      <nav
-        aria-label="Primary navigation"
+      <span
+        aria-hidden="true"
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 2,
-          padding: 0,
-          borderRadius: "var(--rd-r-pill)",
-          background: "transparent",
+          color: "var(--rd-ink-mute)",
+          fontSize: 11,
+          letterSpacing: "0.02em",
         }}
       >
-        {NAV.map((item) => {
-          const isActive = item.id === active;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => onChange(item.id)}
-              aria-current={isActive ? "page" : undefined}
-              aria-keyshortcuts={`Alt+${item.slot}`}
-              title={`${item.label} (Alt+${item.slot})`}
-              className="rd-btn rd-btn--quiet"
-              style={{
-                padding: "7px 12px",
-                minHeight: 34,
-                borderRadius: "var(--rd-r-pill)",
-                fontSize: 13,
-                fontWeight: isActive ? 590 : 500,
-                background: isActive ? "var(--rd-accent-soft)" : "transparent",
-                color: isActive ? "var(--rd-accent-strong)" : "var(--rd-ink-soft)",
-                boxShadow: "none",
-              }}
-            >
-              {item.label}
-            </button>
-          );
-        })}
-      </nav>
+        Decision workspace
+      </span>
 
-      <div style={{ marginLeft: "auto", display: "flex", justifyContent: "flex-end", minWidth: 0 }}>
-        <button
-          type="button"
-          onClick={onOpenPalette}
-          aria-label="Find a person, company, or action"
-          aria-keyshortcuts="Meta+K Control+K"
-          className="rd-btn rd-btn--quiet"
-          data-rd-topnav-search
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            padding: "7px 12px",
-            minHeight: 34,
-            width: prototypeMode ? 276 : 270,
-            borderRadius: "var(--rd-r-pill)",
-            border: "1px solid var(--rd-line)",
-            background: "var(--rd-panel)",
-            color: "var(--rd-ink-mute)",
-            fontSize: prototypeMode ? 11.5 : 12,
-            justifyContent: "flex-start",
-          }}
-        >
-          <span
-            style={{
-              flex: 1,
-              textAlign: "left",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
+      <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 7 }}>
+        {!isLoading && !isAuthenticated && (
+          <button
+            type="button"
+            onClick={onSignIn}
+            className="rd-btn rd-btn--quiet rd-btn--sm"
+            data-rd-account-slot
+            style={{ minHeight: 32, padding: "6px 10px", fontSize: 12 }}
           >
-            Find a person, company, or action
-          </span>
-          <kbd
-            data-rd-topnav-kbd
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              padding: "1px 5px",
-              fontFamily: "var(--rd-font-mono)",
-              fontSize: 10,
-              fontWeight: 590,
-              color: "var(--rd-ink-soft)",
-              background: "var(--rd-muted)",
-              border: "1px solid var(--rd-line-faint)",
-              borderRadius: 4,
-            minWidth: 18,
-            justifyContent: "center",
-            lineHeight: 1.4,
-          }}
-        >
-            Ctrl K
-          </kbd>
-        </button>
-      </div>
+            Sign in
+          </button>
+        )}
 
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          flexShrink: 0,
-        }}
-      >
-        <button
-          type="button"
-          onClick={onToggleWideMode}
-          data-rd-wide-toggle
-          aria-pressed={wideMode}
-          aria-label={wideMode ? "Use standard width" : "Use wide mode"}
-          title={wideMode ? "Use standard width (W)" : "Use wide mode (W)"}
-          className="rd-btn rd-btn--quiet"
-          style={{
-            width: 34,
-            height: 34,
-            padding: 0,
-            borderRadius: "50%",
-            border: "1px solid var(--rd-line)",
-            background: wideMode ? "var(--rd-accent-soft)" : "var(--rd-panel)",
-            display: "grid",
-            placeItems: "center",
-            color: wideMode ? "var(--rd-accent-strong)" : "var(--rd-ink-mute)",
-          }}
-        >
-          <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M4 8V5h3" />
-            <path d="M20 8V5h-3" />
-            <path d="M4 16v3h3" />
-            <path d="M20 16v3h-3" />
-            <path d="M9 12h6" />
-          </svg>
-        </button>
+        {isAuthenticated && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                data-rd-account-slot
+                aria-label="Account menu"
+                title="Account"
+                className="rd-account-trigger"
+              >
+                NB
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="rd-account-menu">
+              <DropdownMenuLabel>NodeBench account</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={onSignOut}>Sign out</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
 
         <button
           type="button"
           onClick={onToggleTheme}
-          aria-label={
-            theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
-          }
+          aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
           title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
           className="rd-btn rd-btn--quiet"
           style={{
-            width: 34,
-            height: 34,
+            width: 32,
+            height: 32,
             padding: 0,
             borderRadius: "50%",
             border: "1px solid var(--rd-line)",
@@ -300,67 +132,16 @@ export function TopNav({
           }}
         >
           {theme === "dark" ? (
-            <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <circle cx="12" cy="12" r="4" />
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
             </svg>
           ) : (
-            <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
             </svg>
           )}
         </button>
-
-        {showAccountSlot && isLoading ? (
-          <div
-            data-rd-account-slot
-            aria-hidden="true"
-            style={{
-              width: 34,
-              height: 34,
-              borderRadius: "50%",
-              background: "var(--rd-muted)",
-            }}
-          />
-        ) : showAccountSlot && initials ? (
-          <button
-            type="button"
-            data-rd-account-slot
-            aria-label="Account menu"
-            className="rd-btn rd-btn--quiet"
-            style={{
-              width: 34,
-              height: 34,
-              padding: 0,
-              borderRadius: "50%",
-              background: "var(--rd-accent-soft)",
-              color: "var(--rd-accent-strong)",
-              fontFamily: "var(--rd-font-mono)",
-              fontSize: 10.5,
-              fontWeight: 700,
-              letterSpacing: "0.04em",
-              display: "grid",
-              placeItems: "center",
-            }}
-          >
-            {initials}
-          </button>
-        ) : showAccountSlot ? (
-          <button
-            type="button"
-            data-rd-account-slot
-            onClick={onSignIn}
-            className="rd-btn rd-btn--primary rd-btn--sm"
-            style={{
-              padding: "7px 12px",
-              minHeight: 34,
-              fontSize: 12.5,
-              fontWeight: 590,
-            }}
-          >
-            Continue
-          </button>
-        ) : null}
       </div>
     </header>
   );

--- a/src/features/redesign/lib/oneSurfaceRouting.test.ts
+++ b/src/features/redesign/lib/oneSurfaceRouting.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { canonicalRedesignChatTarget, pathToChatHash } from "./oneSurfaceRouting";
+
+describe("one-surface routing", () => {
+  it("keeps canonical chat and reproducible chat entries on the same runtime tree", () => {
+    expect(canonicalRedesignChatTarget("/redesign/chat", "?report=r1")).toBeNull();
+    expect(canonicalRedesignChatTarget("/redesign/chat/r/abc_123", "")).toBeNull();
+    expect(pathToChatHash("/redesign/chat/r/abc_123")).toBe("abc_123");
+  });
+
+  it("contracts former page routes into contextual chat intents", () => {
+    expect(canonicalRedesignChatTarget("/redesign", "")).toBe("/redesign/chat");
+    expect(canonicalRedesignChatTarget("/redesign/reports", "")).toBe("/redesign/chat?intent=reports");
+    expect(canonicalRedesignChatTarget("/redesign/inbox", "")).toBe("/redesign/chat?intent=attention");
+    expect(canonicalRedesignChatTarget("/redesign/me", "")).toBe("/redesign/chat?intent=account");
+  });
+
+  it("keeps the pure routing helper total for arbitrary in-memory path strings", () => {
+    expect(canonicalRedesignChatTarget("/redesign/reports/bad%2", "")).toBe(
+      "/redesign/chat?report=bad%252&intent=review-report",
+    );
+  });
+
+  it("preserves unusual but valid encoded report identifiers", () => {
+    expect(canonicalRedesignChatTarget("/redesign/reports/bad%25", "")).toBe(
+      "/redesign/chat?report=bad%25&intent=review-report",
+    );
+    expect(canonicalRedesignChatTarget("/redesign/reports/%E0%A4%A6", "")).toBe(
+      "/redesign/chat?report=%E0%A4%A6&intent=review-report",
+    );
+  });
+
+  it("preserves report and artifact context without mounting a workspace page", () => {
+    expect(canonicalRedesignChatTarget("/redesign/reports/report%201", "?fresh=1")).toBe(
+      "/redesign/chat?fresh=1&report=report+1&intent=review-report",
+    );
+    expect(canonicalRedesignChatTarget("/redesign/workspace", "?report=r1&tab=sources")).toBe(
+      "/redesign/chat?report=r1&intent=workspace&artifact=sources",
+    );
+  });
+
+  it("drops retired showcase flags", () => {
+    expect(canonicalRedesignChatTarget("/redesign", "?classic=1&edition=0&qa=home-v2-implementation")).toBe(
+      "/redesign/chat",
+    );
+  });
+});

--- a/src/features/redesign/lib/oneSurfaceRouting.ts
+++ b/src/features/redesign/lib/oneSurfaceRouting.ts
@@ -1,0 +1,56 @@
+export function pathToChatHash(pathname: string): string | null {
+  const match = pathname.match(/^\/redesign\/chat\/r\/([A-Za-z0-9_-]+)/);
+  return match?.[1] ?? null;
+}
+
+function safeDecodePathSegment(value: string): string {
+  // BrowserRouter and tests can call this helper with arbitrary strings. At
+  // the public HTTP boundary, Vercel correctly rejects invalid percent escapes
+  // with 400 before the SPA runs; valid URL-encoded legacy links land here.
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Preserve useful deep-link context while contracting every old product page
+ * into the one conversation surface. Returning null means the URL is already
+ * a canonical chat or reproducible-chat entry point. This compatibility layer
+ * accepts valid URL-encoded paths; malformed HTTP request targets remain a
+ * platform-level 400 and are not advertised as recoverable application URLs.
+ */
+export function canonicalRedesignChatTarget(pathname: string, search: string): string | null {
+  if (pathname === "/redesign/chat" || pathToChatHash(pathname)) return null;
+
+  const params = new URLSearchParams(search);
+  const reportMatch = pathname.match(/^\/redesign\/reports\/([^/]+)/);
+
+  if (reportMatch?.[1]) {
+    params.set("report", safeDecodePathSegment(reportMatch[1]));
+    params.set("intent", "review-report");
+  } else if (pathname.startsWith("/redesign/reports")) {
+    params.set("intent", "reports");
+  } else if (pathname.startsWith("/redesign/inbox")) {
+    params.set("intent", "attention");
+  } else if (pathname.startsWith("/redesign/me")) {
+    params.set("intent", "account");
+  } else if (pathname.startsWith("/redesign/workspace")) {
+    params.set("intent", "workspace");
+    const tab = params.get("tab");
+    if (tab) {
+      params.set("artifact", tab);
+      params.delete("tab");
+    }
+  } else {
+    params.delete("intent");
+  }
+
+  params.delete("classic");
+  params.delete("edition");
+  if (params.get("qa") === "home-v2-implementation") params.delete("qa");
+
+  const query = params.toString();
+  return `/redesign/chat${query ? `?${query}` : ""}`;
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -603,39 +603,6 @@
   border-right: none;
 }
 
-[data-redesign][data-wide="true"] .rd-shell {
-  grid-template-columns: 168px minmax(0, 1fr);
-}
-
-[data-redesign][data-wide="true"] .rd-shell__main,
-[data-redesign][data-wide="true"] .rd-shell--home-v2 .rd-shell__main,
-[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-shell__main,
-[data-redesign][data-wide="true"] .rd-shell--chat-v3 .rd-shell__main {
-  grid-template-columns: minmax(0, 1fr) 320px;
-}
-
-[data-redesign][data-wide="true"] .rd-shell--chat-v3 .rd-pane--right.chat-context {
-  width: 320px;
-}
-
-[data-redesign][data-wide="true"] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child,
-[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-shell__main > .rd-pane:first-child {
-  padding-left: 40px;
-  padding-right: 40px;
-}
-
-[data-redesign][data-wide="true"] .rd-v2-home {
-  max-width: 1180px;
-}
-
-[data-redesign][data-wide="true"] .rd-v3-halo-card {
-  flex-basis: 188px;
-}
-
-[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-v3-grid {
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-}
-
 [data-redesign] .rd-v2-left {
   min-height: 0;
   overflow-y: auto;
@@ -2835,20 +2802,9 @@
 
 @media (max-width: 640px) {
   [data-redesign] [data-rd-topnav] {
-    gap: 2px !important;
+    gap: 6px !important;
     padding: 8px 6px !important;
     overflow: hidden;
-  }
-
-  [data-redesign] [data-rd-topnav] > button:first-of-type,
-  [data-redesign] [data-rd-wide-toggle],
-  [data-redesign] [data-rd-account-slot] { display: none !important; }
-
-  [data-redesign] [data-rd-topnav] nav { flex: 1; justify-content: space-between; min-width: 0; }
-  [data-redesign] [data-rd-topnav] nav .rd-btn { min-height: 32px !important; padding: 6px 8px !important; font-size: 11.5px !important; }
-
-  [data-redesign] [data-rd-topnav-search] {
-    display: none !important;
   }
 
   [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
@@ -12278,23 +12234,18 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 
 @media (max-width: 760px) {
   /* Keep this selector more specific than the desktop chat grid in
-     agent-workspace.css, which is imported after this file. Persisted
-     data-wide state must never reserve an inspector column on mobile. */
-  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main,
-  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main {
+     agent-workspace.css, which is imported after this file. */
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  /* Chat also carries the home shell class for shared chrome. Do not let the
-     home wide-mode gutters push the transcript and composer past the viewport. */
-  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child,
-  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child {
+  /* Chat also carries the home shell class for shared chrome. */
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child {
     min-width: 0;
     padding-inline: 0;
   }
 
-  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context,
-  [data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context {
+  [data-redesign] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context {
     display: none;
     width: 0;
   }

--- a/src/features/redesign/surfaces/AgentWorkspaceHonesty.guard.test.ts
+++ b/src/features/redesign/surfaces/AgentWorkspaceHonesty.guard.test.ts
@@ -20,7 +20,7 @@ describe("first-class agent workspace honesty contract", () => {
     expect(chat).toContain("runtimeContextPacket.selectedContext.length");
     expect(chat).toContain("blockedClaimCount");
     expect(inspector).toContain('title="Scope"');
-    expect(inspector).toContain("Open review workspace");
+    expect(inspector).toContain("Review sources here");
   });
 
   it("does not simulate execution or advertise toast-only work controls", () => {
@@ -67,8 +67,9 @@ describe("first-class agent workspace honesty contract", () => {
     expect(chat).not.toContain("scrollRef");
     expect(chat).not.toContain("unseenCount");
     expect(shell).toContain('import "./agent-workspace.css"');
-    expect(shell).toContain(') : surface === "chat" ? (');
-    expect(workspaceCss).toContain('[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-focus');
+    expect(shell).toContain("showChatInspector &&");
+    expect(shell).toContain('data-product-surface="decision-workspace"');
+    expect(workspaceCss).not.toContain('data-wide="true"');
     expect(conversation).toContain('reducedMotion ? "instant" : "smooth"');
   });
 });

--- a/src/features/redesign/surfaces/AgentWorkspaceResponsiveCss.guard.test.ts
+++ b/src/features/redesign/surfaces/AgentWorkspaceResponsiveCss.guard.test.ts
@@ -12,17 +12,12 @@ const workspaceCss = readFileSync(
   "utf8",
 );
 
-const selectorWeight = (selector: string) =>
-  (selector.match(/\[[^\]]+\]|\.[-_a-zA-Z0-9]+/g) ?? []).length;
-
 describe("agent workspace responsive CSS contract", () => {
-  it("out-ranks the later desktop chat grid when persisted wide mode reaches mobile", () => {
+  it("collapses the contextual inspector without any legacy wide-mode state", () => {
     const desktopSelector = "[data-redesign] .rd-shell--chat-v3 .rd-shell__main";
-    const mobileWideSelector =
-      '[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-shell__main';
-    const mobileRuleStart = primitives.indexOf(
-      "[data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main,",
-    );
+    const mobileSelector =
+      "[data-redesign] .rd-shell.rd-shell--chat-v3 .rd-shell__main";
+    const mobileRuleStart = primitives.indexOf(`${mobileSelector} {`);
     const mobileRuleEnd = primitives.indexOf(
       "[data-redesign] .rd-agent-workspace-head { padding: 14px; }",
       mobileRuleStart,
@@ -34,22 +29,22 @@ describe("agent workspace responsive CSS contract", () => {
       primitives.lastIndexOf("@media (max-width: 760px) {", mobileRuleStart),
     ).toBeGreaterThan(-1);
     expect(workspaceCss).toContain(`${desktopSelector} {`);
-    expect(selectorWeight(mobileWideSelector)).toBeGreaterThan(
-      selectorWeight(desktopSelector),
-    );
 
     const mobileChatRules = primitives.slice(mobileRuleStart, mobileRuleEnd);
-    expect(mobileChatRules).toContain(mobileWideSelector);
+    expect(mobileChatRules).toContain(mobileSelector);
     expect(mobileChatRules).toContain("grid-template-columns: minmax(0, 1fr);");
     expect(mobileChatRules).toContain(
       '.rd-shell.rd-shell--chat-v3 .rd-shell__main > .rd-pane:first-child',
     );
     expect(mobileChatRules).toContain("padding-inline: 0;");
     expect(mobileChatRules).toContain(
-      '[data-redesign][data-wide="true"] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context',
+      "[data-redesign] .rd-shell.rd-shell--chat-v3 .rd-pane--right.chat-context",
     );
     expect(mobileChatRules).toContain("display: none;");
     expect(mobileChatRules).toContain("width: 0;");
     expect(mobileChatRules).not.toContain("!important");
+    expect(primitives).not.toContain('data-wide="true"');
+    expect(workspaceCss).not.toContain('data-wide="true"');
+    expect(primitives).not.toMatch(/data-rd-account-slot[^}]*display:\s*none/);
   });
 });

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { UniversalComposer, DEFAULT_TIERS, type RouterTier } from "../components/UniversalComposer";
 import { Pill } from "../components/Pill";
 import type { AgentRailItem, AgentRailSnapshot, AgentRailStatus } from "../components/RightInspector";
@@ -436,14 +436,14 @@ function buildChatAgentRailSnapshot(args: {
       label: liveDetail.title,
       status: "done",
       detail: `${liveDetail.kind} - ${liveDetail.sourceCount} sources`,
-      href: `/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=brief`,
+      href: `/redesign/chat?report=${encodeURIComponent(liveDetail.id)}&artifact=brief`,
     });
     artifactItems.push({
       id: "notebook",
       label: "Report notebook",
       status: liveDetail.notebookHtml ? "done" : "queued",
       detail: liveDetail.primaryAction,
-      href: `/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=notebook`,
+      href: `/redesign/chat?report=${encodeURIComponent(liveDetail.id)}&artifact=notebook`,
     });
   }
   if (run?.hash) {
@@ -616,7 +616,7 @@ function buildChatAgentRailSnapshot(args: {
           ? `${verifiedSourceCount} verified · ${softWarningSourceCount} limited · ${sourceCount} total`
           : isRunning ? "Checks pending" : "No claim checks recorded",
       reviewHref: liveDetail
-        ? `/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=sources`
+        ? `/redesign/chat?report=${encodeURIComponent(liveDetail.id)}&artifact=sources`
         : undefined,
     },
   };
@@ -778,6 +778,68 @@ function buildResearchStages(trace: ResearchTraceLike[] = [], running = false): 
   return [{ ...RESEARCH_STAGE_TEMPLATE[0], state: "running", detail: "Waiting for the first runtime event" }];
 }
 
+function LaunchContextCard({
+  intent,
+  artifactKey,
+  requestedReportId,
+  detail,
+  isAuthenticated,
+}: {
+  intent: string | null;
+  artifactKey: string | null;
+  requestedReportId: string | null;
+  detail: LiveArtifactDetail | null | undefined;
+  isAuthenticated: boolean;
+}) {
+  if (!intent && !artifactKey && !requestedReportId) return null;
+
+  const artifactLabels: Record<string, string> = {
+    brief: "Brief",
+    cards: "Claim card",
+    map: "Map",
+    notebook: "Notebook",
+    sources: "Source",
+  };
+  const artifactLabel = artifactKey ? artifactLabels[artifactKey] ?? "Artifact" : null;
+
+  let title = "Context selected";
+  let body = detail
+    ? `${detail.title} is attached to the next run with ${detail.sourceCount} source${detail.sourceCount === 1 ? "" : "s"}. Nothing is written until you explicitly ask.`
+    : "The requested saved context is not available in this session. You can still ask a new question below.";
+
+  if (artifactLabel) {
+    title = `${artifactLabel} context selected`;
+  } else if (requestedReportId || intent === "review-report") {
+    title = detail ? "Report context selected" : "Requested report unavailable";
+  } else if (intent === "account" || intent === "settings") {
+    title = "Account controls";
+    body = isAuthenticated
+      ? "Use the account menu in the header to sign out. Your conversation remains on this workspace."
+      : "Use Sign in in the header to connect an email-backed account and run live chat.";
+  } else if (intent === "attention") {
+    title = "Attention review";
+    body = "Ask NodeBench to identify unresolved follow-ups, approvals, or evidence gaps. There is no separate inbox to manage.";
+  } else if (intent === "reports") {
+    title = "Saved research";
+    body = "Ask for the report, company, or prior decision you need. Results stay in this conversation instead of opening a separate report browser.";
+  } else if (intent === "sources") {
+    title = "Source review";
+    body = detail
+      ? `${detail.sourceCount} source${detail.sourceCount === 1 ? "" : "s"} from ${detail.title} will ground the next run.`
+      : "Attach a source or name the evidence you want reviewed in the composer below.";
+  } else if (intent === "workspace") {
+    title = detail ? "Workspace context selected" : "Workspace context unavailable";
+  }
+
+  return (
+    <aside className="rd-launch-context" data-testid="chat-launch-context" aria-label={title}>
+      <span className="rd-eyebrow">Current focus</span>
+      <strong>{title}</strong>
+      <p>{body}</p>
+    </aside>
+  );
+}
+
 export function ChatSurface({
   contextLabel = "Asking about: current context",
   workspaceDetail,
@@ -787,13 +849,12 @@ export function ChatSurface({
   onAgentRailChange,
 }: ChatSurfaceProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const liveArtifacts = useLiveArtifacts(24);
-  const requestedReportId = typeof window !== "undefined"
-    ? new URLSearchParams(window.location.search).get("report")
-    : null;
-  const requestedArtifactKey = typeof window !== "undefined"
-    ? new URLSearchParams(window.location.search).get("artifact")
-    : null;
+  const launchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const requestedReportId = launchParams.get("report");
+  const requestedArtifactKey = launchParams.get("artifact");
+  const requestedIntent = launchParams.get("intent");
   const _rawLiveDetail = requestedReportId
     ? liveArtifacts.details.find((detail) => detail.id === requestedReportId) ?? null
     : liveArtifacts.details[0];
@@ -807,8 +868,7 @@ export function ChatSurface({
   const probeRun = useMutation(api.domains.redesign.chatRuns.probeRun);
   // ?fresh=1 escape hatch: treat as if no live artifact is loaded and show the
   // explicit live-chat unavailable state instead of seeded showcase content.
-  const _skipLiveSeed = typeof window !== "undefined"
-    && new URLSearchParams(window.location.search).has("fresh");
+  const _skipLiveSeed = launchParams.has("fresh");
   const liveDetail = workspaceDetail ?? (_skipLiveSeed ? null : _rawLiveDetail);
   useEffect(() => {
     onActiveContextChange?.(liveDetail ?? null);
@@ -828,7 +888,8 @@ export function ChatSurface({
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
   const consumedInitialPromptRef = useRef<string | null>(null);
   const hasInitialPrompt = Boolean(initialPrompt?.trim());
-  const hasLaunchContext = hasInitialPrompt || Boolean(continuationHash);
+  const hasLaunchContext = hasInitialPrompt
+    || Boolean(continuationHash || requestedIntent || requestedArtifactKey || requestedReportId);
   const turnIdCounterRef = useRef(0);
   const nextTurnId = (prefix: "u" | "a") => {
     turnIdCounterRef.current += 1;
@@ -926,11 +987,7 @@ export function ChatSurface({
     ]);
     showToast({
       tone: "success",
-      message: "Follow-up queued in this chat. Open Inbox to promote it to shared workflow state.",
-      action: {
-        label: "Open Inbox",
-        onClick: () => navigate("/redesign/inbox"),
-      },
+      message: "Follow-up queued in this conversation. Ask NodeBench to promote it when you are ready.",
     });
   };
   const removeFollowUp = (id: string) => {
@@ -938,10 +995,10 @@ export function ChatSurface({
   };
   const openCurrentReport = () => {
     if (liveDetail?.id) {
-      navigate(`/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=brief`);
+      navigate(`/redesign/chat?report=${encodeURIComponent(liveDetail.id)}&artifact=brief`);
       return;
     }
-    navigate("/redesign/reports");
+    navigate("/redesign/chat?intent=reports");
   };
 
   const agentRailSnapshot = useMemo(() => buildChatAgentRailSnapshot({
@@ -1310,6 +1367,13 @@ export function ChatSurface({
       </BatchLiveBoundary>
       <Conversation className="rd-chat-transcript">
         <ConversationContent className="rd-chat-transcript__content">
+        <LaunchContextCard
+          intent={requestedIntent}
+          artifactKey={requestedArtifactKey}
+          requestedReportId={requestedReportId}
+          detail={liveDetail}
+          isAuthenticated={isAuthenticated}
+        />
         {batch && <BatchMonitorCell batch={batch} />}
 
         {turns.length === 0 && continuationHash && continuedRun === undefined ? (
@@ -1678,12 +1742,8 @@ function InlineCorrection({ onSave }: InlineCorrectionProps = {}) {
         showToast({
           tone: result.ok ? "success" : "warning",
           message: result.message || (result.ok
-            ? "Correction saved. Review at /redesign/me."
+            ? "Correction saved to your NodeBench memory."
             : "Could not save correction — try again."),
-          action: result.ok ? {
-            label: "Open Me",
-            onClick: () => { window.location.href = "/redesign/me"; },
-          } : undefined,
         });
       } finally {
         setBusy(false);
@@ -1695,11 +1755,7 @@ function InlineCorrection({ onSave }: InlineCorrectionProps = {}) {
     // but it is not written to the long-term feedback ledger.
     showToast({
       tone: "info",
-      message: "Sign in to persist corrections to memory.",
-      action: {
-        label: "Open Me",
-        onClick: () => { window.location.href = "/redesign/me"; },
-      },
+      message: "Use Sign in in the header to persist corrections to memory.",
     });
     setEditing(null);
   };

--- a/src/features/redesign/surfaces/OneSurface.guard.test.ts
+++ b/src/features/redesign/surfaces/OneSurface.guard.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("NodeBench one-surface product contract", () => {
+  const app = read("src/App.tsx");
+  const shell = read("src/features/redesign/RedesignShell.tsx");
+  const header = read("src/features/redesign/components/TopNav.tsx");
+  const chat = read("src/features/redesign/surfaces/ChatSurface.tsx");
+  const inspector = read("src/features/redesign/components/RightInspector.tsx");
+  const workspaceCss = read("src/features/redesign/agent-workspace.css");
+
+  it("mounts only the canonical decision workspace in the primary shell", () => {
+    expect(shell).toContain('data-product-surface="decision-workspace"');
+    expect(shell).toContain("<ChatSurface");
+    expect(shell).not.toContain("<MobileShell");
+    expect(shell).not.toContain("<ReportsSurface");
+    expect(shell).not.toContain("<InboxSurface");
+    expect(shell).not.toContain("<MeSurface");
+    expect(shell).not.toContain("<WorkspaceSurface");
+    expect(shell).not.toContain("<CommandPalette");
+    expect(shell).not.toContain("<ShortcutsOverlay");
+  });
+
+  it("keeps the header free of page navigation and duplicate input", () => {
+    expect(header).not.toContain("const NAV");
+    expect(header).not.toContain("Primary navigation");
+    expect(header).not.toContain("Find a person, company, or action");
+    expect(header).not.toContain("wideMode");
+    expect(header).toContain("Sign in");
+    expect(header).toContain("DropdownMenu");
+    expect(header).toContain("Account menu");
+    expect(header).toContain("Sign out");
+    expect(header).toContain("Switch to dark mode");
+  });
+
+  it("keeps contextual chat actions inside the same surface", () => {
+    for (const source of [chat, inspector]) {
+      expect(source).not.toMatch(/\/redesign\/(?:reports|inbox|me|workspace)/);
+    }
+    expect(chat).toContain("/redesign/chat?report=");
+    expect(chat).toContain("requestedIntent");
+    expect(chat).toContain("<LaunchContextCard");
+    expect(chat).toContain("buildLiveContextRef(liveDetail, requestedArtifactKey)");
+    expect(chat).not.toContain("Review settings");
+    expect(inspector).not.toContain("Open Map");
+    expect(inspector).not.toContain("Open notebook handoff");
+    expect(inspector).toContain("Review sources here");
+  });
+
+  it("keeps read scope visible on mobile", () => {
+    expect(workspaceCss).toMatch(/span:nth-of-type\(2\)[^{]*\{[^}]*display:\s*block/s);
+    expect(workspaceCss).not.toMatch(/span:nth-of-type\(2\)[^{]*,[^{]*span:nth-of-type\(3\)[^{]*\{[^}]*display:\s*none/s);
+  });
+
+  it("routes the root application to chat on desktop and mobile", () => {
+    expect(app).toContain('const shouldUseRedesignLanding = location.pathname === "/"');
+    expect(app).toContain("<Navigate to={`/redesign/chat");
+    expect(app).toContain('return <Navigate to="/redesign/chat" replace />');
+    expect(app).not.toContain("<CockpitLayout");
+    expect(app).not.toContain("<GlobalFastAgentPanel");
+    expect(app).not.toContain("<ReportDetailPage");
+    expect(app).not.toContain("<ReportNotebookDetail");
+    expect(app).toContain('nextParams.set("artifact", artifact)');
+    expect(app).toContain("const isStandaloneWorkspaceRoute = isWorkspaceHost");
+    expect(app).not.toContain("!isMobileViewport");
+  });
+});

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Tier B runtime-grounding verification for the five ExactKit cockpit surfaces.
+ * Tier B production-parity contract for NodeBench's single decision workspace.
  *
- * These checks deliberately do not require fixture counts. Optional product
- * sections may render only when their backing runtime query returns data.
+ * Legacy entry points must converge on the same runtime-backed chat surface;
+ * this suite intentionally rejects the retired five-surface cockpit.
  */
 
 import { expect, test, type Page } from "@playwright/test";
@@ -15,302 +15,88 @@ test.beforeEach(async ({ page }) => {
   await installVercelPreviewBypass(page, BASE_URL);
 });
 
-async function navigate(page: Page, surface: string) {
-  await page.goto(`${BASE_URL}/?surface=${surface}`, {
+async function open(page: Page, path: string) {
+  await page.goto(`${BASE_URL}${path}`, {
     waitUntil: "domcontentloaded",
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-product-surface="decision-workspace"]')).toBeVisible({
     timeout: 30_000,
   });
 }
 
-test("Quick Search follows the real Home route and focuses its canonical composer", async ({
+async function expectSingleWorkspace(page: Page) {
+  await expect(page).toHaveURL(/\/redesign\/chat(?:[/?#]|$)/);
+  await expect(page.locator('[data-product-surface="decision-workspace"]')).toHaveCount(1);
+  await expect(page.getByTestId("one-surface-workspace")).toBeVisible();
+  await expect(page.locator("textarea:visible")).toHaveCount(1);
+  await expect(page.locator("nav")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /^sign in$/i })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /switch to (light|dark) mode/i }),
+  ).toBeVisible();
+}
+
+test("legacy cockpit entry points converge on exactly one decision workspace", async ({
   page,
 }) => {
-  await navigate(page, "workspace");
-  await page.getByRole("button", { name: "Search reports, entities, inbox" }).click();
-  await page.locator('[data-agent-id="cmd:quick-search"]').click();
+  const paths = [
+    "/",
+    "/?surface=home",
+    "/?surface=chat",
+    "/?surface=reports",
+    "/?surface=inbox",
+    "/?surface=me",
+    "/?surface=workspace",
+    "/agents",
+    "/workspace",
+    "/developers",
+  ];
 
-  await expect(page).toHaveURL(/\/redesign(?:\?|$)/);
-  await expect(page.locator("#redesign-home-composer")).toBeFocused();
-});
-
-test("Home keeps one useful composer and renders only runtime-returned sections", async ({
-  page,
-}) => {
-  await navigate(page, "ask");
-
-  await expect(page.getByTestId("exact-web-home-surface")).toBeVisible();
-  await expect(page.getByTestId("exact-web-home-composer")).toBeVisible();
-  await expect(page.locator(".nb-composer-hero h1")).toHaveText(
-    "Get the read before you walk in.",
-  );
-  await expect(page.getByTestId("home-async-proof")).toHaveText(
-    "Background runs continue server-side and stay visible in Reports.",
-  );
-  await expect(page.getByTestId("home-first-impression-board")).toBeVisible();
-
-  const state = await page.evaluate(() => {
-    const has = (selector: string) => Boolean(document.querySelector(selector));
-    const count = (selector: string) => document.querySelectorAll(selector).length;
-    return {
-      pulsePresent: has('[data-testid="exact-home-pulse-strip"]'),
-      pulseItems: count(".nb-pulse-card, .nb-pulse-mini"),
-      todayPresent: has('[data-testid="exact-home-today-intel"]'),
-      todayItems: count(".nb-today-item"),
-      activeEventPresent: has('[data-testid="exact-home-active-event"]'),
-      recentSection: has('[data-testid="exact-home-recent-reports"]'),
-      recentLoading: has('[data-testid="home-recent-reports-loading"]'),
-      recentEmpty: has('[data-testid="home-recent-reports-empty"]'),
-      recentCards: count(".nb-recent-card"),
-      bodyText: document.body.textContent ?? "",
-    };
-  });
-
-  expect(state.recentSection).toBe(true);
-  expect(
-    Number(state.recentLoading) +
-      Number(state.recentEmpty) +
-      Number(state.recentCards > 0),
-    "Recent reports has one honest loading, empty, or live-data state",
-  ).toBe(1);
-  expect(state.pulsePresent).toBe(false);
-  expect(state.pulseItems).toBe(0);
-  if (state.todayPresent) expect(state.todayItems).toBeGreaterThan(0);
-  if (state.activeEventPresent) {
-    await expect(page.getByTestId("exact-home-active-event")).toBeVisible();
+  for (const path of paths) {
+    await open(page, path);
+    await expectSingleWorkspace(page);
   }
-  expect(state.bodyText).not.toMatch(/Orbital Labs|DISCO|Mercor|attached 10-K/i);
 });
 
-test("Chat routes guests to the session runtime and has one prompt row", async ({
-  page,
-}) => {
-  await navigate(page, "workspace");
+test("retired cockpit controls and fixture projections stay absent", async ({ page }) => {
+  await open(page, "/redesign/chat");
+  await expectSingleWorkspace(page);
 
-  const stream = page.getByTestId("exact-web-chat-stream");
-  await expect(stream).toBeVisible();
-  await expect(stream).toHaveAttribute("data-chat-runtime-route", "session-fast-agent");
-  await expect(stream).toHaveAttribute("data-chat-live-eligible", "false");
-  await expect(stream).toHaveAttribute("data-chat-live-status", /.+/);
-  await expect(page.locator(".nb-stream-header h2")).toContainText(
-    "Live Context Runtime",
+  await expect(
+    page.getByRole("heading", { name: "What do you need to know?" }),
+  ).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(
+    /Orbital Labs|DISCO|Mercor|Ship Demo Day|Pro plan|Upgrade|usage/i,
   );
-  await expect(page.locator(".nb-stream-inner")).toContainText(
-    "Runtime evidence and sources appear after you send.",
-  );
-  await expect(page.locator(".nb-composer-card")).toBeVisible();
   await expect(
     page.locator(
-      '[data-exact-composer="golden"][data-exact-composer-version="2026-05-02"]',
+      '[data-testid="exact-web-home-surface"], [data-testid="exact-web-chat-stream"], [data-testid="reports-performance-root"], [data-testid="exact-web-inbox-surface"], [data-testid="exact-web-me-surface"], [data-testid="exact-avatar-menu"]',
     ),
-  ).toBeVisible();
-  await expect(page.locator(".nb-composer-input")).toHaveAttribute(
-    "placeholder",
-    "Ask or paste text... (@ to mention an entity)",
-  );
-  await expect(page.locator(".nb-prompt-chip")).toHaveCount(3);
-  await expect(page.locator(".nb-followup-chip")).toHaveCount(0);
-  await expect(page.locator(".nb-model-trigger")).toHaveCount(0);
-  await expect(page.locator(".nb-epill, .nb-confirm")).toHaveCount(0);
-  await expect(page.locator("body")).not.toContainText("Ship Demo Day");
-});
-
-test("Reports exposes honest loading, empty, or live state without fixture chrome", async ({
-  page,
-}) => {
-  await navigate(page, "reports");
-
-  const root = page.getByTestId("reports-performance-root");
-  await expect(root).toBeVisible();
-  await expect(page.getByTestId("pipeline-launcher")).toBeVisible();
-  await expect(page.getByTestId("pipeline-launcher-sign-in")).toBeVisible();
-  await expect(
-    page.locator('[data-testid="pipeline-runs-panel"], [data-testid="pipeline-runs-empty"], [data-testid="pipeline-runs-unavailable"]'),
-  ).toBeVisible();
-
-  await expect
-    .poll(
-      async () => root.getAttribute("data-reports-source"),
-      { timeout: 15_000 },
-    )
-    .not.toBe("loading");
-
-  const state = await page.evaluate(() => {
-    const root = document.querySelector('[data-testid="reports-performance-root"]');
-    const reportCards = root?.querySelectorAll('[data-testid="report-card"]').length ?? 0;
-    return {
-      source: root?.getAttribute("data-reports-source"),
-      loading: Boolean(root?.querySelector('[data-testid="reports-loading"]')),
-      empty: Boolean(root?.querySelector('[data-testid="reports-empty"]')),
-      reportCards,
-      sourcePills: root?.querySelectorAll(".nb-reports-source-pill").length ?? 0,
-      viewToggles: root?.querySelectorAll(".nb-view-toggle").length ?? 0,
-      bodyText: root?.textContent ?? "",
-    };
-  });
-
-  expect(["empty", "live_convex"]).toContain(state.source);
-  expect(
-    Number(state.loading) + Number(state.empty) + Number(state.reportCards > 0),
-    "Reports has exactly one runtime-backed state",
-  ).toBe(1);
-  if (state.source === "empty") {
-    expect(state.empty).toBe(true);
-    expect(state.sourcePills).toBe(0);
-    expect(state.viewToggles).toBe(0);
-  } else {
-    expect(state.reportCards).toBeGreaterThan(0);
-    expect(state.sourcePills).toBe(1);
-    expect(state.viewToggles).toBe(1);
-  }
-  expect(state.bodyText).not.toMatch(/Orbital Labs|DISCO|Mercor/i);
-  await expect(page.getByTestId("pipeline-launcher")).not.toContainText(
-    /Upload a file|Record voice|Add URL/i,
-  );
-});
-
-test("Inbox shows runtime nudges or an honest loading/empty state", async ({
-  page,
-}) => {
-  await navigate(page, "nudges");
-
-  const surface = page.getByTestId("exact-web-inbox-surface");
-  await expect(surface).toBeVisible();
-  await expect(surface.locator(".nb-inbox-head h1")).toHaveText("Inbox");
-  await expect(surface.locator(".nb-inbox-filter button")).toHaveCount(4);
-  await expect(surface.locator(".nb-inbox-filter button")).toContainText([
-    "All",
-    "Act",
-    "Auto",
-    "Watch",
-  ]);
-
-  const stateCount = await surface.evaluate((node) =>
-    Number(Boolean(node.querySelector('[data-testid="inbox-loading"]'))) +
-    Number((node.textContent ?? "").includes("No runtime nudges")) +
-    Number(node.querySelectorAll(".nb-ibx-row").length > 0),
-  );
-  expect(stateCount).toBe(1);
-});
-
-test("Me reflects guest or runtime identity without plans or preference clutter", async ({
-  page,
-}) => {
-  await navigate(page, "me");
-
-  const surface = page.getByTestId("exact-web-me-surface");
-  await expect(surface).toBeVisible();
-  await expect(surface.locator(".nb-me-sidenav")).toBeVisible();
-  await expect(surface.locator(".nb-settings-h1")).toHaveText("Memory");
-  await expect(surface.locator(".nb-me-sidenav .section-title")).toHaveText([
-    "Account",
-  ]);
-  await expect(surface.locator(".nb-me-sidenav button")).toContainText(
-    "Settings",
-  );
-
-  const identity = await surface.evaluate((node) => ({
-    initial: node.querySelector(".nb-me-sidenav .av")?.textContent?.trim() ?? "",
-    name: node.querySelector(".nb-me-sidenav .nm")?.textContent?.trim() ?? "",
-    detail: node.querySelector(".nb-me-sidenav .em")?.textContent?.trim() ?? "",
-    loading: Boolean(node.querySelector('[data-testid="me-memory-loading"]')),
-    empty: Boolean(node.querySelector('[data-testid="me-memory-empty"]')),
-    live: Boolean(node.querySelector(".nb-settings-section")),
-  }));
-  expect(identity.initial).toBe(identity.name.slice(0, 1).toUpperCase());
-  if (identity.detail === "Anonymous session") {
-    expect(identity.name).toBe("Guest workspace");
-    expect(identity.initial).toBe("G");
-  } else {
-    expect(identity.name.length).toBeGreaterThan(0);
-    expect(identity.detail.length).toBeGreaterThan(0);
-  }
-  expect(Number(identity.loading) + Number(identity.empty) + Number(identity.live)).toBe(1);
-  await expect(surface.locator(".nb-me-sidenav .section-title")).not.toContainText(
-    /Preferences|Workspace/i,
-  );
-  await expect(surface).not.toContainText(/Pro plan|Upgrade|usage/i);
-});
-
-test("An unknown report stays in the cockpit and fails closed", async ({ page }) => {
-  const reportId = "__missing_runtime_report__";
-  await page.goto(`${BASE_URL}/?surface=packets&report=${reportId}`, {
-    waitUntil: "domcontentloaded",
-    timeout: 30_000,
-  });
-
-  const detail = page.getByTestId("exact-web-report-detail");
-  await expect(detail).toBeVisible();
-  await expect(detail).toHaveAttribute("data-report-id", reportId);
-  await expect(detail).toContainText(
-    "No runtime-backed report was found for this id.",
-  );
-  await expect(detail.locator(".nb-rdetail-cockpit, .nb-rdetail-title")).toHaveCount(0);
-  expect(page.url()).not.toContain("workspace.nodebenchai.com");
-
-  await page.getByTestId("report-detail-back").click();
-  await expect(page).toHaveURL(/surface=packets/);
-  await expect(page).not.toHaveURL(/report=/);
-  await expect(page.getByTestId("reports-performance-root")).toBeVisible();
-});
-
-test("Avatar menu exposes runtime identity and useful controls only", async ({
-  page,
-}) => {
-  await navigate(page, "ask");
-
-  const trigger = page.locator(".nb-avm-trigger");
-  await expect(trigger).toBeVisible();
-  const triggerInitial = (await trigger.locator(".nb-avm-avatar-sm").textContent())?.trim() ?? "";
-  await expect(page.getByTestId("exact-avatar-menu")).toHaveCount(0);
-  await trigger.click();
-
-  const menu = page.getByTestId("exact-avatar-menu");
-  await expect(menu).toBeVisible();
-  const identity = await menu.evaluate((node) => ({
-    name: node.querySelector(".nb-avm-name")?.textContent?.trim() ?? "",
-    detail: node.querySelector(".nb-avm-id")?.textContent?.trim() ?? "",
-    watchRows: node.querySelectorAll(".nb-avm-watch-row").length,
-    watchEmpty: node.querySelectorAll(".nb-avm-section .nb-avm-empty").length,
-    sessionRows: node.querySelectorAll(".nb-avm-session").length,
-    sessionEmpty: (node.textContent ?? "").includes("runtime sessions"),
-  }));
-  expect(triggerInitial).toBe(identity.name.slice(0, 1).toUpperCase());
-  if (identity.detail === "Anonymous session") {
-    expect(identity.name).toBe("Guest workspace");
-    expect(triggerInitial).toBe("G");
-  }
-
-  await expect(menu.locator(".nb-avm-section-label")).toContainText([
-    /Recent entities/,
-    "Recent sessions",
-    "Theme",
-  ]);
-  expect(identity.watchRows > 0 || identity.watchEmpty > 0).toBe(true);
-  expect(identity.sessionRows > 0 || identity.sessionEmpty).toBe(true);
-  await expect(menu.locator(".nb-avm-theme-opt")).toHaveText(["Light", "Dark"]);
-  await expect(menu.locator(".nb-avm-link")).toHaveText(["Settings"]);
-  await expect(
-    menu.locator(".nb-avm-pro, .nb-avm-pulse, .nb-avm-usage, .nb-avm-upgrade"),
   ).toHaveCount(0);
-  await expect(menu).not.toContainText(/Hannah Sato|Today's pulse|This month|Shortcuts|Help|Sign out/i);
-
-  await page.keyboard.press("Escape");
-  await expect(menu).toHaveCount(0);
 });
 
-test("Developers page starts from an honest MCP empty state", async ({ page }) => {
-  await page.goto(`${BASE_URL}/developers`, {
-    waitUntil: "domcontentloaded",
-    timeout: 30_000,
-  });
+test("report artifact URLs preserve context without reopening report editors", async ({
+  page,
+}) => {
+  const reportId = "__missing_runtime_report__";
+  await open(page, `/reports/${reportId}/notebook`);
 
-  await expect(page.getByRole("heading", { name: /Bring NodeBench into Claude/i })).toBeVisible();
-  await expect(page.getByTestId("mcp-terminal-empty")).toContainText(
-    "No MCP call has run on this page.",
+  await expectSingleWorkspace(page);
+  await expect(page).toHaveURL(
+    new RegExp(`/redesign/chat\\?report=${reportId}&artifact=notebook`),
   );
-  await expect(page.getByRole("button", { name: "Copy install command" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Copy hosted public URL" })).toBeVisible();
-  await expect(page.getByTestId("mcp-terminal-empty")).not.toContainText(
-    /DISCO|first dossier returned|tools loaded/i,
+  await expect(page.getByText(/notebook context/i).first()).toBeVisible();
+  await expect(page.getByTestId("exact-web-report-detail")).toHaveCount(0);
+});
+
+test("the single composer remains useful and focused", async ({ page }) => {
+  await open(page, "/redesign/chat");
+  const composer = page.locator("textarea:visible");
+
+  await composer.fill("What changed, why does it matter, and what should I do next?");
+  await expect(composer).toHaveValue(
+    "What changed, why does it matter, and what should I do next?",
   );
+  await expect(page.getByRole("button", { name: /run research/i })).toBeEnabled();
 });

--- a/tests/e2e/full-ui-dogfood.spec.ts
+++ b/tests/e2e/full-ui-dogfood.spec.ts
@@ -3,29 +3,9 @@ import path from "node:path";
 
 const ROUTES = [
   {
-    path: "/?surface=home",
-    name: "home",
-    readyHeading: /(Ask once\. Turn it into reusable intelligence\.|Daily intelligence pulse)/i,
-  },
-  {
-    path: "/?surface=chat",
-    name: "chat",
-    readyHeading: "Ask NodeBench",
-  },
-  {
-    path: "/?surface=reports",
-    name: "reports",
-    readyHeading: "Reports",
-  },
-  {
-    path: "/?surface=inbox",
-    name: "inbox",
-    readyHeading: "Where you decide. Everything else runs in the background.",
-  },
-  {
-    path: "/?surface=me",
-    name: "me",
-    readyHeading: "This is what NodeBench remembers about you.",
+    path: "/redesign/chat",
+    name: "decision-workspace",
+    readyHeading: "What do you need to know?",
   },
 ] as const;
 
@@ -134,6 +114,12 @@ function formatBrowserIssues(issues: BrowserIssue[]) {
 }
 
 async function signInIfPrompted(page: Page) {
+  // The single workspace is intentionally usable before authentication. Its
+  // header's "Sign in" control is an account action, not an auth wall.
+  if (await page.locator("#main-content").isVisible().catch(() => false)) {
+    return;
+  }
+
   const anonymousButton = page.getByRole("button", { name: /sign in anonymously/i }).first();
   if (await anonymousButton.count()) {
     await anonymousButton.click();
@@ -143,19 +129,6 @@ async function signInIfPrompted(page: Page) {
     return;
   }
 
-  const signInButton = page.getByRole("button", { name: /^sign in$/i }).first();
-  if (await signInButton.count()) {
-    await signInButton.click();
-    await page.waitForTimeout(500);
-
-    const modalAnonymousButton = page.getByRole("button", { name: /sign in anonymously/i }).first();
-    if (await modalAnonymousButton.count()) {
-      await modalAnonymousButton.click();
-      await page.waitForLoadState("domcontentloaded");
-      await page.waitForSelector("#main-content", { state: "visible", timeout: 60_000 });
-      await page.waitForTimeout(1000);
-    }
-  }
 }
 
 async function navigateWithinApp(page: Page, targetPath: string) {
@@ -213,40 +186,7 @@ async function ensureSurfaceReady(
   if (routeRegionVisible) {
     return;
   }
-  if (route.name === "chat") {
-    const chatRegion = page.getByRole("region", { name: "Chat" }).first();
-    const chatRegionVisible = await chatRegion.isVisible().catch(() => false);
-    if (chatRegionVisible) {
-      return;
-    }
-    await expect(
-      page.locator("textarea:visible").first(),
-    ).toBeVisible({ timeout: 20_000 });
-    return;
-  }
   await expect(heading).toBeVisible({ timeout: 20_000 });
-}
-
-async function ensureChatRunReady(page: Page, query: string) {
-  await expect(page).toHaveURL(/(?:surface=chat|\/redesign\/chat(?:$|[/?#]))/, { timeout: 20_000 });
-  await expect(page.getByText("Something went wrong")).toHaveCount(0);
-  const queryHeading = page.getByRole("heading", { name: query }).first();
-  const headingVisible = await queryHeading.isVisible().catch(() => false);
-  if (headingVisible) {
-    return;
-  }
-  const queryEcho = page.getByText(query, { exact: true }).first();
-  const queryEchoVisible = await queryEcho.isVisible().catch(() => false);
-  if (queryEchoVisible) {
-    return;
-  }
-  const primaryComposer = page.locator("textarea:visible").first();
-  if (await primaryComposer.count()) {
-    await expect(primaryComposer).toBeVisible({ timeout: 20_000 });
-    return;
-  }
-
-  await expect(page.locator("textarea:visible").first()).toBeVisible({ timeout: 20_000 });
 }
 
 async function setTheme(page: Page, theme: "dark" | "light") {
@@ -349,17 +289,16 @@ test.describe("Full UI Dogfood", () => {
       await page.setViewportSize({ width: 1440, height: 900 });
       await setTheme(page, "dark");
 
-      activeRoute = "/?surface=home";
-      await navigateWithinApp(page, "/?surface=home");
-      const homeQuery = "What does Ditto AI do and what matters most right now?";
-      const homeInput = page.locator("textarea:visible").first();
-      await expect(homeInput).toBeVisible({ timeout: 20_000 });
-      await homeInput.fill(homeQuery);
-      await page.getByRole("button", { name: /^run research$/i }).first().click();
-      await page.waitForTimeout(2500);
-      await ensureChatRunReady(page, homeQuery);
+      activeRoute = "/redesign/chat";
+      await navigateWithinApp(page, "/redesign/chat");
+      const workspaceQuery = "What changed, why does it matter, and what should I do next?";
+      const workspaceInput = page.locator("textarea:visible").first();
+      await expect(workspaceInput).toBeVisible({ timeout: 20_000 });
+      await workspaceInput.fill(workspaceQuery);
+      await expect(workspaceInput).toHaveValue(workspaceQuery);
+      await expect(page.getByRole("button", { name: /^run research$/i })).toBeEnabled();
       await page.screenshot({
-        path: getScreenshotPath("interaction-home-to-chat.png"),
+        path: getScreenshotPath("interaction-workspace-ready.png"),
         fullPage: true,
       });
 
@@ -374,15 +313,16 @@ test.describe("Full UI Dogfood", () => {
       await themeToggle.click();
       await page.waitForTimeout(500);
 
-      activeRoute = "/?surface=reports";
-      await navigateWithinApp(page, "/?surface=reports");
-      const visibleChatButton = page.locator("button:visible").filter({ hasText: /^Chat$/i }).first();
-      await expect(visibleChatButton).toBeVisible({ timeout: 20_000 });
-      await visibleChatButton.click();
-      await page.waitForTimeout(1500);
-      await ensureChatRunReady(page, homeQuery);
+      activeRoute = "/reports/dogfood-report/notebook";
+      await navigateWithinApp(page, "/reports/dogfood-report/notebook");
+      await expect(page).toHaveURL(
+        /\/redesign\/chat\?report=dogfood-report&artifact=notebook/,
+      );
+      await expect(page.getByText(/notebook context/i).first()).toBeVisible();
+      await expect(page.locator('[data-product-surface="decision-workspace"]')).toHaveCount(1);
+      await expect(page.locator("textarea:visible")).toHaveCount(1);
       await page.screenshot({
-        path: getScreenshotPath("interaction-reports-to-chat.png"),
+        path: getScreenshotPath("interaction-report-context.png"),
         fullPage: true,
       });
     }

--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -29,7 +29,7 @@
  * hydrate and render the correct component for the route".
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { installVercelPreviewBypass } from "./helpers/vercelPreview";
 
 const BASE_URL =
@@ -44,11 +44,20 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     await installVercelPreviewBypass(page, BASE_URL);
   });
 
+  async function expectSingleWorkspace(page: Page) {
+    await expect(page).toHaveURL(/\/redesign\/chat(?:[/?#]|$)/);
+    await expect(page.locator('[data-product-surface="decision-workspace"]')).toHaveCount(1);
+    await expect(page.getByTestId("one-surface-workspace")).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator("textarea:visible")).toHaveCount(1);
+    await expect(page.locator("nav")).toHaveCount(0);
+  }
+
   test("landing renders after hydration", async ({ page }) => {
     await page.goto(BASE_URL + "/");
-    // After hydration there must be AT LEAST one element with real content —
-    // picking <h1> as the universal "page has content" signal.
-    await expect(page.locator("h1").first()).toBeVisible({ timeout: 15_000 });
+    await expectSingleWorkspace(page);
+    await expect(
+      page.getByRole("heading", { name: "What do you need to know?" }),
+    ).toBeVisible();
   });
 
   test("/share/{dummy} renders 'Link not found' StatusCard", async ({ page }) => {
@@ -90,65 +99,31 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     });
   });
 
-  test("/reports/:slug/graph mounts ReportDetailWorkspace", async ({ page }) => {
+  test("/reports/:slug/graph opens map context in the single workspace", async ({ page }) => {
     const response = await page.goto(BASE_URL + "/reports/acme-ai/graph");
     expect(response?.status()).toBe(200);
-    // ReportDetailPage falls back to fixture cards in demo mode so this
-    // assertion does not require the Convex ontology to be populated.
-    await expect(
-      page.locator('[data-testid="report-detail-workspace"]'),
-    ).toBeVisible({ timeout: 20_000 });
-    // Cards tab is the default; expect at least one card + the breadcrumb.
-    await expect(
-      page.locator('[data-testid="resource-card"]').first(),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('[aria-label="Breadcrumb"]')).toBeVisible();
+    await expectSingleWorkspace(page);
+    await expect(page).toHaveURL(/\/redesign\/chat\?report=acme-ai&artifact=map/);
+    await expect(page.getByText(/map context/i).first()).toBeVisible();
+    await expect(page.locator('[data-testid="report-detail-workspace"]')).toHaveCount(0);
   });
 
-  test("/?surface=reports shows one honest runtime state", async ({ page }) => {
+  test("/?surface=reports retires the reports rail into the single workspace", async ({ page }) => {
     const response = await page.goto(BASE_URL + "/?surface=reports");
     expect(response?.status()).toBe(200);
-    const reports = page.getByTestId("reports-performance-root");
-    await expect(reports).toBeVisible({ timeout: 20_000 });
-    await expect
-      .poll(() => reports.getAttribute("data-reports-source"), { timeout: 20_000 })
-      .not.toBe("loading");
-
-    const state = await reports.evaluate((node) => ({
-      loading: node.querySelectorAll('[data-testid="reports-loading"]').length,
-      empty: node.querySelectorAll('[data-testid="reports-empty"]').length,
-      cards: node.querySelectorAll('[data-testid="report-card"]').length,
-    }));
-    expect(Number(state.loading > 0) + Number(state.empty > 0) + Number(state.cards > 0)).toBe(1);
-    await expect(reports).not.toContainText(/Orbital Labs|DISCO|Mercor/i);
-
-    if (state.cards > 0) {
-      const firstCard = reports.locator('[data-testid="report-card"]').first();
-      const actionRow = firstCard.locator('[data-testid="report-card-actions"]');
-      await expect(actionRow).toBeVisible();
-      await expect(firstCard.getByRole("button", { name: /Open .* report/i })).toBeVisible();
-      await expect(actionRow.getByRole("button", { name: /Resume report chat/i })).toBeVisible();
-    }
+    await expectSingleWorkspace(page);
+    await expect(page.getByTestId("reports-performance-root")).toHaveCount(0);
   });
 
-  test("/workspace/w/:id mounts UniversalWorkspacePage chromelessly", async ({ page }) => {
-    // Workspace is a separate deploy surface per docs/design/PRODUCT_SURFACES.md.
-    // On the main domain the path `/workspace/*` triggers the chromeless shell
-    // (the same bundle rendered via `workspace.nodebenchai.com` once DNS is live).
+  test("main-host /workspace/w/:id converges on the single workspace", async ({ page }) => {
+    // Dedicated workspace hosts retain their separate delivery surface. On the
+    // main product host, workspace paths must not resurrect a second app shell.
     const response = await page.goto(BASE_URL + "/workspace/w/acme-ai?tab=brief");
     expect(response?.status()).toBe(200);
-    // Chromeless shell: assert the stable runtime contact and current report-shell
-    // contract rather than retired fixture-era copy.
-    const workspace = page.locator(
-      '[data-agent-contact="standalone-workspace-runtime"]',
-    );
-    await expect(workspace).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole("heading", { name: "acme-ai" })).toBeVisible();
-    await expect(page.getByText("WORKSPACE", { exact: true })).toBeVisible();
+    await expectSingleWorkspace(page);
     await expect(
-      page.getByText("Detail pending - report shell active", { exact: true }),
-    ).toBeVisible();
-    await expect(page.locator("[data-rd-topnav]")).toHaveCount(0);
+      page.locator('[data-agent-contact="standalone-workspace-runtime"]'),
+    ).toHaveCount(0);
   });
 
   test("console has no uncaught errors during landing load", async ({ page }) => {

--- a/tests/e2e/one-flow-regression.spec.ts
+++ b/tests/e2e/one-flow-regression.spec.ts
@@ -1,33 +1,16 @@
 /**
- * One-flow regression: an anonymous visitor can traverse the five canonical
- * surfaces and sees only runtime-backed loading, empty, or live states.
+ * One-flow regression: every product entry point resolves to one usable,
+ * runtime-backed decision workspace with one composer.
  */
 
 import { expect, test, type Page } from "@playwright/test";
 import { installVercelPreviewBypass } from "./helpers/vercelPreview";
 
-const BASE_URL = process.env.BASE_URL ?? "http://127.0.0.1:4173";
+const BASE_URL = (process.env.BASE_URL ?? "http://127.0.0.1:4173").replace(/\/$/, "");
 
 test.beforeEach(async ({ page }) => {
   await installVercelPreviewBypass(page, BASE_URL);
 });
-
-const SURFACES = {
-  home: "/?surface=home",
-  chat: "/?surface=chat",
-  reports: "/?surface=reports",
-  inbox: "/?surface=inbox",
-  me: "/?surface=me",
-  exactHome: "/?surface=ask",
-} as const;
-
-async function goSurface(page: Page, surface: keyof typeof SURFACES) {
-  await page.goto(`${BASE_URL}${SURFACES[surface]}`, {
-    waitUntil: "networkidle",
-    timeout: 30_000,
-  });
-  await page.waitForTimeout(800);
-}
 
 function collectErrors(page: Page) {
   const errors: string[] = [];
@@ -35,87 +18,48 @@ function collectErrors(page: Page) {
   page.on("console", (message) => {
     if (message.type() !== "error") return;
     const text = message.text();
-    if (text.includes("ResizeObserver") || text.includes("React DevTools")) return;
+    if (/ResizeObserver|React DevTools|ERR_CONNECTION_(?:REFUSED|RESET)/i.test(text)) return;
     errors.push(`console.error: ${text}`);
   });
   return errors;
 }
 
+async function go(page: Page, path: string) {
+  await page.goto(`${BASE_URL}${path}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("one-surface-workspace")).toBeVisible({ timeout: 30_000 });
+}
+
 test.describe("ONE-FLOW REGRESSION", () => {
-  test("anonymous visitor completes a fixture-free runtime surface tour", async ({ page }) => {
+  test("anonymous visitor gets one calm workspace across legacy routes", async ({ page }) => {
     const errors = collectErrors(page);
 
-    await goSurface(page, "home");
-    await expect(page).toHaveURL(/\/redesign(?:[/?#]|$)/);
-    const home = page.getByTestId("home-v3-chat-first-frontpage");
-    await expect(home).toBeVisible();
-    await expect(
-      home.getByPlaceholder(
-        "Ask about a company, person, event, market, report, or source packet...",
-      ),
-    ).toBeVisible();
+    for (const path of [
+      "/",
+      "/?surface=home",
+      "/?surface=reports",
+      "/?surface=inbox",
+      "/?surface=me",
+      "/agents",
+      "/workspace",
+    ]) {
+      await go(page, path);
+      await expect(page).toHaveURL(/\/redesign\/chat(?:[/?#]|$)/);
+      await expect(page.locator('[data-product-surface="decision-workspace"]')).toHaveCount(1);
+      await expect(page.locator("textarea:visible")).toHaveCount(1);
+      await expect(page.locator("nav")).toHaveCount(0);
+    }
 
-    await goSurface(page, "chat");
-    const chat = page.getByTestId("exact-web-chat-stream");
-    await expect(chat).toBeVisible();
-    await expect(chat).toHaveAttribute(
-      "data-chat-runtime-route",
-      /^(paid-redesign|session-fast-agent)$/,
-    );
-    await expect(chat.locator('[data-exact-composer="golden"]')).toHaveCount(1);
-    await expect(chat.locator(".nb-prompt-chip")).toHaveCount(3);
-    await expect(chat.locator(".nb-followup-chip")).toHaveCount(0);
-    await expect(chat).not.toContainText(/Ship Demo Day|no fixture answer loaded|ContextRuntimePacket/i);
+    await go(page, "/reports/runtime-report/graph");
+    await expect(page).toHaveURL(/\/redesign\/chat\?report=runtime-report&artifact=map/);
+    await expect(page.getByText(/map context/i).first()).toBeVisible();
 
-    await goSurface(page, "reports");
-    const reports = page.getByTestId("reports-performance-root");
-    await expect(reports).toBeVisible();
-    await expect
-      .poll(() => reports.getAttribute("data-reports-source"), { timeout: 15_000 })
-      .not.toBe("loading");
-    const reportStateCount = await reports.evaluate((node) => {
-      const cards = node.querySelectorAll('[data-testid="report-card"]').length;
-      return Number(Boolean(node.querySelector('[data-testid="reports-loading"]'))) +
-        Number(Boolean(node.querySelector('[data-testid="reports-empty"]'))) +
-        Number(cards > 0);
-    });
-    expect(reportStateCount, "Reports exposes one loading, empty, or live runtime state").toBe(1);
-    await expect(reports).not.toContainText(/Orbital Labs|DISCO|Mercor/i);
-
-    await goSurface(page, "inbox");
-    const inbox = page.getByTestId("exact-web-inbox-surface");
-    await expect(inbox).toBeVisible();
-    await expect(inbox.locator(".nb-inbox-filter button")).toHaveCount(4);
-    const inboxStateCount = await inbox.evaluate((node) =>
-      Number(Boolean(node.querySelector('[data-testid="inbox-loading"]'))) +
-      Number((node.textContent ?? "").includes("No runtime nudges")) +
-      Number(node.querySelectorAll(".nb-ibx-row").length > 0));
-    expect(inboxStateCount, "Inbox exposes one loading, empty, or live runtime state").toBe(1);
-
-    await goSurface(page, "me");
-    const me = page.getByTestId("exact-web-me-surface");
-    await expect(me).toBeVisible();
-    const meStateCount = await me.evaluate((node) =>
-      Number(Boolean(node.querySelector('[data-testid="me-memory-loading"]'))) +
-      Number(Boolean(node.querySelector('[data-testid="me-memory-empty"]'))) +
-      Number(Boolean(node.querySelector(".nb-settings-section"))));
-    expect(meStateCount, "Me exposes one loading, empty, or live memory state").toBe(1);
-    await expect(me).not.toContainText(/Pro plan|Upgrade|usage/i);
-
-    await goSurface(page, "exactHome");
-    await page.locator(".nb-avm-trigger").click();
-    const menu = page.getByTestId("exact-avatar-menu");
-    await expect(menu).toBeVisible();
-    await expect(menu.locator(".nb-avm-section-label")).toContainText([
-      /Recent entities/,
-      "Recent sessions",
-      "Theme",
-    ]);
-    await expect(menu.locator(".nb-avm-theme-opt")).toHaveText(["Light", "Dark"]);
-    await expect(menu.locator(".nb-avm-link")).toHaveText(["Settings"]);
-    await expect(
-      menu.locator(".nb-avm-pro, .nb-avm-pulse, .nb-avm-usage, .nb-avm-upgrade"),
-    ).toHaveCount(0);
+    const composer = page.locator("textarea:visible");
+    await composer.fill("Give me the decision, evidence, and next action.");
+    await expect(composer).toHaveValue("Give me the decision, evidence, and next action.");
+    await expect(page.getByRole("button", { name: /run research/i })).toBeEnabled();
 
     expect(errors, `console errors during flow: ${errors.join(" | ")}`).toEqual([]);
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -509,11 +509,23 @@ window.addEventListener('message', async (message) => {
             if (id.includes('/node_modules/convex/')) {
               return 'convex-runtime';
             }
-            // Editor ecosystem — ALL related packages MUST land in one chunk.
-            // @blocknote/@tiptap/prosemirror have circular init deps; splitting
-            // them across chunks causes "Cannot access X before initialization".
-            // Including the full transitive set (unified/rehype/remark, yjs,
-            // emoji-mart, floating-ui) prevents Rollup from splitting them.
+            // Editor ecosystem: keep each internally coupled family intact.
+            // Splitting the stateful BlockNote/TipTap/ProseMirror graph causes
+            // "Cannot access X before initialization" at runtime.
+            // Markdown syntax/AST packages form a one-way dependency of the
+            // editor runtime. Keep that complete family together, but separate
+            // from the stateful editor graph so neither release chunk grows
+            // beyond the PWA or bundle-budget limits.
+            if (
+              id.includes('/node_modules/unified/') ||
+              id.includes('/node_modules/rehype-') ||
+              id.includes('/node_modules/remark-') ||
+              id.includes('/node_modules/hast-') ||
+              id.includes('/node_modules/mdast-') ||
+              id.includes('/node_modules/unist-')
+            ) {
+              return 'editor-markdown-vendor';
+            }
             if (
               id.includes('/node_modules/@tiptap/') ||
               id.includes('/node_modules/@blocknote/') ||
@@ -524,12 +536,6 @@ window.addEventListener('message', async (message) => {
               id.includes('/node_modules/y-protocols') ||
               id.includes('/node_modules/yjs/') ||
               id.includes('/node_modules/lib0/') ||
-              id.includes('/node_modules/unified/') ||
-              id.includes('/node_modules/rehype-') ||
-              id.includes('/node_modules/remark-') ||
-              id.includes('/node_modules/hast-') ||
-              id.includes('/node_modules/mdast-') ||
-              id.includes('/node_modules/unist-') ||
               id.includes('/node_modules/emoji-mart') ||
               id.includes('/node_modules/@emoji-mart/') ||
               id.includes('/node_modules/@floating-ui/')
@@ -714,10 +720,12 @@ window.addEventListener('message', async (message) => {
             return 'route-calendar';
           }
 
-          // Heavy editors from src
-          if (id.includes('/components/Editor/') || id.includes('UnifiedEditor')) {
-            return 'editor';
-          }
+          // Editor application modules already sit behind lazy route/component
+          // boundaries. Do not force them into one shared chunk: doing so creates
+          // a circular chunk graph with BlockNote, TipTap, Mantine, and React,
+          // which Rolldown resolves by merging the whole graph into a multi-MiB
+          // `editor` chunk. Leaving them unmatched preserves the real lazy
+          // boundaries and keeps every emitted chunk within the release budget.
 
           // Default: shared application code
           return undefined;


### PR DESCRIPTION
## Outcome
- makes `/redesign/chat` the single main-site NodeBench decision workspace
- retires the old cockpit, peer redesign pages, duplicate nav/search, and main-host report editors
- preserves report/artifact/receipt context inside chat, runtime provenance, streaming, approvals, exports, and failure states
- keeps recursive Workspace isolated to its dedicated hostname and bounded delivery routes intact
- adds an accessible Radix account menu, mobile read-scope disclosure, and valid legacy-link guards

## Verification
- `npx tsc --noEmit --pretty false`
- 20 focused one-surface tests
- 251 FastAgent tests passed (19 intentionally skipped)
- design system tests and design linter (0 high violations)
- production build
- responsive light/dark browser captures and clutter audit
- fresh 390px browser verification for legacy cockpit/workspace/report variants: 1 surface, 1 composer, 0 nav, 0 overflow
- independent expanded-scope audit: PASS, no reachable P0/P1/P2 findings

## Release
Ready for the repository P0 CI-gated squash merge. Do not bypass required checks.