### PR TITLE
fix(redesign): honor title-only requests behind any determiner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           src/features/dogfood/components/TasteBenchPanel.test.tsx
           src/features/evaluation/data/tasteBenchScenario.test.ts
           scripts/__tests__/releaseWorkflowContracts.test.ts
+          convex/domains/redesign/chatRuns.responseShape.test.ts
+          src/features/redesign/components/UniversalComposer.test.tsx
 
   scratchnode-launch-gates:
     name: ScratchNode launch gates

--- a/CHANGELOG/pages/redesign-chat.md
+++ b/CHANGELOG/pages/redesign-chat.md
@@ -3,6 +3,49 @@
 Append-only lane for the public redesign chat, reproducible answer receipts, and their
 transition into an authenticated live conversation. Newest entries first.
 
+## 2026-07-17 - Honor title-only requests behind any determiner
+
+`detectRequestedResponseShape` recognized `return only the title` but not `return only
+its title`: the determiner group listed articles (`a`/`the`) and no possessives, so the
+possessive phrasing fell through to the five-section memo and silently overrode an
+explicit user output constraint on a paid run. The determiner set now lives in one
+`TITLE_DETERMINER` constant shared by every title pattern, so the patterns cannot drift
+apart again. User-visible effect: a prompt ending `return only its title` now returns one
+plain title line instead of a Short answer / Why it matters / Evidence / Risks / Next
+action memo.
+
+This was found by re-verifying the 2026-07-16 production audit against `main` rather than
+trusting it. Four of its five P1s were already fixed by #550/#561/#564 within hours of the
+run; only this one survived. The suite stayed green throughout because every title case it
+asserted used the one phrasing that worked - so the regression tests here use the audit's
+**verbatim** production prompts, and both new test files were added to the CI runtime-smoke
+allowlist, which is an explicit file list rather than a full-suite run.
+
+Also corrected the `UniversalComposer` header comment, which still claimed "no provider
+names in UI / provider names appear only in the trace" - the opposite of the disclosure
+contract shipped in #550 - and pinned `DEFAULT_TIERS` to the runtime's `modelForTier` with
+a parity test, since the two were hand-maintained mirrors with no test binding them.
+
+**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: `pending`
+- Checks: `npx tsc --noEmit --pretty false` -> 0 errors. `npx vitest run
+  convex/domains/redesign/chatRuns.responseShape.test.ts
+  src/features/redesign/components/UniversalComposer.test.tsx` -> 16 passed. Fix reverted
+  in isolation to prove the guard: audit prompt fails `expected { kind: 'memo' } to deeply
+  equal { kind: 'title_only' }` (2 failed / 11 passed), restored -> 16 passed. Redesign
+  sweep `npx vitest run convex/domains/redesign src/features/redesign shared/redesign` ->
+  141 passed, 3 failed in `ScratchnodeEventsSurface.test.tsx`, confirmed pre-existing on
+  clean `main` with all edits stashed and unrelated to this change.
+- Visual proof: `not recorded` - no rendered surface changed; the response body shape is
+  produced by the runtime, and the composer edit is a comment.
+- Preview: `not recorded`
+- Production live: `not recorded`
+
+**Author**: Homen Shum + Claude Opus 4.8.
+**Touches**: this change is chat-runtime only; no other lane.
+
 ## 2026-07-16 - Contract NodeBench to one decision workspace
 
 NodeBench now has one primary product surface: the runtime-backed conversation at

--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -32,6 +32,46 @@ describe("redesign chat runtime response policy", () => {
     expect(detectRequestedResponseShape("Research Acme's market position.")).toEqual({ kind: "memo" });
   });
 
+  // Both prompts below are verbatim from the 2026-07-16 authenticated production
+  // runs. The possessive one silently rendered the five-section memo in prod while
+  // this suite stayed green, because every title case asserted here used "the".
+  it("honors the shape of the verbatim production prompts that regressed", () => {
+    expect(
+      detectRequestedResponseShape(
+        "Production recovery QA run 2026-07-16: From the attached Daily Brief, identify one unresolved claim and return only its title. Do not write, share, approve, or modify any data.",
+      ),
+    ).toEqual({ kind: "title_only" });
+
+    expect(
+      detectRequestedResponseShape(
+        "Production QA run 2026-07-16: Using the attached Daily Brief, return exactly two bullets: (1) the strongest supported claim with its best source, and (2) one concrete review gap. Do not write, share, approve, or modify any data.",
+      ),
+    ).toEqual({ kind: "bullets", count: 2 });
+  });
+
+  it("detects a title request behind any determiner, not just an article", () => {
+    for (const prompt of [
+      "Return only its title.",
+      "Return only their title.",
+      "Just give me his title.",
+      "Return only this title.",
+      "Return only title.",
+      "Provide its title only",
+      "Title-only please.",
+    ]) {
+      expect(detectRequestedResponseShape(prompt)).toEqual({ kind: "title_only" });
+    }
+  });
+
+  it("does not mistake incidental prose about titles for a shape request", () => {
+    expect(
+      detectRequestedResponseShape("Summarize the report and explain why its title is misleading."),
+    ).toEqual({ kind: "memo" });
+    expect(
+      detectRequestedResponseShape("Compare each vendor's job titles across the market."),
+    ).toEqual({ kind: "memo" });
+  });
+
   it("returns one plain title line while omitting memo-only fields", () => {
     const shaped = applyDeterministicResponsePolicy(
       "Provide a title only",

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -842,13 +842,29 @@ function parseRequestedCount(value: string): number | null {
   return Number.isInteger(count) && count >= 1 && count <= 12 ? count : null;
 }
 
+// Determiners that may precede "title". Articles alone drop possessive phrasings
+// such as "return only its title", which then fall back to the five-section memo
+// and silently override the user's explicit shape request. Kept in one place so
+// the patterns below cannot drift apart.
+const TITLE_DETERMINER = String.raw`(?:a |an |the |its |their |his |her |our |your |this |that )?`;
+
+const TITLE_ONLY_PATTERNS: RegExp[] = [
+  /\btitle[- ]only\b/,
+  new RegExp(
+    String.raw`\b(?:only|just) (?:give|return|output|provide|write|respond with)?\s*(?:me )?`
+      + TITLE_DETERMINER
+      + String.raw`title\b`,
+  ),
+  new RegExp(
+    String.raw`\b(?:give|return|output|provide|write|respond with) (?:me )?`
+      + TITLE_DETERMINER
+      + String.raw`title only\b`,
+  ),
+];
+
 export function detectRequestedResponseShape(prompt: string): RequestedResponseShape {
   const normalized = prompt.replace(/\s+/g, " ").trim().toLowerCase();
-  if (
-    /\btitle[- ]only\b/.test(normalized)
-    || /\b(?:only|just) (?:give|return|output|provide|write|respond with)?\s*(?:me )?(?:a |the )?title\b/.test(normalized)
-    || /\b(?:give|return|output|provide|write|respond with) (?:me )?(?:a |the )?title only\b/.test(normalized)
-  ) {
+  if (TITLE_ONLY_PATTERNS.some((pattern) => pattern.test(normalized))) {
     return { kind: "title_only" };
   }
 

--- a/src/features/redesign/components/UniversalComposer.test.tsx
+++ b/src/features/redesign/components/UniversalComposer.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { modelForTier } from "../../../../convex/domains/redesign/chatRuns";
 import {
   CANCEL_ARM_DELAY_MS,
   DEFAULT_TIERS,
@@ -26,6 +27,20 @@ describe("UniversalComposer runtime controls", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  // The preflight names a provider and model before a paid submit, but DEFAULT_TIERS
+  // is a hand-maintained mirror of the runtime's modelForTier. Drift between them
+  // makes the disclosure advertise a model the runtime never runs — and never prices.
+  it("discloses the exact model the chat runtime resolves for every offered tier", () => {
+    expect(DEFAULT_TIERS.length).toBeGreaterThan(0);
+
+    for (const tier of DEFAULT_TIERS) {
+      expect({ id: tier.id, model: tier.model }).toEqual({
+        id: tier.id,
+        model: modelForTier(tier.id),
+      });
+    }
   });
 
   it("does not let the second click of submit immediately cancel the new run", () => {

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -7,8 +7,11 @@
  *   - Bottom row: `+` tools menu (left) · mic (left) · keyboard hint · circular send (right).
  *   - Tools / paid-tier hints / estimates live behind the dropdown popover, not as a 4-pill row.
  *
- * Spec: "no provider names in UI" — the dropdown shows tiers (Auto / Quick / Deep / Compare),
- * not model names. Provider names appear only in the trace.
+ * Disclosure contract: a paid run must reveal its resolved provider and model
+ * BEFORE submit, not only afterwards in the trace. `DEFAULT_TIERS` therefore
+ * mirrors `modelForTier` in convex/domains/redesign/chatRuns.ts, and a parity
+ * test pins the two together — if they drift, the preflight advertises a model
+ * the runtime does not charge for.
  *
  * Submit: Enter sends. Shift+Enter inserts newline. ⌘↵ also sends.
  */


### PR DESCRIPTION
## What

`detectRequestedResponseShape` matched `return only the title` but not `return only its title`. The determiner group listed articles (`a`/`the`) and no possessives, so the possessive phrasing fell through to the five-section memo and **silently overrode an explicit user output constraint on a paid run**.

The determiner set now lives in one `TITLE_DETERMINER` constant shared by every title pattern — it was duplicated across two regexes, which is how they could disagree in the first place.

## Why this is the only P1 left from the 2026-07-16 audit

The audit listed five P1s. Re-verifying each against `main` rather than trusting the doc:

| Audit P1 | Verdict |
|---|---|
| Mobile wide-mode collapses chat to 70px | **RESOLVED** — #550 wrote the mobile rule at specificity (0,3,0) and lost a tie-break; #561 prepended `.rd-shell` → (0,4,0). Cause was misattributed: the rule was in `agent-workspace.css`, not `primitives.css`, and no "persisted wide-mode flag" exists (`nb-wide` is prototype-only) — the collapse was unconditional at ≤760px. |
| Double-click submit cancels the new run | **RESOLVED** — #550 added `CANCEL_ARM_DELAY_MS` + `cancelArmed`. The audit captured a ~66-minute window between #548 and #550. |
| Exact output constraints lose to memo template | **HALF LIVE → fixed here.** `exactly two bullets` already worked; `return only its title` did not. |
| Preflight withholds provider/model | **RESOLVED** — #550 deleted `Provider names appear in the trace, not here.` and now renders `Paid · {provider} · {model}` pre-submit. |
| Evidence lineage too coarse for "best source" | **RESOLVED for the audited case** — `sanitizeUnsupportedSuperlatives` already rewrites the superlative and appends a source-needed limitation. One residual remains, see below. |

The audit was taken against production hours before #550 landed, so it reads as stale against `main`.

## Why the suite stayed green while production failed

`responseShape.test.ts:29` asserted `"Return only the title."` — **the one phrasing that works**. The test encoded the bug's blind spot. The new tests therefore use the audit's **verbatim production prompts**, plus negative cases (`"explain why its title is misleading"`, `"job titles"`) to pin the false-positive risk the wider pattern introduces.

Both test files are added to the CI runtime-smoke allowlist, which is an **explicit file list**, not a full-suite run. Without that, this guard would never execute in CI — repeating the same blind spot one level up.

## Also included

- `DEFAULT_TIERS` pinned to the runtime's `modelForTier` with a parity test. They were hand-maintained mirrors with no test binding them; drift would make the paid preflight advertise a model the runtime never runs (and never prices).
- `UniversalComposer` header comment corrected — it still claimed "no provider names in UI / provider names appear only in the trace", the opposite of the contract shipped in #550, so a future reader could "restore" it and re-open that finding.

## Verification

- `npx tsc --noEmit --pretty false` → 0 errors
- `npx tsc -p convex --noEmit --pretty false` → 0 errors
- `npm run build` → clean
- Targeted → 16 passed
- **Guard proven**: reverting only the detector fix makes the audit's verbatim prompt fail with `expected { kind: 'memo' } to deeply equal { kind: 'title_only' }` (2 failed / 11 passed); restored → 16 passed
- Redesign sweep → 141 passed; 3 failures in `ScratchnodeEventsSurface.test.tsx` confirmed **pre-existing on clean main** with all edits stashed, and unrelated

No visual proof: no rendered surface changed — the response body is runtime-produced and the composer edit is a comment.

## Known gaps, not fixed here

1. **Evidence gate is run-level, not claim-level.** `sanitizeUnsupportedSuperlatives` fires only when *zero* supported URLs exist run-wide. A mixed run (one valid URL + five cached labels) still lets "strongest supported claim with its best source" through unsanitized. Fixing it is a product-design question, not a bug fix.
2. **`ScratchnodeEventsSurface.test.tsx` is red on main** (`ImportRecapButton:448` reads `.product` of undefined) and CI structurally cannot see it — it is not in the runtime-smoke allowlist.
3. **No 390px computed-geometry regression test.** The audit's release order asked for one; it never landed. The existing `AgentWorkspaceResponsiveCss.guard.test.ts` is a `readFileSync` + `toContain` string match and cannot catch a new higher-specificity competitor.
4. **Cancel arming is a 400ms timer, not a spatially distinct control.** Windows' double-click interval is user-configurable to ~900ms, so a slow/assistive double-click can still arm.
5. **`detectRequestedResponseShape` covers only `title_only` and `bullets`.** `"one sentence"`, `"a table"`, `"JSON"`, `"under 50 words"` still fall through to the memo — a feature gap, not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)