### PR TITLE
fix(redesign): ground best-source superlatives on their own citation

### DIFF
--- a/CHANGELOG/pages/redesign-chat.md
+++ b/CHANGELOG/pages/redesign-chat.md
@@ -3,6 +3,43 @@
 Append-only lane for the public redesign chat, reproducible answer receipts, and their
 transition into an authenticated live conversation. Newest entries first.
 
+## 2026-07-17 - Ground "best source" superlatives on their own citation
+
+`applyDeterministicResponsePolicy` only rewrote unsupported "best/strongest source|claim"
+superlatives when the run had **zero** URL-backed evidence rows. In a mixed run - one real
+URL plus several cached section labels like `Setup` or `Rising Action` - the superlative
+passed through, so an answer could claim "strongest supported claim with its best source"
+while the rendered best source was a label with no URL. On a paid runtime path that is a
+false confidence signal, not honest degradation.
+
+The gate is now sentence-level: a superlative stands only if its own sentence carries a
+`[N]` citation resolving to a URL-backed evidence row; otherwise that sentence is rewritten
+to "source or claim requiring verification" and the source-needed limitation is appended.
+A superlative citing a cached label, or citing nothing, is rewritten even when a URL-backed
+row exists elsewhere in the same run. The "best/strongest" pattern now lives in one shared
+constant used by both the sanitizer and the gate so they cannot disagree.
+
+This closes the residual left open by the 2026-07-16 audit follow-up (#565 fixed four of
+the five P1s; this is the fifth). Tracked as #566.
+
+**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: `pending`
+- Checks: `npx tsc -p convex --noEmit --pretty false` -> 0 errors. `npx vitest run
+  convex/domains/redesign/chatRuns.responseShape.test.ts` -> 16 passed (3 new: grounded
+  citation kept, cached-label citation rewritten, uncited superlative rewritten). Gate
+  reverted to run-level in isolation to prove the guard: the cached-label and uncited cases
+  fail `expected 'acme is the strongest supported claim...' not to contain 'strongest
+  supported claim'` (2 failed / 14 passed), restored -> 16 passed.
+- Visual proof: `not recorded` - the answer body is runtime-produced; no rendered surface
+  markup changed.
+- Preview: `not recorded`
+- Production live: `not recorded`
+
+**Author**: Homen Shum + Claude Opus 4.8.
+**Touches**: chat-runtime only.
+
 ## 2026-07-17 - Honor title-only requests behind any determiner
 
 `detectRequestedResponseShape` recognized `return only the title` but not `return only

--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -76,7 +76,7 @@ describe("redesign chat runtime response policy", () => {
     const shaped = applyDeterministicResponsePolicy(
       "Provide a title only",
       memo,
-      [{ source: "https://example.com/acme", quote: "Acme launched a new product." }],
+      [{ idx: 1, source: "https://example.com/acme", quote: "Acme launched a new product." }],
     );
 
     expect(shaped.shortAnswer).not.toContain("\n");
@@ -90,7 +90,7 @@ describe("redesign chat runtime response policy", () => {
     const shaped = applyDeterministicResponsePolicy(
       "Answer in exactly 3 bullets",
       memo,
-      [{ source: "https://example.com/acme", quote: "Acme launched a new product." }],
+      [{ idx: 1, source: "https://example.com/acme", quote: "Acme launched a new product." }],
     );
     const bullets = shaped.shortAnswer.split("\n");
 
@@ -202,5 +202,50 @@ describe("redesign chat runtime response policy", () => {
       expect(shaped.shortAnswer.toLowerCase()).not.toContain("strongest supported claim");
       expect(shaped.nextAction).toContain("Add a supported source URL");
     }
+  });
+
+  // Mixed run: one URL-backed row plus cached section labels. This is the exact
+  // shape the 2026-07-16 audit hit ("strongest supported claim with its best
+  // source" while the best source rendered as a label like "Setup"). A run-level
+  // "some URL exists" gate lets it pass; the claim must be grounded by its own
+  // citation.
+  const mixedEvidence = [
+    { idx: 1, source: "https://example.com/acme-filing", quote: "Acme raised $50M." },
+    { idx: 2, source: "Setup", quote: "Act I framing" },
+    { idx: 3, source: "Rising Action", quote: "Act II framing" },
+  ];
+
+  it("keeps a best-source superlative that cites the URL-backed row", () => {
+    const grounded = applyDeterministicResponsePolicy(
+      "Analyze Acme",
+      { shortAnswer: "Acme is the strongest supported claim [1].", whyItMatters: "", risks: [], nextAction: "" },
+      mixedEvidence,
+    );
+
+    expect(grounded.shortAnswer).toContain("strongest supported claim");
+    expect(grounded.risks).toEqual([]);
+  });
+
+  it("rewrites a best-source superlative citing a cached label even when a URL-backed row exists elsewhere", () => {
+    const mislabeled = applyDeterministicResponsePolicy(
+      "Analyze Acme",
+      { shortAnswer: "Acme is the strongest supported claim [2].", whyItMatters: "", risks: [], nextAction: "" },
+      mixedEvidence,
+    );
+
+    expect(mislabeled.shortAnswer.toLowerCase()).not.toContain("strongest supported claim");
+    expect(mislabeled.shortAnswer).toContain("source or claim requiring verification");
+    expect(mislabeled.risks.at(-1)).toContain("Source needed:");
+  });
+
+  it("rewrites a best-source superlative that carries no citation at all", () => {
+    const uncited = applyDeterministicResponsePolicy(
+      "Analyze Acme",
+      { shortAnswer: "Acme is the best source in the packet.", whyItMatters: "", risks: [], nextAction: "" },
+      mixedEvidence,
+    );
+
+    expect(uncited.shortAnswer.toLowerCase()).not.toContain("best source");
+    expect(uncited.risks.at(-1)).toContain("Source needed:");
   });
 });

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -893,11 +893,53 @@ function urlsInText(text: string): string[] {
   });
 }
 
+// One source of truth for the "best/strongest source|claim" superlative, shared
+// by the sanitizer (replace) and the sentence-level gate (test) so the two can
+// never disagree about what counts as an unsupported strength claim.
+const UNSUPPORTED_SUPERLATIVE_SOURCE = String.raw`\b(?:best|strongest)\s+(?:(?:supported|grounded|available)\s+)?(?:source|claim|evidence)\b`;
+const UNSUPPORTED_SUPERLATIVE_TEST = new RegExp(UNSUPPORTED_SUPERLATIVE_SOURCE, "i");
+
 function sanitizeUnsupportedSuperlatives(text: string): string {
   return text.replace(
-    /\b(?:best|strongest)\s+(?:(?:supported|grounded|available)\s+)?(?:source|claim|evidence)\b/gi,
+    new RegExp(UNSUPPORTED_SUPERLATIVE_SOURCE, "gi"),
     "source or claim requiring verification",
   );
+}
+
+function citationIndices(text: string): number[] {
+  return [...text.matchAll(/\[(\d+)\]/g)].map((match) => Number(match[1]));
+}
+
+/**
+ * Sentence-level honesty gate for "best/strongest source|claim" superlatives.
+ *
+ * A run-level "some supported URL exists somewhere" check is too weak: a mixed
+ * run (one URL-backed row plus several cached section labels) would let the
+ * answer assert "strongest supported claim with its best source" while the
+ * rendered best source is a label with no URL. So the sentence making the
+ * superlative must itself cite a [N] marker resolving to a URL-backed evidence
+ * row; otherwise the superlative is rewritten and the caller appends the
+ * source-needed limitation.
+ */
+function gateSuperlativeClaims(
+  text: string,
+  supportedIdx: Set<number>,
+): { text: string; sanitizedUngrounded: boolean } {
+  if (!UNSUPPORTED_SUPERLATIVE_TEST.test(text)) {
+    return { text, sanitizedUngrounded: false };
+  }
+  let sanitizedUngrounded = false;
+  // Split on sentence-final punctuation, but keep a citation marker that trails
+  // the terminator ("...claim. [1]") attached to the sentence it annotates.
+  const sentences = text.split(/(?<=[.!?])\s+(?!\[\d+\])/);
+  const gated = sentences.map((sentence) => {
+    if (!UNSUPPORTED_SUPERLATIVE_TEST.test(sentence)) return sentence;
+    const grounded = citationIndices(sentence).some((idx) => supportedIdx.has(idx));
+    if (grounded) return sentence;
+    sanitizedUngrounded = true;
+    return sanitizeUnsupportedSuperlatives(sentence);
+  });
+  return { text: gated.join(" "), sanitizedUngrounded };
 }
 
 function compactResponseUnit(text: string, stripCitations = false): string {
@@ -944,21 +986,29 @@ export function applyDeterministicResponsePolicy(
   prompt: string,
   parsed: ParsedMemo,
   evidence: Array<{
+    idx?: number;
     source: string;
     quote?: string;
     blocking?: boolean;
     verificationState?: EvidenceVerificationState;
   }>,
 ): ParsedMemo {
-  const supportedUrls = evidence.flatMap((row) => {
-    const url = sourceUrl(row.source);
-    return url
+  const supportedRows = evidence.filter(
+    (row) =>
+      sourceUrl(row.source)
       && row.blocking !== true
       && row.verificationState !== "unsupported"
-      && row.verificationState !== "fetch_blocked"
-      ? [url]
-      : [];
+      && row.verificationState !== "fetch_blocked",
+  );
+  const supportedUrls = supportedRows.flatMap((row) => {
+    const url = sourceUrl(row.source);
+    return url ? [url] : [];
   });
+  // Which citation markers ([N]) point at a URL-backed row. Drives the
+  // sentence-level superlative gate below.
+  const supportedIdx = new Set(
+    supportedRows.flatMap((row) => (row.idx !== undefined ? [row.idx] : [])),
+  );
   const requestedUrls = urlsInText(prompt);
   // Grounding providers commonly return an opaque redirect even when the
   // user supplied the canonical source. Keep the provider URL in evidence,
@@ -967,17 +1017,37 @@ export function applyDeterministicResponsePolicy(
   const primarySupportedUrl = hasSupportedUrl
     ? requestedUrls[0] ?? supportedUrls[0]
     : null;
-  const honest: ParsedMemo = hasSupportedUrl
-    ? parsed
-    : {
-        shortAnswer: sanitizeUnsupportedSuperlatives(parsed.shortAnswer),
-        whyItMatters: sanitizeUnsupportedSuperlatives(parsed.whyItMatters),
+  let honest: ParsedMemo;
+  if (hasSupportedUrl) {
+    // Some URL-backed evidence exists, but a superlative must be grounded by its
+    // OWN citation, not by the mere presence of a URL elsewhere in the run.
+    const gatedShort = gateSuperlativeClaims(parsed.shortAnswer, supportedIdx);
+    const gatedWhy = gateSuperlativeClaims(parsed.whyItMatters, supportedIdx);
+    if (gatedShort.sanitizedUngrounded || gatedWhy.sanitizedUngrounded) {
+      honest = {
+        shortAnswer: gatedShort.text,
+        whyItMatters: gatedWhy.text,
         risks: [
-          ...parsed.risks.map(sanitizeUnsupportedSuperlatives).filter((risk) => risk !== SOURCE_NEEDED_LIMITATION),
+          ...parsed.risks.filter((risk) => risk !== SOURCE_NEEDED_LIMITATION),
           SOURCE_NEEDED_LIMITATION,
         ],
-        nextAction: "Add a supported source URL before selecting or promoting any claim.",
+        nextAction: parsed.nextAction,
       };
+    } else {
+      // No ungrounded superlative — leave the parsed memo byte-for-byte intact.
+      honest = parsed;
+    }
+  } else {
+    honest = {
+      shortAnswer: sanitizeUnsupportedSuperlatives(parsed.shortAnswer),
+      whyItMatters: sanitizeUnsupportedSuperlatives(parsed.whyItMatters),
+      risks: [
+        ...parsed.risks.map(sanitizeUnsupportedSuperlatives).filter((risk) => risk !== SOURCE_NEEDED_LIMITATION),
+        SOURCE_NEEDED_LIMITATION,
+      ],
+      nextAction: "Add a supported source URL before selecting or promoting any claim.",
+    };
+  }
 
   const shape = detectRequestedResponseShape(prompt);
   if (shape.kind === "memo") return honest;


### PR DESCRIPTION
## What

`applyDeterministicResponsePolicy` (`convex/domains/redesign/chatRuns.ts`) sanitized "best/strongest source|claim" superlatives only when the run had **zero** URL-backed evidence rows. In a **mixed** run — one real URL plus several cached section labels (`Setup`, `Rising Action`) — the superlative passed through, so an answer could assert *"strongest supported claim with its best source"* while the rendered best source was a label with no URL. On a paid runtime path that is false confidence, not honest degradation.

Closes #566. This is the **fifth** and last P1 from the 2026-07-16 production audit; #565 fixed the other four (or verified them already fixed by #550/#561/#564).

## The fix — sentence-level citation gate

A superlative now stands only if **its own sentence** carries a `[N]` marker resolving to a URL-backed evidence row. Otherwise that sentence is rewritten to "source or claim requiring verification" and the source-needed limitation is appended.

- Superlative cites `[1]` (the URL-backed row) → kept.
- Superlative cites `[2]` (a cached label) → rewritten, **even though `[1]` exists elsewhere in the run**.
- Superlative with no citation → rewritten.

Mechanics:
- Widened the `evidence` param to carry `idx` (production rows already have it — set at the `geminiEvidence`/`fallbackEvidence`/`memoryEvidence` construction; only the local param type omitted it). `idx` is optional so existing callers compile.
- `supportedIdx` = the `idx` set of rows that are URL-backed and not blocked/unsupported/fetch_blocked — computed from the same `supportedRows` filter that already drives `supportedUrls` (no duplicated predicate).
- The "best/strongest" pattern is extracted to one `UNSUPPORTED_SUPERLATIVE_SOURCE` constant shared by the sanitizer (`replace`) and the gate (`test`) so they can't drift — the same class of bug as the determiner fix in #565.
- When no superlative is present, the parsed memo is returned **byte-for-byte** as before; the run-level sanitize-all path for zero-URL runs is unchanged.

## Verification

- `npx tsc -p convex --noEmit --pretty false` → 0 errors
- `npx vitest run convex/domains/redesign/chatRuns.responseShape.test.ts` → 16 passed (3 new)
- **Guard proven**: reverting only the gate to the old run-level check makes the cached-label and uncited cases fail with `expected 'acme is the strongest supported claim…' not to contain 'strongest supported claim'` (2 failed / 14 passed); restored → 16 passed
- This test file is already in the CI runtime-smoke allowlist (added in #565), so the new guards run in CI

No visual proof: the answer body is runtime-produced; no rendered surface markup changed.

## Deliberately not in scope

Full claim→source binding at claim granularity (the `claim.sourceRefIds` model in `shared/productAnswerControl.ts`) is a larger design change touching both renderers and is not attempted here. This PR closes the specific audited honesty gap; issue #566 can track the broader model if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)