### PR TITLE
fix: resolve all four audit hardening residuals (#567-#570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           scripts/__tests__/releaseWorkflowContracts.test.ts
           convex/domains/redesign/chatRuns.responseShape.test.ts
           src/features/redesign/components/UniversalComposer.test.tsx
+          src/features/redesign/surfaces/ScratchnodeEventsSurface.test.tsx
 
   scratchnode-launch-gates:
     name: ScratchNode launch gates

--- a/CHANGELOG/pages/redesign-chat.md
+++ b/CHANGELOG/pages/redesign-chat.md
@@ -3,6 +3,48 @@
 Append-only lane for the public redesign chat, reproducible answer receipts, and their
 transition into an authenticated live conversation. Newest entries first.
 
+## 2026-07-17 - Resolve the four hardening residuals from the production audit
+
+The 2026-07-16 audit cycle left four filed residuals (#567-#570); all four land here.
+
+1. **Red tests CI could not see (#567)** - three ScratchnodeEventsSurface tests failed on
+   clean main (`TypeError: reading 'product'`) because the test's api mock predated
+   ImportRecapButton's `domains.product.scratchnodeImport` query, and the runtime-smoke
+   allowlist never ran the file. The api mock is now a Proxy that degrades unknown
+   function refs to unresolved queries, the missing `useMutation` mock is added, two
+   scenarios cover the import affordance's published/unresolved gates, and the file joins
+   the CI allowlist.
+2. **Timer-only cancel guard (#568)** - Stop and submit are both always rendered: Stop in
+   a reserved `visibility:hidden` slot, submit staying at identical coordinates while
+   streaming (disabled). A double-click's second click lands on an inert control at ANY
+   user double-click interval; the 400ms arming stays as defense in depth.
+3. **Shape detector gap (#569)** - "in one sentence", "a single paragraph", and
+   "under N words" are now detected, instructed via an exhaustive
+   `responseShapeSystemInstructions` switch, and deterministically enforced (first-sentence
+   extraction, prose collapse, sentence-accumulating word budget). Honesty survives
+   compaction: unsupported runs carry `Source needed:` within the requested shape.
+   JSON/table stay model-side deliberately - the render path is markdown prose.
+4. **No computed-geometry regression capture (#570)** - one-flow-regression (Tier B,
+   per-PR) gains a 390x844 test asserting `.rd-shell__main` resolves to ONE grid track and
+   `main#main-content` stays >300px wide - the audit's 70px collapse was invisible to both
+   the CSS-source string guard and the document-overflow boolean.
+
+**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: `pending`
+- Checks: `npx tsc --noEmit` -> 0 errors. Full runtime-smoke allowlist locally ->
+  312 passed / 25 skipped (integration skips without env keys, matching CI). Adjacent
+  guards (ChatResponseShape, ChatRunLifecycle, ChatContinuation, sourceVerificationPolicy)
+  -> 12 passed.
+- Visual proof: `not recorded` - behavior changes are runtime/composer mechanics.
+- Preview: Tier B one-flow-regression includes the new 390px geometry test on this PR.
+- Production live: `not recorded` at entry time.
+
+**Author**: Homen Shum + Claude Fable 5.
+**Touches**: [components/fast-agent-panel.md](../components/fast-agent-panel.md) is NOT
+touched - the composer change is redesign-chat's UniversalComposer, not FastAgentPanel.
+
 ## 2026-07-17 - Ground "best source" superlatives on their own citation
 
 `applyDeterministicResponsePolicy` only rewrote unsupported "best/strongest source|claim"
@@ -22,10 +64,10 @@ constant used by both the sanitizer and the gate so they cannot disagree.
 This closes the residual left open by the 2026-07-16 audit follow-up (#565 fixed four of
 the five P1s; this is the fifth). Tracked as #566.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: `#571` / `6198dc39`.
 
 **Evidence state**:
-- Source: `pending`
+- Source: `merged`
 - Checks: `npx tsc -p convex --noEmit --pretty false` -> 0 errors. `npx vitest run
   convex/domains/redesign/chatRuns.responseShape.test.ts` -> 16 passed (3 new: grounded
   citation kept, cached-label citation rewritten, uncited superlative rewritten). Gate
@@ -63,10 +105,10 @@ names in UI / provider names appear only in the trace" - the opposite of the dis
 contract shipped in #550 - and pinned `DEFAULT_TIERS` to the runtime's `modelForTier` with
 a parity test, since the two were hand-maintained mirrors with no test binding them.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: `#565` / `b2d12ae0`.
 
 **Evidence state**:
-- Source: `pending`
+- Source: `merged`
 - Checks: `npx tsc --noEmit --pretty false` -> 0 errors. `npx vitest run
   convex/domains/redesign/chatRuns.responseShape.test.ts
   src/features/redesign/components/UniversalComposer.test.tsx` -> 16 passed. Fix reverted

--- a/convex/domains/redesign/chatRuns.responseShape.test.ts
+++ b/convex/domains/redesign/chatRuns.responseShape.test.ts
@@ -63,6 +63,91 @@ describe("redesign chat runtime response policy", () => {
     }
   });
 
+  // Issue #569 — every explicit shape beyond title/bullets used to fall
+  // through to the five-section memo. These scenarios model an analyst
+  // pasting exact-output constraints into the composer.
+  it("detects single-sentence, single-paragraph, and word-limit requests", () => {
+    expect(detectRequestedResponseShape("Summarize the brief in one sentence.")).toEqual({ kind: "sentence" });
+    expect(detectRequestedResponseShape("Give me just one sentence on the risk.")).toEqual({ kind: "sentence" });
+    expect(detectRequestedResponseShape("Write a one-sentence summary.")).toEqual({ kind: "sentence" });
+    expect(detectRequestedResponseShape("Explain the funding round in a single paragraph.")).toEqual({ kind: "paragraph" });
+    expect(detectRequestedResponseShape("One-paragraph answer please.")).toEqual({ kind: "paragraph" });
+    expect(detectRequestedResponseShape("Summarize in under 50 words.")).toEqual({ kind: "word_limit", limit: 50 });
+    expect(detectRequestedResponseShape("Answer in 30 words or fewer.")).toEqual({ kind: "word_limit", limit: 30 });
+    expect(detectRequestedResponseShape("No more than 80 words.")).toEqual({ kind: "word_limit", limit: 80 });
+  });
+
+  it("keeps memo for incidental or degenerate shape phrasing", () => {
+    // The memo template itself says "one sentence" per heading — user prose
+    // that merely mentions sentences/paragraphs must not flip the shape.
+    expect(detectRequestedResponseShape("The first sentence of their pitch is misleading.")).toEqual({ kind: "memo" });
+    expect(detectRequestedResponseShape("Compare the opening paragraph across both reports.")).toEqual({ kind: "memo" });
+    // Degenerate or absurd limits never bind.
+    expect(detectRequestedResponseShape("Summarize in under 2 words.")).toEqual({ kind: "memo" });
+    expect(detectRequestedResponseShape("Summarize in under 90000 words.")).toEqual({ kind: "memo" });
+    // Bullets outrank a word limit when both appear.
+    expect(
+      detectRequestedResponseShape("Give me exactly 3 bullets, under 50 words."),
+    ).toEqual({ kind: "bullets", count: 3 });
+  });
+
+  it("returns exactly one sentence while omitting memo-only fields", () => {
+    // idx binds the [1] marker to the URL-backed row so the #571 superlative
+    // gate recognizes the claim as grounded and leaves the sentence intact.
+    const shaped = applyDeterministicResponsePolicy(
+      "Summarize the brief in one sentence.",
+      memo,
+      [{ idx: 1, source: "https://example.com/acme", quote: "Acme launched a new product." }],
+    );
+    expect(shaped.shortAnswer).toBe("Acme is the strongest supported claim in the current packet. [1]");
+    expect(shaped.whyItMatters).toBe("");
+    expect(shaped.risks).toEqual([]);
+    expect(shaped.nextAction).toBe("");
+  });
+
+  it("collapses the memo into one paragraph and keeps the source-needed limitation inline when unsupported", () => {
+    const supported = applyDeterministicResponsePolicy(
+      "Explain it in a single paragraph.",
+      memo,
+      [{ source: "https://example.com/acme", quote: "Acme launched a new product." }],
+    );
+    expect(supported.shortAnswer).not.toContain("\n");
+    expect(supported.whyItMatters).toBe("");
+
+    const unsupported = applyDeterministicResponsePolicy(
+      "Explain it in a single paragraph.",
+      memo,
+      [{ source: "Setup" }],
+    );
+    // Honesty survives the compact shape: the limitation rides inside the
+    // paragraph because compact renders hide the risks section entirely.
+    expect(unsupported.shortAnswer).toContain("Source needed");
+    expect(unsupported.risks).toEqual([]);
+  });
+
+  it("enforces an explicit word limit deterministically, including the honesty prefix", () => {
+    const longMemo = {
+      ...memo,
+      shortAnswer:
+        "Acme closed the round. The filing lists twelve investors across three continents and two follow-on commitments.",
+    };
+    const shaped = applyDeterministicResponsePolicy(
+      "Summarize in under 8 words.",
+      longMemo,
+      [{ source: "https://example.com/acme", quote: "Acme closed the round." }],
+    );
+    expect(shaped.shortAnswer.split(/\s+/).length).toBeLessThanOrEqual(8);
+    expect(shaped.whyItMatters).toBe("");
+
+    const unsupported = applyDeterministicResponsePolicy(
+      "Summarize in under 8 words.",
+      longMemo,
+      [{ source: "Setup" }],
+    );
+    expect(unsupported.shortAnswer.startsWith("Source needed:")).toBe(true);
+    expect(unsupported.shortAnswer.split(/\s+/).length).toBeLessThanOrEqual(8);
+  });
+
   it("does not mistake incidental prose about titles for a shape request", () => {
     expect(
       detectRequestedResponseShape("Summarize the report and explain why its title is misleading."),

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -817,7 +817,10 @@ export interface ParsedMemo {
 export type RequestedResponseShape =
   | { kind: "memo" }
   | { kind: "title_only" }
-  | { kind: "bullets"; count: number };
+  | { kind: "bullets"; count: number }
+  | { kind: "sentence" }
+  | { kind: "paragraph" }
+  | { kind: "word_limit"; limit: number };
 
 const RESPONSE_COUNT_WORDS: Record<string, number> = {
   one: 1,
@@ -862,6 +865,39 @@ const TITLE_ONLY_PATTERNS: RegExp[] = [
   ),
 ];
 
+// "one sentence" / "one paragraph" requests. The unit is parameterized so the
+// two shapes cannot drift apart the way the title determiners once did (#565).
+function singleUnitPatterns(unit: string): RegExp[] {
+  return [
+    new RegExp(String.raw`\b(?:in|as)\s+(?:exactly\s+)?(?:one|a\s+single|1)\s+${unit}\b`),
+    new RegExp(String.raw`\b(?:only|just)\s+(?:one|a\s+single|1)\s+${unit}\b`),
+    new RegExp(String.raw`\bone[- ]${unit}\s+(?:answer|summary|response|reply)\b`),
+  ];
+}
+const SINGLE_SENTENCE_PATTERNS = singleUnitPatterns("sentence");
+const SINGLE_PARAGRAPH_PATTERNS = singleUnitPatterns("paragraph");
+
+// "under 50 words" and equivalents. Bounds reject degenerate limits ("under 2
+// words") and absurd ones that would never bind ("under 90000 words").
+const WORD_LIMIT_MIN = 5;
+const WORD_LIMIT_MAX = 400;
+const WORD_LIMIT_PATTERNS: RegExp[] = [
+  /\b(?:under|within|at most|no more than|max(?:imum)?(?: of)?|fewer than|less than)\s+(\d+)\s+words\b/,
+  /\bin\s+(\d+)\s+words\s+or\s+(?:less|fewer)\b/,
+];
+
+function detectWordLimit(normalized: string): number | null {
+  for (const pattern of WORD_LIMIT_PATTERNS) {
+    const match = normalized.match(pattern);
+    if (!match) continue;
+    const limit = Number(match[1]);
+    if (Number.isInteger(limit) && limit >= WORD_LIMIT_MIN && limit <= WORD_LIMIT_MAX) {
+      return limit;
+    }
+  }
+  return null;
+}
+
 export function detectRequestedResponseShape(prompt: string): RequestedResponseShape {
   const normalized = prompt.replace(/\s+/g, " ").trim().toLowerCase();
   if (TITLE_ONLY_PATTERNS.some((pattern) => pattern.test(normalized))) {
@@ -872,7 +908,86 @@ export function detectRequestedResponseShape(prompt: string): RequestedResponseS
     /\b(?:exactly|in|as|using|give(?: me)?|return|output|provide|write)\s+(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:concise\s+|short\s+)?(?:bullet(?:\s+points?)?|bullets)\b/,
   );
   const count = bulletMatch ? parseRequestedCount(bulletMatch[1]) : null;
-  return count ? { kind: "bullets", count } : { kind: "memo" };
+  if (count) return { kind: "bullets", count };
+
+  if (SINGLE_SENTENCE_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return { kind: "sentence" };
+  }
+  if (SINGLE_PARAGRAPH_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return { kind: "paragraph" };
+  }
+  const wordLimit = detectWordLimit(normalized);
+  if (wordLimit !== null) return { kind: "word_limit", limit: wordLimit };
+
+  return { kind: "memo" };
+}
+
+/**
+ * System-prompt fragments for a requested response shape. One function so the
+ * shape detector, the model instruction, and the deterministic policy can
+ * never disagree about which shapes exist — adding a union member without a
+ * branch here is a compile error via the exhaustive switch.
+ */
+export function responseShapeSystemInstructions(shape: RequestedResponseShape): {
+  shapeInstruction: string;
+  citationInstruction: string;
+  calculationInstruction: string;
+} {
+  const inlineCitations =
+    "Use [1], [2], [3] inline cite markers when a statement has a supported source URL.";
+  const compactCalculation =
+    "If the request requires a calculation or reconciliation, include the exact derivation and pass/fail conclusion within the requested response shape.";
+  switch (shape.kind) {
+    case "title_only":
+      return {
+        shapeInstruction:
+          "The user requested a title-only response. Output exactly one plain-text title line with no heading, label, bullets, explanation, or memo sections.",
+        citationInstruction: "Do not include citation markers in the title.",
+        calculationInstruction: "",
+      };
+    case "bullets":
+      return {
+        shapeInstruction: `The user requested exactly ${shape.count} bullets. Output exactly ${shape.count} Markdown bullet lines beginning with "- " and no heading, preamble, conclusion, or memo sections.`,
+        citationInstruction: inlineCitations,
+        calculationInstruction:
+          "If the request requires a calculation or reconciliation, include the exact derivation and pass/fail conclusion within the requested bullet count.",
+      };
+    case "sentence":
+      return {
+        shapeInstruction:
+          "The user requested a single-sentence response. Output exactly one sentence with no heading, bullets, preamble, or memo sections.",
+        citationInstruction: inlineCitations,
+        calculationInstruction: compactCalculation,
+      };
+    case "paragraph":
+      return {
+        shapeInstruction:
+          "The user requested a single-paragraph response. Output exactly one plain-prose paragraph with no heading, bullets, or memo sections.",
+        citationInstruction: inlineCitations,
+        calculationInstruction: compactCalculation,
+      };
+    case "word_limit":
+      return {
+        shapeInstruction: `The user requested a response of at most ${shape.limit} words. Stay within ${shape.limit} words of plain prose with no heading, bullets, or memo sections.`,
+        citationInstruction: inlineCitations,
+        calculationInstruction: compactCalculation,
+      };
+    case "memo":
+      return {
+        shapeInstruction: `Produce a banker-style memo. Do not include To, From, Date, or Subject headers. Use exactly these markdown section headings:
+1. Short answer (one sentence with citation markers like [1] [2])
+2. Why it matters (one paragraph with citation markers)
+3. Evidence (3-5 bullets, each citing a source)
+4. Risks / unknowns (2-3 bullets)
+5. Next action (one imperative sentence)`,
+        citationInstruction: inlineCitations,
+        calculationInstruction: `If the user's request involves a numeric calculation, reconciliation, balancing check, or explicitly
+asks you to "show your math" / "show your work" / confirm a total: state the actual derivation
+(the specific numbers and operation, e.g. "$X - $Y = $Z") and an explicit pass/fail confirmation
+of what they asked you to verify inside "Why it matters" - do not just assert the conclusion. This
+does not apply to ordinary research/company/market questions.`,
+      };
+  }
 }
 
 function sourceUrl(source: string): string | null {
@@ -910,6 +1025,28 @@ function citationIndices(text: string): number[] {
   return [...text.matchAll(/\[(\d+)\]/g)].map((match) => Number(match[1]));
 }
 
+// Split on sentence-final punctuation, but keep a citation marker that trails
+// the terminator ("...claim. [1]") attached to the sentence it annotates.
+// Shared by the superlative gate and the sentence/word-limit shape policies.
+const SENTENCE_SPLITTER = /(?<=[.!?])\s+(?!\[\d+\])/;
+
+// Flatten memo prose into plain sentences: markdown bullet/number prefixes
+// removed per line, whitespace collapsed.
+function plainProse(parts: string[]): string {
+  return parts
+    .map((part) =>
+      part
+        .split("\n")
+        .map((line) => line.replace(/^\s*(?:[-*•]|\d+[.)])\s*/, "").trim())
+        .filter(Boolean)
+        .join(" "),
+    )
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 /**
  * Sentence-level honesty gate for "best/strongest source|claim" superlatives.
  *
@@ -929,9 +1066,7 @@ function gateSuperlativeClaims(
     return { text, sanitizedUngrounded: false };
   }
   let sanitizedUngrounded = false;
-  // Split on sentence-final punctuation, but keep a citation marker that trails
-  // the terminator ("...claim. [1]") attached to the sentence it annotates.
-  const sentences = text.split(/(?<=[.!?])\s+(?!\[\d+\])/);
+  const sentences = text.split(SENTENCE_SPLITTER);
   const gated = sentences.map((sentence) => {
     if (!UNSUPPORTED_SUPERLATIVE_TEST.test(sentence)) return sentence;
     const grounded = citationIndices(sentence).some((idx) => supportedIdx.has(idx));
@@ -1056,6 +1191,56 @@ export function applyDeterministicResponsePolicy(
     const title = (compactResponseUnit(honest.shortAnswer || honest.whyItMatters, true) || "Evidence review").slice(0, 240);
     return {
       shortAnswer: hasSupportedUrl ? title : `Source needed: ${title}`.slice(0, 240),
+      whyItMatters: "",
+      risks: [],
+      nextAction: "",
+    };
+  }
+
+  if (shape.kind === "sentence") {
+    const prose = plainProse([honest.shortAnswer]) || plainProse([honest.whyItMatters]) || "Evidence review.";
+    const sentence = (prose.split(SENTENCE_SPLITTER)[0] ?? prose).trim().slice(0, 400);
+    return {
+      shortAnswer: hasSupportedUrl ? sentence : `Source needed: ${sentence}`.slice(0, 400),
+      whyItMatters: "",
+      risks: [],
+      nextAction: "",
+    };
+  }
+
+  if (shape.kind === "paragraph") {
+    const body = plainProse([honest.shortAnswer, honest.whyItMatters]) || "Evidence review.";
+    const paragraph = hasSupportedUrl ? body : `${body} ${SOURCE_NEEDED_LIMITATION}`;
+    return {
+      shortAnswer: paragraph.slice(0, 1600),
+      whyItMatters: "",
+      risks: [],
+      nextAction: "",
+    };
+  }
+
+  if (shape.kind === "word_limit") {
+    // Honesty costs two words of the budget when no supported URL exists —
+    // "Source needed:" — rather than busting the user's explicit limit with
+    // the full limitation sentence.
+    const prefix = hasSupportedUrl ? "" : "Source needed: ";
+    const budget = Math.max(1, shape.limit - (prefix ? 2 : 0));
+    const prose = plainProse([honest.shortAnswer, honest.whyItMatters]) || "Evidence review.";
+    const words: string[] = [];
+    for (const sentence of prose.split(SENTENCE_SPLITTER)) {
+      const tokens = sentence.trim().split(/\s+/).filter(Boolean);
+      if (tokens.length === 0) continue;
+      if (words.length === 0 && tokens.length > budget) {
+        // Even the first sentence overruns: hard-trim at the word boundary so
+        // the explicit limit still wins over completeness.
+        words.push(...tokens.slice(0, budget));
+        break;
+      }
+      if (words.length + tokens.length > budget) break;
+      words.push(...tokens);
+    }
+    return {
+      shortAnswer: `${prefix}${words.join(" ") || "Evidence review."}`,
       whyItMatters: "",
       risks: [],
       nextAction: "",
@@ -1624,28 +1809,11 @@ export const runStreamingChat = internalAction({
         ? `\n\nA server-side VERIFIED_CALCULATION is available in the context packet's "verifiedCalculation" field: ${bankReconciliationFact.fact} This arithmetic has already been computed and checked for you. State it verbatim (the exact numbers and the tie/no-tie conclusion) inside "Why it matters" instead of recomputing or restating different numbers.`
         : "";
       const requestedResponseShape = detectRequestedResponseShape(args.prompt);
-      const responseShapeInstruction = requestedResponseShape.kind === "title_only"
-        ? "The user requested a title-only response. Output exactly one plain-text title line with no heading, label, bullets, explanation, or memo sections."
-        : requestedResponseShape.kind === "bullets"
-          ? `The user requested exactly ${requestedResponseShape.count} bullets. Output exactly ${requestedResponseShape.count} Markdown bullet lines beginning with \"- \" and no heading, preamble, conclusion, or memo sections.`
-          : `Produce a banker-style memo. Do not include To, From, Date, or Subject headers. Use exactly these markdown section headings:
-1. Short answer (one sentence with citation markers like [1] [2])
-2. Why it matters (one paragraph with citation markers)
-3. Evidence (3-5 bullets, each citing a source)
-4. Risks / unknowns (2-3 bullets)
-5. Next action (one imperative sentence)`;
-      const citationInstruction = requestedResponseShape.kind === "title_only"
-        ? "Do not include citation markers in the title."
-        : "Use [1], [2], [3] inline cite markers when a statement has a supported source URL.";
-      const calculationInstruction = requestedResponseShape.kind === "title_only"
-        ? ""
-        : requestedResponseShape.kind === "bullets"
-          ? "If the request requires a calculation or reconciliation, include the exact derivation and pass/fail conclusion within the requested bullet count."
-          : `If the user's request involves a numeric calculation, reconciliation, balancing check, or explicitly
-asks you to "show your math" / "show your work" / confirm a total: state the actual derivation
-(the specific numbers and operation, e.g. "$X - $Y = $Z") and an explicit pass/fail confirmation
-of what they asked you to verify inside "Why it matters" - do not just assert the conclusion. This
-does not apply to ordinary research/company/market questions.`;
+      const {
+        shapeInstruction: responseShapeInstruction,
+        citationInstruction,
+        calculationInstruction,
+      } = responseShapeSystemInstructions(requestedResponseShape);
       const systemPrompt = `You are NodeBench's evidence-first analyst. ${responseShapeInstruction}
 
 ${citationInstruction} ${liveGrounding.useLiveGrounding ? "Keep claims grounded in the web sources you retrieve. Prefer recency." : "Use only the selected memory/context packet and cached source refs; do not imply a fresh web search was performed."} If you can't find grounded evidence, say so explicitly.

--- a/src/features/redesign/components/UniversalComposer.test.tsx
+++ b/src/features/redesign/components/UniversalComposer.test.tsx
@@ -59,9 +59,17 @@ describe("UniversalComposer runtime controls", () => {
     fireEvent.click(screen.getByRole("button", { name: "Run research" }));
     expect(onSubmit).toHaveBeenCalledTimes(1);
 
-    // The parent flips streaming after accepting the first click. The control at
-    // the same coordinates is now Stop, but it stays inert through dblclick #2.
+    // The parent flips streaming after accepting the first click. The submit
+    // button STAYS at the same coordinates — disabled, so the second click of
+    // a double-click is structurally a no-op at any double-click interval.
+    // Stop lives in its own reserved slot and is also arm-delayed.
     rerender(<UniversalComposer {...props} streaming />);
+    const submit = screen.getByRole("button", { name: "Run research" });
+    expect(submit).toBeDisabled();
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+
     const stop = screen.getByRole("button", { name: "Cancel active run" });
     expect(stop).toBeDisabled();
     fireEvent.click(stop);
@@ -70,6 +78,11 @@ describe("UniversalComposer runtime controls", () => {
 
     act(() => vi.advanceTimersByTime(CANCEL_ARM_DELAY_MS));
     expect(stop).toBeEnabled();
+    // Even armed, the submit slot stays inert — the double-click landing zone
+    // never becomes a cancel control (issue #568's structural requirement).
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
 
     // Escape remains usable even when focus is no longer in the textarea.
     fireEvent.keyDown(document, { key: "Escape" });

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -718,23 +718,41 @@ export function UniversalComposer({
               Chat now
             </button>
           )}
-          {streaming && onStop ? (
+          {/* Stop and submit are BOTH always rendered so neither ever moves:
+              the Stop slot is reserved (visibility:hidden) while idle, and the
+              submit button stays at identical coordinates while streaming —
+              merely disabled. The second click of a double-click therefore
+              lands on the inert submit, never on Stop, regardless of the
+              user's double-click interval. The CANCEL_ARM_DELAY_MS arming
+              below stays as defense in depth for pointer replays that do
+              land on Stop (e.g. Escape spam, automation). */}
+          {onStop ? (
             <button
               type="button"
               onClick={() => {
-                if (cancelArmed) onStop();
+                if (streaming && cancelArmed) onStop();
               }}
-              disabled={!cancelArmed}
+              disabled={!streaming || !cancelArmed}
               aria-label="Cancel active run"
-              title={cancelArmed ? "Cancel active run (Esc)" : "Preparing cancel control"}
+              aria-hidden={!streaming}
+              tabIndex={streaming ? 0 : -1}
+              title={
+                !streaming
+                  ? undefined
+                  : cancelArmed
+                    ? "Cancel active run (Esc)"
+                    : "Preparing cancel control"
+              }
               className="rd-btn rd-btn--sm"
               style={{
                 gap: 6,
                 background: "var(--rd-amber)",
                 borderColor: "var(--rd-amber)",
                 color: "#fff",
-                opacity: cancelArmed ? 1 : 0.6,
-                cursor: cancelArmed ? "pointer" : "wait",
+                opacity: !streaming ? 0 : cancelArmed ? 1 : 0.6,
+                cursor: !streaming ? "default" : cancelArmed ? "pointer" : "wait",
+                visibility: streaming ? "visible" : "hidden",
+                pointerEvents: streaming ? undefined : "none",
               }}
             >
               <svg width={11} height={11} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -742,24 +760,23 @@ export function UniversalComposer({
               </svg>
               Stop
             </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => handleSubmit("research")}
-              disabled={!text.trim()}
-              aria-label="Run research"
-              title="Run research (Enter)"
-              className="rd-btn rd-btn--primary rd-composer-submit"
-              style={{
-                opacity: text.trim() ? 1 : 0.55,
-                cursor: text.trim() ? "pointer" : "not-allowed",
-              }}
-            >
-              <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.1} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M12 19V5M5 12l7-7 7 7" />
-              </svg>
-            </button>
-          )}
+          ) : null}
+          <button
+            type="button"
+            onClick={() => handleSubmit("research")}
+            disabled={!text.trim() || streaming}
+            aria-label="Run research"
+            title={streaming ? "Run in progress" : "Run research (Enter)"}
+            className="rd-btn rd-btn--primary rd-composer-submit"
+            style={{
+              opacity: text.trim() && !streaming ? 1 : 0.55,
+              cursor: text.trim() && !streaming ? "pointer" : "not-allowed",
+            }}
+          >
+            <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.1} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M12 19V5M5 12l7-7 7 7" />
+            </svg>
+          </button>
           {onRunOnList && batchTargets.length > 0 && (
             <button
               type="button"

--- a/src/features/redesign/surfaces/ScratchnodeEventsSurface.test.tsx
+++ b/src/features/redesign/surfaces/ScratchnodeEventsSurface.test.tsx
@@ -19,24 +19,52 @@ import { MemoryRouter } from "react-router-dom";
 type MockedResponses = {
   listMyJoinedEvents?: unknown;
   listMyNotes?: unknown;
+  scratchnodeImportStatus?: unknown;
 };
 let mockedResponses: MockedResponses = {};
+const mockRunImport = vi.fn(async () => ({ ok: true }));
 
 vi.mock("convex/react", () => ({
   useQuery: (fnRef: unknown, args: unknown) => {
     if (args === "skip") return undefined;
     if (fnRef === "fn:listMyJoinedEvents") return mockedResponses.listMyJoinedEvents;
     if (fnRef === "fn:listMyNotes") return mockedResponses.listMyNotes;
+    if (fnRef === "fn:getScratchnodeImportStatus") return mockedResponses.scratchnodeImportStatus;
     return undefined;
   },
+  useMutation: () => mockRunImport,
 }));
 
-vi.mock("../../../../convex/_generated/api", () => ({
-  api: {
-    scratchnodeHandoff: { listMyJoinedEvents: "fn:listMyJoinedEvents" },
-    notes: { listMyNotes: "fn:listMyNotes" },
-  },
-}));
+// The api mock is a Proxy so that a component adding a NEW `(api as any).x.y.z`
+// reference degrades to an unknown-function query (useQuery returns undefined,
+// the surface's honest gates render nothing) instead of throwing a TypeError at
+// property access. That exact TypeError shipped red on main for three tests
+// while CI's allowlist never ran this file (issue #567). Known functions still
+// resolve to stable "fn:" strings so responses stay keyed by name.
+vi.mock("../../../../convex/_generated/api", () => {
+  // Declared inside the factory: vi.mock is hoisted above top-level statements.
+  const KNOWN_API_FNS: Record<string, string> = {
+    "scratchnodeHandoff.listMyJoinedEvents": "fn:listMyJoinedEvents",
+    "notes.listMyNotes": "fn:listMyNotes",
+    "domains.product.scratchnodeImport.getScratchnodeImportStatus":
+      "fn:getScratchnodeImportStatus",
+    "domains.product.scratchnodeImport.importPublishedWiki": "fn:importPublishedWiki",
+  };
+  const apiNode = (path: string): unknown => {
+    const known = KNOWN_API_FNS[path];
+    if (known) return known;
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (typeof prop !== "string") return undefined;
+          return apiNode(path ? `${path}.${prop}` : prop);
+        },
+      },
+    );
+  };
+  return { api: apiNode("") };
+});
 
 import { ScratchnodeEventsSurface } from "./ScratchnodeEventsSurface";
 
@@ -227,5 +255,53 @@ describe("ScratchnodeEventsSurface — step 9 NodeBench handoff", () => {
     expect(getByTestId("scratchnode-events-loading")).toBeTruthy();
     expect(queryByTestId("scratchnode-events-empty-no-events")).toBeNull();
     expect(queryByTestId("scratchnode-events-empty-no-session")).toBeNull();
+  });
+
+  /**
+   * Scenario 7 — Attendee whose event has a published recap wiki.
+   * User: returning attendee; the host published the event wiki and the
+   *   attendee wants it inside NodeBench.
+   * Goal: see the import affordance on that event row and none on rows
+   *   without a published wiki (honest gate: no affordance without a
+   *   KNOWN published recap).
+   * Failure mode covered: the ImportRecapButton query reads an api path
+   *   (domains.product.scratchnodeImport) that this file's api mock did
+   *   not model — three tests crashed with a TypeError on clean main
+   *   while CI's runtime-smoke allowlist never ran the file (issue #567).
+   */
+  it("renders the import-recap affordance only when a published wiki exists", () => {
+    setMockedResponses({
+      listMyJoinedEvents: { joined: SAMPLE_EVENTS, _truncated: false },
+      scratchnodeImportStatus: {
+        published: true,
+        imported: false,
+        documentId: null,
+        entitySlug: null,
+      },
+    });
+    const { getAllByTestId } = renderSurface("session-power-user-9");
+    // The status mock is keyed by function (not per-slug), so every rendered
+    // row reports a published recap — assert one affordance per row.
+    expect(getAllByTestId(/scratchnode-import-recap-/)).toHaveLength(
+      SAMPLE_EVENTS.length,
+    );
+  });
+
+  /**
+   * Scenario 8 — Import status still loading (or wiki unpublished).
+   * User: attendee opening the list the moment after join; status query
+   *   has not resolved.
+   * Goal: no import affordance flashes before the published state is
+   *   KNOWN (mirrors the component's "honest gate" comment).
+   * Failure mode covered: affordance rendered from undefined status →
+   *   click on a recap that may not exist.
+   */
+  it("renders no import affordance while import status is unresolved", () => {
+    setMockedResponses({
+      listMyJoinedEvents: { joined: SAMPLE_EVENTS, _truncated: false },
+      // scratchnodeImportStatus intentionally absent → useQuery undefined
+    });
+    const { queryByTestId } = renderSurface("session-power-user-9");
+    expect(queryByTestId(/scratchnode-import-recap-/)).toBeNull();
   });
 });

--- a/tests/e2e/one-flow-regression.spec.ts
+++ b/tests/e2e/one-flow-regression.spec.ts
@@ -63,4 +63,51 @@ test.describe("ONE-FLOW REGRESSION", () => {
 
     expect(errors, `console errors during flow: ${errors.join(" | ")}`).toEqual([]);
   });
+
+  test("mobile 390px resolves the chat workspace to one full-width column", async ({ browser }) => {
+    // 2026-07-16 production audit: `.rd-shell__main` computed `70px 320px` at
+    // 390x844, clipping the chat to a 70px strip while the document-level
+    // horizontal-overflow boolean stayed false — so only COMPUTED geometry
+    // catches this class of regression (issue #570). The CSS-source guard
+    // (AgentWorkspaceResponsiveCss.guard.test.ts) string-matches the mobile
+    // rule but cannot detect a new higher-specificity competitor; this can.
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+    });
+    const page = await context.newPage();
+    try {
+      await installVercelPreviewBypass(page, BASE_URL);
+      await page.goto(`${BASE_URL}/redesign/chat`, {
+        waitUntil: "domcontentloaded",
+        timeout: 30_000,
+      });
+      await expect(page.getByTestId("one-surface-workspace")).toBeVisible({ timeout: 30_000 });
+
+      const geometry = await page.evaluate(() => {
+        const main = document.querySelector<HTMLElement>(".rd-shell__main");
+        const content = document.querySelector<HTMLElement>("main#main-content");
+        if (!main || !content) return null;
+        return {
+          gridTemplateColumns: getComputedStyle(main).gridTemplateColumns,
+          mainWidth: main.getBoundingClientRect().width,
+          contentWidth: content.getBoundingClientRect().width,
+        };
+      });
+
+      expect(geometry, ".rd-shell__main and main#main-content must exist on /redesign/chat").not.toBeNull();
+      const trackCount = geometry!.gridTemplateColumns.trim().split(/\s+/).length;
+      expect(
+        trackCount,
+        `expected a single grid column at 390px, got "${geometry!.gridTemplateColumns}"`,
+      ).toBe(1);
+      // The audit's failure mode left main#main-content at 70px. Full-width
+      // minus padding must stay in the hundreds.
+      expect(geometry!.contentWidth).toBeGreaterThan(300);
+      expect(geometry!.mainWidth).toBeGreaterThan(300);
+    } finally {
+      await context.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Resolves every open residual from the 2026-07-16 production audit cycle in one branch, four commits:

1. **#567 — red tests CI could not see**: the ScratchnodeEventsSurface api mock predated `ImportRecapButton`'s `domains.product.scratchnodeImport` query (TypeError on clean main) and the runtime-smoke allowlist never ran the file. Proxy-based api mock degrades unknown refs to unresolved queries, `useMutation` mock added, two new gate scenarios, file added to the CI allowlist.
2. **#568 — timer-only cancel guard**: Stop and submit are now both always rendered — Stop in a reserved hidden slot, submit staying at identical coordinates while streaming (disabled). The double-click's second click lands on an inert control at any user double-click interval; the 400ms arming remains as defense in depth.
3. **#569 — shape detector gap**: "in one sentence", "a single paragraph", "under N words" are detected, instructed via an exhaustive `responseShapeSystemInstructions` switch, and deterministically enforced with honesty preserved (`Source needed:` within the requested shape). JSON/table deliberately stay model-side.
4. **#570 — no computed-geometry regression capture**: one-flow-regression (Tier B, per-PR) gains a 390x844 test asserting `.rd-shell__main` resolves to one grid track and `main#main-content` >300px.

## Verification

- `npx tsc --noEmit` — 0 errors
- Full runtime-smoke allowlist locally — 312 passed / 25 skipped (matches CI skip behavior)
- Adjacent guards (ChatResponseShape, ChatRunLifecycle, ChatContinuation, sourceVerificationPolicy) — 12 passed
- `npx vite build` clean; new 390px test passed against the served bundle (2.5s)
- **Reversion proof (#570)**: reinjecting a higher-specificity two-column rule reproduces the audit's exact `70px 320px` geometry, which the new assertions reject
- **Reversion behavior (#567)**: without the mock fix the file fails 3/6 — and now CI runs it

Closes #567, closes #568, closes #569, closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)