### PR TITLE
fix(redesign): design nitpick pass — honest dark captures, state copy, icons, row layout

### DIFF
--- a/CHANGELOG/pages/redesign-chat.md
+++ b/CHANGELOG/pages/redesign-chat.md
@@ -3,6 +3,45 @@
 Append-only lane for the public redesign chat, reproducible answer receipts, and their
 transition into an authenticated live conversation. Newest entries first.
 
+## 2026-07-17 - Design nitpick pass over the 4-variant dogfood captures
+
+Pixel review of every capture (desktop/mobile x dark/light + interactions) after the
+recent workspace changes. Six findings, five fixed, one accepted:
+
+- **Dishonest dark evidence (P1)**: the capture spec's `setTheme` wrote only legacy
+  cockpit keys; `RedesignShell` reads `nodebench:redesign:theme`, so every "dark"
+  screenshot since #561 was a light render mislabeled dark. Spec now writes the
+  shell's key - pass-2 captures are the first honest dark evidence.
+- **Contradictory state copy (P2)**: the context-miss banner titled itself
+  "Notebook context selected" while the body said the context was unavailable.
+  Title now tracks the miss.
+- **Mobile truncation of load-bearing data (P2)**: the status row repeated the
+  context title the chip below already carries, pushing "12 attached sources"
+  into ellipsis at 390px. Row now leads with the count.
+- **Emoji chips (P2)**: starter chips used platform emoji against an all-SVG
+  surface; replaced with a shared STARTER_ICONS stroke-SVG set.
+- **Floating meta text (P3)**: `flex: 1 + max-width: 36ch` reserved a title-sized
+  column in the run-scope summary, leaving "Review · no shared writes" mid-air on
+  desktop once the title moved. Content-sized with shrink+ellipsis kept.
+- **Accepted**: first-chip two-line wrap is content-driven (dated title), not a
+  layout defect.
+
+Pass 3 re-capture: zero new findings; loop converged.
+
+**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+
+**Evidence state**:
+- Source: `pending`
+- Checks: `npx tsc --noEmit` -> 0 errors. Redesign feature suite -> 92 passed.
+  CSS/lifecycle/shape guards + composer suite -> 34 passed post-rebase.
+- Visual proof: `test-results/full-ui-dogfood/` pass-3 captures (not committed;
+  regenerate via the dogfood spec).
+- Preview: Tier B one-flow-regression runs on the PR.
+- Production live: `not recorded` at entry time.
+
+**Author**: Homen Shum + Claude Fable 5.
+**Touches**: ChatSurface, ChatEmptyState, agent-workspace.css, full-ui-dogfood spec.
+
 ## 2026-07-17 - Honor JSON and table response shapes end to end
 
 The last declared shape boundary falls: "as JSON" / "in a markdown table" are now
@@ -15,10 +54,10 @@ limitation cannot ride inside JSON without corrupting it. Both renderers now sho
 structured bodies in a bounded monospace block (`.rd-answer-structured`) with its own
 horizontal scroll, via a shared `isStructuredAnswer` so they cannot disagree.
 
-**PR / canonical main commit**: `PENDING #NNN MAIN SHA / FINAL QA`.
+**PR / canonical main commit**: `#573` / `e7e423fb`.
 
 **Evidence state**:
-- Source: `pending`
+- Source: `merged`
 - Checks: `npx tsc --noEmit` -> 0 errors. `npx vitest run chatRuns.responseShape +
   ChatResponseShape.guard + ChatRunLifecycle.guard` -> 30 passed (4 new: detector
   incl. incidental-mention negatives, fenced-JSON passthrough with brace-in-string,

--- a/src/features/redesign/agent-workspace.css
+++ b/src/features/redesign/agent-workspace.css
@@ -237,7 +237,11 @@
 
 [data-redesign] .rd-run-scope > summary span:first-of-type {
   min-width: 0;
-  flex: 1;
+  /* Size to content, shrink with ellipsis under pressure. flex: 1 reserved a
+     36ch column sized for the old title-bearing string, which left the
+     trailing "Review" span floating mid-row once the title moved to the
+     context chip. */
+  flex: 0 1 auto;
   max-width: 36ch;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/features/redesign/components/ChatEmptyState.tsx
+++ b/src/features/redesign/components/ChatEmptyState.tsx
@@ -3,17 +3,86 @@
  *
  * Used when ChatSurface has zero turns. Mirrors ChatGPT/Cursor/Claude's
  * "what would you like to do?" first-impression UX.
+ *
+ * Chip icons are inline stroke SVGs (the CardStack / composer house style),
+ * not emoji: emoji render with platform-specific color glyphs that ignore
+ * the theme and clash with every other icon on the surface.
  */
+
+import type { ReactNode } from "react";
 
 interface ChatEmptyStateProps {
   onPick: (prompt: string) => void;
-  starters?: Array<{ icon: string; title: string; prompt: string }>;
+  starters?: Array<{ icon: ReactNode; title: string; prompt: string }>;
 }
 
+function StarterIcon({ children }: { children: ReactNode }) {
+  return (
+    <svg
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** Shared starter glyphs — one place so live and default chip sets match. */
+export const STARTER_ICONS = {
+  search: (
+    <StarterIcon>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </StarterIcon>
+  ),
+  compare: (
+    <StarterIcon>
+      <path d="M3 3v18h18" />
+      <path d="M18 17V9" />
+      <path d="M13 17V5" />
+      <path d="M8 17v-3" />
+    </StarterIcon>
+  ),
+  watch: (
+    <StarterIcon>
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </StarterIcon>
+  ),
+  summarize: (
+    <StarterIcon>
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path d="M16 13H8" />
+      <path d="M16 17H8" />
+    </StarterIcon>
+  ),
+  promote: (
+    <StarterIcon>
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+      <path d="m9 12 2 2 4-4" />
+    </StarterIcon>
+  ),
+  export: (
+    <StarterIcon>
+      <path d="M12 3v12" />
+      <path d="m17 8-5-5-5 5" />
+      <path d="M3 15v4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-4" />
+    </StarterIcon>
+  ),
+} as const;
+
 const STARTERS = [
-  { icon: "🔍", title: "Run diligence on a company", prompt: "Run a banker-style diligence pass on the company I name. Focus on evidence, risks, and next action." },
-  { icon: "📊", title: "Compare a short list", prompt: "Compare these entities on funding, hiring velocity, source quality, and strategic fit. Use the Founder/banker lens." },
-  { icon: "📰", title: "What's new in my watchlist?", prompt: "Summarize what changed in my watchlist over the last 7 days. Group by signal class." },
+  { icon: STARTER_ICONS.search, title: "Run diligence on a company", prompt: "Run a banker-style diligence pass on the company I name. Focus on evidence, risks, and next action." },
+  { icon: STARTER_ICONS.compare, title: "Compare a short list", prompt: "Compare these entities on funding, hiring velocity, source quality, and strategic fit. Use the Founder/banker lens." },
+  { icon: STARTER_ICONS.watch, title: "What's new in my watchlist?", prompt: "Summarize what changed in my watchlist over the last 7 days. Group by signal class." },
 ];
 
 export function ChatEmptyState({ onPick, starters = STARTERS }: ChatEmptyStateProps) {

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -29,6 +29,7 @@ import {
 import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 import { buildConversationContext } from "../lib/chatContinuation";
 import { isStructuredAnswer } from "../../../../shared/redesign/answerFormat";
+import { STARTER_ICONS } from "../components/ChatEmptyState";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { LiveResearchChecklist, type ResearchStage, type ResearchStageId } from "../../research/LiveResearchChecklist";
@@ -265,7 +266,9 @@ function buildRunScopeSnapshot(args: {
     reads: runtimeContextPacket?.hasContext
       ? `${runtimeContextPacket.selectedContext.length} selected context items · ${runtimeContextPacket.sourceRefs.length} source refs`
       : liveDetail
-        ? `${liveDetail.title} · ${liveDetail.sourceCount} attached source${liveDetail.sourceCount === 1 ? "" : "s"}`
+        // The context chip directly below already names the context; repeating
+        // the title here pushed the source count into ellipsis at 390px.
+        ? `${liveDetail.sourceCount} attached source${liveDetail.sourceCount === 1 ? "" : "s"}`
         : "Prompt only · no report context attached",
     writes: "Review mode · no automatic shared writes",
     verification: blockedClaimCount > 0
@@ -458,13 +461,17 @@ function LaunchContextCard({
   };
   const artifactLabel = artifactKey ? artifactLabels[artifactKey] ?? "Artifact" : null;
 
-  let title = "Context selected";
+  // The title must agree with the body: claiming "selected" while the body
+  // admits the context is unavailable reads as a success state on a miss.
+  let title = detail ? "Context selected" : "Saved context unavailable";
   let body = detail
     ? `${detail.title} is attached to the next run with ${detail.sourceCount} source${detail.sourceCount === 1 ? "" : "s"}. Nothing is written until you explicitly ask.`
     : "The requested saved context is not available in this session. You can still ask a new question below.";
 
   if (artifactLabel) {
-    title = `${artifactLabel} context selected`;
+    title = detail
+      ? `${artifactLabel} context selected`
+      : `${artifactLabel} context unavailable`;
   } else if (requestedReportId || intent === "review-report") {
     title = detail ? "Report context selected" : "Requested report unavailable";
   } else if (intent === "account" || intent === "settings") {
@@ -527,10 +534,10 @@ export function ChatSurface({
   const liveStarters = useMemo(() => {
     if (!liveDetail) return undefined;
     return [
-      { icon: "🧾", title: `Summarize ${liveDetail.title}`, prompt: `Summarize ${liveDetail.title}. Keep it evidence-led and end with a next action.` },
-      { icon: "✅", title: "Promote strongest claim", prompt: `Promote the strongest verified signal from ${liveDetail.title} into a notebook claim with sources.` },
-      { icon: "🔎", title: "Find the review gaps", prompt: `List what still needs source review in ${liveDetail.title}, grouped by risk.` },
-      { icon: "📤", title: "Prepare an export", prompt: `Create a CRM-ready export summary for ${liveDetail.title}.` },
+      { icon: STARTER_ICONS.summarize, title: `Summarize ${liveDetail.title}`, prompt: `Summarize ${liveDetail.title}. Keep it evidence-led and end with a next action.` },
+      { icon: STARTER_ICONS.promote, title: "Promote strongest claim", prompt: `Promote the strongest verified signal from ${liveDetail.title} into a notebook claim with sources.` },
+      { icon: STARTER_ICONS.search, title: "Find the review gaps", prompt: `List what still needs source review in ${liveDetail.title}, grouped by risk.` },
+      { icon: STARTER_ICONS.export, title: "Prepare an export", prompt: `Create a CRM-ready export summary for ${liveDetail.title}.` },
     ];
   }, [liveDetail]);
   const [turns, setTurns] = useState<Turn[]>([]);

--- a/tests/e2e/full-ui-dogfood.spec.ts
+++ b/tests/e2e/full-ui-dogfood.spec.ts
@@ -203,6 +203,10 @@ async function setTheme(page: Page, theme: "dark" | "light") {
       }),
     );
     localStorage.setItem("theme", t);
+    // RedesignShell (the ONLY product surface since #561) reads this key.
+    // The two legacy keys above serve pre-redesign routes; without this one
+    // the "dark" variant screenshots silently captured light renders.
+    localStorage.setItem("nodebench:redesign:theme", t);
     localStorage.setItem("nodebench-redesign-qa-chrome", "1");
   }, theme);
 }


### PR DESCRIPTION
## Summary

Pixel review of all 4-variant dogfood captures (desktop/mobile × dark/light + interaction states) after the recent workspace changes. Six findings; five fixed, one accepted-by-design. Loop ran three capture passes and converged at zero new findings.

1. **Dishonest dark evidence (P1)** — the capture spec's `setTheme` wrote only the legacy cockpit theme keys; `RedesignShell` (the only surface since #561) reads `nodebench:redesign:theme`. Every "dark" screenshot was a mislabeled light render. The spec now writes the shell's key; pass-2 captures are the first honest dark evidence this pipeline has produced.
2. **Contradictory state copy (P2)** — context-miss banner titled "Notebook context selected" over a body admitting the context was unavailable. Title now tracks the miss for the artifact and default branches.
3. **Mobile truncation of load-bearing data (P2)** — the status row duplicated the context title carried by the chip directly below it, ellipsizing "12 attached sources" at 390px. Row now leads with the count.
4. **Emoji chips (P2)** — starter chips used platform emoji on an all-SVG surface; replaced with a shared `STARTER_ICONS` stroke-SVG set so the default and live chip sets cannot drift.
5. **Floating meta text (P3)** — `flex: 1` + `max-width: 36ch` reserved a title-sized column in the run-scope summary, leaving "Review · no shared writes" floating mid-row on desktop. Content-sized now, shrink + ellipsis kept.
6. **Accepted** — first-chip two-line wrap is content-driven (dated title), not a layout defect.

## Verification

- `npx tsc --noEmit` — 0 errors
- Redesign feature suite — 92 passed
- CSS/lifecycle/shape guards + composer suite — 34 passed post-rebase onto #573's main
- Pass-3 re-capture at all variants — status row flush, dark genuinely dark, SVG icons theme-aware, zero new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)