### PR TITLE
feat(qa): executable runtime UI contracts + generic contract runner

### DIFF
--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -303,7 +303,9 @@ jobs:
           fi
           # exact-kit-parity-prod: visual selector parity (per-PR canonical-component check)
           # one-flow-regression: full surface tour + A9 fallback + interactive chip behavior
-          npx playwright test tests/e2e/vercel-preview-security.spec.ts tests/e2e/exact-kit-parity-prod.spec.ts tests/e2e/one-flow-regression.spec.ts --project=chromium --reporter=line
+          # ui-contract-runner: executes docs/design/ui-contract/surfaces/*.contract.json
+          #   (anchors, computed geometry, theme wiring, state copy) against the preview
+          npx playwright test tests/e2e/vercel-preview-security.spec.ts tests/e2e/exact-kit-parity-prod.spec.ts tests/e2e/one-flow-regression.spec.ts tests/e2e/ui-contract-runner.spec.ts --project=chromium --reporter=line
 
       - name: Upload Playwright artifacts on failure
         if: failure()

--- a/docs/design/ui-contract/README.md
+++ b/docs/design/ui-contract/README.md
@@ -4,6 +4,27 @@ This directory is the append-only evidence store for NodeBench UI migrations.
 It is governed by [`../UI_CONTRACT.md`](../UI_CONTRACT.md); the machine-readable
 companion is [`src/design/designSystem.ts`](../../../src/design/designSystem.ts).
 
+## Runtime surface contracts (`surfaces/`)
+
+`surfaces/*.contract.json` are **executable** surface contracts — the third
+layer beside the static design manifest (designSystem.ts) and this evidence
+store. Each declares a surface's anchors, computed-geometry invariants, theme
+wiring (the storage key + attribute the shell actually reads), and
+deep-link-forced states with copy that must agree with reality.
+
+`tests/e2e/ui-contract-runner.spec.ts` executes every manifest against the
+live DOM per theme x viewport (Tier B runs it per-PR against the preview).
+Adding a surface means adding a manifest — no new spec code. Vision QA
+(Gemini loop, screenshot review) stays for taste; everything objectively
+checkable belongs in a contract here instead.
+
+Why this layer exists — two shipped failures no other layer could catch:
+the 2026-07-16 mobile collapse (computed `70px 320px` invisible to overflow
+booleans and CSS-source string guards) and the 2026-07-17 discovery that
+every "dark" QA capture since #561 was a light render because the capture
+spec wrote a theme key the shell no longer read. Both are now contract
+clauses (`geometry`, `theme.storageKey`).
+
 At the current `origin/main` boundary through PR #527, this directory contains
 the protocol and schema only. No dated proof folder is present, so this document
 does not claim screenshots, QA findings, an Agentic UI Bar score, preview

--- a/docs/design/ui-contract/surfaces/decision-workspace.contract.json
+++ b/docs/design/ui-contract/surfaces/decision-workspace.contract.json
@@ -1,0 +1,46 @@
+{
+  "schema": "nodebench-surface-contract-v1",
+  "surface": "decision-workspace",
+  "description": "The single NodeBench workspace (/redesign/chat). Every invariant here is executable by tests/e2e/ui-contract-runner.spec.ts against the live DOM — anchors, computed geometry, theme wiring, and deep-link-forced state copy.",
+  "route": "/redesign/chat",
+  "theme": {
+    "storageKey": "nodebench:redesign:theme",
+    "attribute": "data-redesign-theme",
+    "values": ["light", "dark"]
+  },
+  "viewports": [
+    { "name": "desktop", "width": 1440, "height": 900 },
+    { "name": "mobile", "width": 390, "height": 844 }
+  ],
+  "anchors": [
+    { "why": "one canonical workspace", "testId": "one-surface-workspace", "presence": "visible" },
+    { "why": "exactly one composer", "selector": "textarea:visible", "count": 1 },
+    { "why": "no legacy nav shell", "selector": "nav", "count": 0 },
+    { "why": "submit always present and named", "role": "button", "name": "Run research", "presence": "visible" },
+    { "why": "product surface marker for agents", "selector": "[data-product-surface=\"decision-workspace\"]", "count": 1 }
+  ],
+  "geometry": [
+    {
+      "why": "2026-07-16 audit: wide-mode rule collapsed chat to a 70px strip; overflow booleans missed it",
+      "selector": ".rd-shell__main",
+      "viewport": "mobile",
+      "gridTracks": 1,
+      "minWidthPx": 300
+    },
+    {
+      "why": "main content column must hold the viewport, not a rail sliver",
+      "selector": "main#main-content",
+      "viewport": "mobile",
+      "minWidthPx": 300
+    }
+  ],
+  "states": [
+    {
+      "name": "context-miss",
+      "why": "2026-07-17 nitpick pass: banner claimed 'selected' while body said unavailable",
+      "url": "/redesign/chat?report=__contract_missing__&artifact=notebook",
+      "expectText": "Notebook context unavailable",
+      "forbidText": "Notebook context selected"
+    }
+  ]
+}

--- a/tests/e2e/ui-contract-runner.spec.ts
+++ b/tests/e2e/ui-contract-runner.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * UI contract runner — executes every surface contract in
+ * docs/design/ui-contract/surfaces/*.contract.json against the live DOM.
+ *
+ * Agent-native QA: the surface DECLARES its invariants (anchors, computed
+ * geometry, theme wiring, deep-link-forced state copy) as data; this one
+ * generic spec verifies all of them per theme x viewport. Adding a surface
+ * means adding a manifest, not writing a new spec. Vision QA (Gemini loop,
+ * screenshot review) stays for taste; everything objective lives here,
+ * deterministically.
+ *
+ * Pattern: manifest + audit (guidance over enforcement) — the same shape as
+ * src/design/designSystem.ts, moved to runtime.
+ * Prior art:
+ *   - docs/design/UI_CONTRACT.md + manifest.schema.json (evidence layer)
+ *   - agents.md / MCP progressive discovery — machine-readable affordances
+ *   - Storybook play functions / ARIA AX-tree — declared, executable UI intent
+ * Case studies encoded here: the 2026-07-16 70px mobile collapse (geometry)
+ * and the 2026-07-17 mislabeled dark captures (theme.storageKey — the capture
+ * spec and this runner read the SAME key the shell reads).
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+import { installVercelPreviewBypass } from "./helpers/vercelPreview";
+
+const BASE_URL = (process.env.BASE_URL ?? "http://127.0.0.1:4173").replace(/\/$/, "");
+const SPEC_DIR = dirname(fileURLToPath(import.meta.url));
+const CONTRACTS_DIR = join(SPEC_DIR, "..", "..", "docs", "design", "ui-contract", "surfaces");
+
+interface SurfaceContract {
+  schema: string;
+  surface: string;
+  route: string;
+  theme: { storageKey: string; attribute: string; values: Array<"light" | "dark"> };
+  viewports: Array<{ name: string; width: number; height: number }>;
+  anchors?: Array<{
+    why: string;
+    testId?: string;
+    selector?: string;
+    role?: string;
+    name?: string;
+    presence?: "visible";
+    count?: number;
+  }>;
+  geometry?: Array<{
+    why: string;
+    selector: string;
+    viewport: string;
+    gridTracks?: number;
+    minWidthPx?: number;
+  }>;
+  states?: Array<{ name: string; why: string; url: string; expectText: string; forbidText?: string }>;
+}
+
+function loadContracts(): SurfaceContract[] {
+  return readdirSync(CONTRACTS_DIR)
+    .filter((f) => f.endsWith(".contract.json"))
+    .map((f) => JSON.parse(readFileSync(join(CONTRACTS_DIR, f), "utf8")) as SurfaceContract);
+}
+
+async function applyTheme(page: Page, contract: SurfaceContract, theme: "light" | "dark") {
+  await page.evaluate(
+    ([key, value]) => localStorage.setItem(key, value),
+    [contract.theme.storageKey, theme] as const,
+  );
+}
+
+const contracts = loadContracts();
+
+for (const contract of contracts) {
+  test.describe(`ui-contract › ${contract.surface}`, () => {
+    test.setTimeout(60_000);
+
+    for (const theme of contract.theme.values) {
+      for (const viewport of contract.viewports) {
+        test(`${theme} · ${viewport.name}: anchors + geometry + theme attribute`, async ({ page }) => {
+          await page.setViewportSize({ width: viewport.width, height: viewport.height });
+          await installVercelPreviewBypass(page, BASE_URL);
+          // First load establishes origin so localStorage is writable; the
+          // reload lets the shell's initial-state reader pick the theme up.
+          await page.goto(`${BASE_URL}${contract.route}`, { waitUntil: "domcontentloaded" });
+          await applyTheme(page, contract, theme);
+          await page.goto(`${BASE_URL}${contract.route}`, { waitUntil: "domcontentloaded" });
+
+          // Theme wiring: the attribute the stylesheet keys on must reflect
+          // the stored value — this is the invariant whose absence let every
+          // pre-2026-07-17 "dark" capture ship as a light render.
+          await expect(
+            page.locator(`[${contract.theme.attribute}="${theme}"]`).first(),
+          ).toBeAttached({ timeout: 30_000 });
+
+          for (const anchor of contract.anchors ?? []) {
+            const locator = anchor.testId
+              ? page.getByTestId(anchor.testId)
+              : anchor.role
+                ? page.getByRole(anchor.role as Parameters<Page["getByRole"]>[0], { name: anchor.name })
+                : page.locator(anchor.selector!);
+            if (anchor.count !== undefined) {
+              await expect(locator, anchor.why).toHaveCount(anchor.count, { timeout: 30_000 });
+            }
+            if (anchor.presence === "visible") {
+              await expect(locator.first(), anchor.why).toBeVisible({ timeout: 30_000 });
+            }
+          }
+
+          for (const rule of (contract.geometry ?? []).filter((g) => g.viewport === viewport.name)) {
+            const measured = await page.evaluate((selector) => {
+              const el = document.querySelector<HTMLElement>(selector);
+              if (!el) return null;
+              return {
+                gridTemplateColumns: getComputedStyle(el).gridTemplateColumns,
+                width: el.getBoundingClientRect().width,
+              };
+            }, rule.selector);
+            expect(measured, `${rule.why} — ${rule.selector} must exist`).not.toBeNull();
+            if (rule.gridTracks !== undefined) {
+              const tracks = measured!.gridTemplateColumns.trim().split(/\s+/).length;
+              expect(tracks, `${rule.why} — got "${measured!.gridTemplateColumns}"`).toBe(rule.gridTracks);
+            }
+            if (rule.minWidthPx !== undefined) {
+              expect(measured!.width, rule.why).toBeGreaterThan(rule.minWidthPx);
+            }
+          }
+        });
+      }
+    }
+
+    for (const state of contract.states ?? []) {
+      test(`state › ${state.name}: copy agrees with reality`, async ({ page }) => {
+        await installVercelPreviewBypass(page, BASE_URL);
+        await page.goto(`${BASE_URL}${state.url}`, { waitUntil: "domcontentloaded" });
+        await expect(page.getByText(state.expectText).first(), state.why).toBeVisible({
+          timeout: 30_000,
+        });
+        if (state.forbidText) {
+          await expect(page.getByText(state.forbidText), state.why).toHaveCount(0);
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Agent-native QA: the third contract layer beside the static design manifest (`src/design/designSystem.ts`) and the visual-evidence store. Surfaces now declare invariants as data — `docs/design/ui-contract/surfaces/*.contract.json` — and one generic Playwright runner (`tests/e2e/ui-contract-runner.spec.ts`) executes every manifest against the live DOM per theme × viewport. Adding a surface = adding a manifest, zero new spec code. Tier B runs the runner per-PR against the preview.

The seed contract for `decision-workspace` encodes:
- **anchors** — one workspace, one composer, no legacy nav, named submit, agent-discoverable surface marker
- **geometry** — the 2026-07-16 70px mobile collapse as `gridTracks: 1` + `minWidthPx: 300` clauses (computed style, not overflow booleans)
- **theme wiring** — `storageKey: nodebench:redesign:theme`; runner and shell read the *same* key, so the key drift that shipped mislabeled dark captures now fails loudly
- **states** — the context-miss banner as a deep-link-forced state with `expectText`/`forbidText` copy agreement

## Verification

- 5/5 against the live bundle (light/dark × desktop/mobile + state test) in 6.1s
- **Reversion proof**: flipping `gridTracks` to 2 fails exactly the two mobile variants; restored → 5/5
- Vision QA (Gemini loop / screenshot review) remains for taste; everything objectively checkable moves into contracts

Prior art: repo's own UI-contract evidence schema + designSystem manifest+audit pattern, agents.md / MCP progressive-discovery (machine-readable affordances), Storybook play functions, ARIA AX-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)