### PR TITLE
feat: add attested ActiveGraph offline canary

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,6 +57,20 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
+- **2026-07-28 · Codex `/root/activegraph_final_audit` →**
+  `backend/convex/schema.ts#agentTaskTraces+agentTaskSpans+nodeKitRunEvents`,
+  `backend/convex/domains/operations/taskManager/{mutations,nodeKitRunEvents,nodeKitRunExport,nodeKitRunRetention}*`,
+  `backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts#nodekit-events`,
+  `backend/convex/crons.ts#nodekit-retention`,
+  `scripts/nodekit/**`, `scripts/__tests__/{nodekitActiveGraphCanary,releaseWorkflowContracts}.test.ts`,
+  `evals/activegraph/**`, `evals/nodebench-*.json`,
+  `nodekit.yaml`, `nodeagent.yaml`, `agent/**`,
+  `packs/entity-intelligence/**`, `scripts/{preflight-deploy,lib/convexProject}.mjs`,
+  `docs/architecture/{NODEKIT_ACTIVEGRAPH_CANARY,STANDARD_REPO_TREE}.md`,
+  and `evidence/activegraph-*` · PR-ready release packaging, Docker replay,
+  scoped commit/push/PR · branch `codex/activegraph-canary`. No deploy or
+  production mutation.
+
 > **STANDARD-TREE MIGRATION (2026-07-19, feat/standard-tree-migration): repo paths moved.**
 > `convex/` → `backend/convex/` (convex.json `functions` added; function identifiers unchanged),
 > `src/` + `index.html` → `apps/web/` (`@convex` alias replaces relative `../convex` imports),
@@ -76,6 +90,44 @@ Server Error) for an unknown slug.
   that re-deploys the #494 functions the incident note describes → heals prod.
 
 ## Hand-offs (built + ready for the other agent to call)
+
+- **2026-07-28 - Codex `/root/activegraph_final_audit` -> `/root`** -
+  Release-hardening audit complete on the uncommitted
+  `codex/activegraph-canary` candidate. Event chains now enforce terminal
+  semantics, nondecreasing timestamps, and lifecycle-capacity admission.
+  Retention uses terminal-only expiry, bounded whole-chain deletion, stale-run
+  closure/purge, and multi-continuation legacy-span draining. The offline replay
+  boundary enforces byte/time limits and binds evidence to an immutable image,
+  canonical build inputs, candidate commit, pinned upstream tag object, and
+  exact image labels. Final local gates: 61 TypeScript tests, 48 Python tests,
+  Convex/root typechecks, production build, targeted Prettier, pip check, and
+  diff check all pass. The real 9-event Docker replay now passes with network
+  none, a read-only root, one writable evidence mount, and exact SQLite
+  persist/reload parity. No merge, deploy, production mutation, or `.serena`
+  edit.
+  Before/after proof:
+  `evidence/activegraph-release-hardening/{before,after}.txt`.
+
+- **2026-07-28 - Codex `/root/activegraph_canary_docs` → backend/runtime
+  reviewers** - Candidate on `codex/activegraph-canary`, not deployed:
+  `domains/operations/taskManager/nodeKitRunExport:exportNodeKitRun({traceId})`
+  returns `nodekit.run-export/v1` only for the authenticated owner's terminal,
+  newly instrumented trace. The receipt is derived only from immutable IDs and
+  event snapshots; legacy/ownerless traces fail closed. Events are
+  sensitivity-redacted, capped at 2 KiB stored / 32 KiB redacted source / 256
+  events, span-balanced, content-hashed, and retained for 30 days.
+  `domains/operations/taskManager/nodeKitRunRetention:deleteOwnedNodeKitRunHistory({traceId})`
+  deletes only an owner's whole terminal history; the daily internal retention
+  sweep skips running traces and deletes only whole expired chains. Boundary
+  failures carry structured Convex error data.
+  `scripts/nodekit/runActiveGraphCanary.mjs` accepts the export only through a
+  disposable copy and immutable Docker image ID/digest; it enforces
+  network-none/read-only-root/capability-dropped/resource-bounded isolation and
+  exact artifacts. Docker Desktop was stopped during local verification, so no
+  container pass is claimed; missing Docker is a fail-closed result. All
+  TypeScript/Python/typecheck/build/NodeKit gates are recorded in
+  `evidence/activegraph-production-slice/verification.txt`. No Convex deploy,
+  merge, push, or production write occurred.
 
 - **2026-07-17 · Claude → any agent building UI contracts / `.well-known/agent-ui.json`** ·
   The runtime UI-contract substrate ALREADY EXISTS — do not create a parallel

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,22 +1,25 @@
-# agent/ — authored agent surface (phase 0)
+# agent/ — authored agent surface
 
 This directory is the NodeKit-standard, filesystem-first authoring surface for
-the NodeBench agent application. **Phase 0 rule: this surface documents the
-live system; the code remains the source of truth.** Nothing here is loaded at
-runtime yet — there is no manifest compiler, so we do not pretend there is
-(`requireCompiledManifest: false` in `nodekit.yaml`, no fake `.nodeagent/`).
+the NodeBench agent application. **Brownfield rule: this surface documents the
+live system; the repo-local code remains the runtime source of truth.** NodeKit
+can validate and hash this projection, but production does not load a compiled
+definition yet. Compilation proves internal consistency; it does not claim that
+runtime migration or same-path benchmark parity is complete.
 
 Every file carries a `Source:` pointer to the code that actually enforces it.
-When the `@nodeagent` compiler exists, the direction reverses: these files
-become the source and the pointers become generated output.
+When NodeBench switches from `repo-local-nodebench` to `nodeagent-native`, the
+direction reverses: these files become runtime source and legacy pointers become
+compatibility inputs or generated output.
 
 | Standard slot | Status | Lives today at |
 |---|---|---|
 | instructions.md | authored here | mirrors `backend/convex/domains/redesign/chatRuns.ts` |
-| policies/ | authored here | mirrors guards in workers/node/, backend/convex/, adw/goals/ |
+| policies/ | authored here | mirrors guards in `workers/node/`, `backend/convex/`, `adw/goals/` |
 | subagents/ | index only | `backend/convex/domains/agents/**` orchestrator-workers |
-| tools/ | index only | `packages/mcp-local/src/tools/**` (304 tools) |
+| tools/ | index only | `packages/mcp-local/src/tools/**` |
 | planner/ context/ memory/ hooks/ channels/ schedules/ sandbox/ | not yet authored | see `docs/architecture/STANDARD_REPO_TREE.md` mapping |
 
-Do not add `.ts` files here in phase 0 — the app's tsconfig does not include
-this directory and nothing should import from it until the compiler phase.
+Do not add `.ts` files here during brownfield mapping. The app's tsconfig does
+not include this directory and nothing should import from it until the runtime
+adapter phase.

--- a/agent/policies/approvals.yaml
+++ b/agent/policies/approvals.yaml
@@ -1,4 +1,4 @@
-# Human-approval gates. Source: goals/HARD_GATES.md + .claude/rules
+# Human-approval gates. Source: adw/goals/HARD_GATES.md + .claude/rules
 # (self_improvement_loop, backend_contract_migration). Enforced by process +
 # CI branch protection today, not by a runtime policy engine.
 apiVersion: nodeagent.dev/v1

--- a/agent/policies/budgets.yaml
+++ b/agent/policies/budgets.yaml
@@ -1,4 +1,4 @@
-# Budget envelopes. Source: server/mcpAuth.ts (gateway limits), server/pipeline
+# Budget envelopes. Source: workers/node/mcpAuth.ts (gateway limits), workers/node/pipeline
 # (judge latency budget), .claude/rules/orchestrator_workers.md (per-subagent caps).
 apiVersion: nodeagent.dev/v1
 kind: Policy

--- a/agent/policies/egress.yaml
+++ b/agent/policies/egress.yaml
@@ -1,5 +1,5 @@
 # Network egress policy. Source: SSRF guards per .claude/rules/agentic_reliability.md
-# (checklist item 5), enforced in server fetch paths (URL validation before fetch)
+# (checklist item 5), enforced in worker fetch paths (URL validation before fetch)
 # and bounded reads (item 6).
 apiVersion: nodeagent.dev/v1
 kind: Policy

--- a/backend/convex/crons.ts
+++ b/backend/convex/crons.ts
@@ -1050,6 +1050,18 @@ crons.interval(
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Privacy retention for bounded NodeKit observer history. Terminal-only
+// indexes bypass nonterminal rows, each mutation deletes at most 1,024 whole
+// chain rows, one continuation drains backlog, and stale running traces are
+// explicitly failed before their terminal retention clock starts.
+crons.interval(
+  "nodekit run-event retention",
+  { hours: 24 },
+  internal.domains.operations.taskManager.nodeKitRunRetention
+    .purgeExpiredNodeKitRunEvents,
+  {},
+);
+
 // scratchnode.live presence janitor (Phase 1 of live prod plan)
 // ═══════════════════════════════════════════════════════════════════════════
 //

--- a/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts
+++ b/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalMutation } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
+import { appendNodeKitRunEvent } from "../operations/taskManager/nodeKitRunEvents";
 
 const oracleSourceRefValidator = v.object({
   label: v.string(),
@@ -81,6 +82,23 @@ export const mcpStartExecutionRun = internalMutation({
         executionTraceOrigin: "mcp",
         ...(args.metadata && typeof args.metadata === "object" ? (args.metadata as Record<string, unknown>) : {}),
       },
+    });
+
+    await appendNodeKitRunEvent(ctx, {
+      sessionId,
+      traceId,
+      userId: args.userId as Id<"users">,
+      runId: publicTraceId,
+      eventType: "run.started",
+      recordedAt: now,
+      payload: {
+        workflowName: args.workflowName,
+        origin: "mcp",
+        sessionType: args.type ?? "agent",
+        sessionStartedAt: now,
+        ...(args.goalId === undefined ? {} : { goalId: args.goalId }),
+      },
+      allowLegacySkip: false,
     });
 
     return {

--- a/backend/convex/domains/operations/taskManager/mutations.ts
+++ b/backend/convex/domains/operations/taskManager/mutations.ts
@@ -9,6 +9,7 @@ import { v } from "convex/values";
 import { mutation, internalMutation } from "../../../_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import type { Id, Doc } from "../../../_generated/dataModel";
+import { appendNodeKitRunEvent } from "./nodeKitRunEvents";
 
 const oracleSourceRefValidator = v.object({
   label: v.string(),
@@ -686,7 +687,7 @@ export const createTrace = mutation({
   returns: v.id("agentTaskTraces"),
   handler: async (ctx, args) => {
     const userId = await requireAuthenticatedUserId(ctx);
-    await requireOwnedSession(ctx, args.sessionId, userId);
+    const session = await requireOwnedSession(ctx, args.sessionId, userId);
     const traceId = generateTraceId();
     const now = Date.now();
 
@@ -706,6 +707,24 @@ export const createTrace = mutation({
       metadata: args.metadata,
     });
 
+    await appendNodeKitRunEvent(ctx, {
+      sessionId: args.sessionId,
+      traceId: id,
+      userId,
+      runId: traceId,
+      eventType: "run.started",
+      recordedAt: now,
+      payload: {
+        workflowName: args.workflowName,
+        sessionType: session.type,
+        sessionStartedAt: session.startedAt,
+        ...(args.groupId === undefined ? {} : { groupId: args.groupId }),
+        ...(args.model === undefined ? {} : { model: args.model }),
+        ...(args.goalId === undefined ? {} : { goalId: args.goalId }),
+      },
+      allowLegacySkip: false,
+    });
+
     return id;
   },
 });
@@ -718,9 +737,40 @@ async function completeTraceForOwner(
   args: any,
   userId: Id<"users">,
 ) {
-  const { trace } = await requireOwnedTrace(ctx, args.traceId, userId);
+  const { trace, session } = await requireOwnedTrace(
+    ctx,
+    args.traceId,
+    userId,
+  );
   await assertOwnedDogfoodRun(ctx, args.dogfoodRunId, userId);
+  if (trace.status !== "running") {
+    const expectedStatus = args.status === "completed" ? "completed" : "error";
+    if (trace.status === expectedStatus) return;
+    throw new Error(`Trace is already terminal with status ${trace.status}`);
+  }
   const now = Date.now();
+
+  await appendNodeKitRunEvent(ctx, {
+    sessionId: session._id,
+    traceId: args.traceId,
+    userId,
+    runId: trace.traceId,
+    eventType: args.status === "completed" ? "run.completed" : "run.failed",
+    recordedAt: now,
+    payload: {
+      status: args.status,
+      totalDurationMs: now - trace.startedAt,
+      ...(args.crossCheckStatus === undefined
+        ? {}
+        : { crossCheckStatus: args.crossCheckStatus }),
+      ...(args.deltaFromVision === undefined
+        ? {}
+        : { deltaFromVision: args.deltaFromVision }),
+      ...(args.dogfoodRunId === undefined
+        ? {}
+        : { dogfoodRunId: String(args.dogfoodRunId) }),
+    },
+  });
 
   await ctx.db.patch(args.traceId, {
     status: args.status,
@@ -786,10 +836,15 @@ export const createSpan = mutation({
   returns: v.id("agentTaskSpans"),
   handler: async (ctx, args) => {
     const userId = await requireAuthenticatedUserId(ctx);
-    await requireOwnedTrace(ctx, args.traceId, userId);
+    const { trace, session } = await requireOwnedTrace(
+      ctx,
+      args.traceId,
+      userId,
+    );
     await assertParentSpanInTrace(ctx, args.parentSpanId, args.traceId);
     const seq = await getNextSpanSequence(ctx, args.traceId);
     const depth = await getSpanDepth(ctx, args.parentSpanId);
+    const startedAt = Date.now();
 
     const id = await ctx.db.insert("agentTaskSpans", {
       traceId: args.traceId,
@@ -799,9 +854,30 @@ export const createSpan = mutation({
       spanType: args.spanType,
       name: args.name,
       status: "running",
-      startedAt: Date.now(),
+      startedAt,
       data: args.data,
       metadata: args.metadata,
+    });
+
+    await appendNodeKitRunEvent(ctx, {
+      sessionId: session._id,
+      traceId: args.traceId,
+      userId,
+      runId: trace.traceId,
+      eventType: "span.started",
+      recordedAt: startedAt,
+      payload: {
+        spanId: String(id),
+        spanSequence: seq,
+        depth,
+        spanType: args.spanType,
+        name: args.name,
+        ...(args.parentSpanId === undefined
+          ? {}
+          : { parentSpanId: String(args.parentSpanId) }),
+        ...(args.data === undefined ? {} : { data: args.data }),
+        ...(args.metadata === undefined ? {} : { metadata: args.metadata }),
+      },
     });
 
     return id;
@@ -866,6 +942,27 @@ async function recordStepForOwner(
     args.resultSummary,
   );
 
+  await appendNodeKitRunEvent(ctx, {
+    sessionId: session._id,
+    traceId: args.traceId,
+    userId,
+    runId: trace.traceId,
+    eventType: "step.recorded",
+    recordedAt: endedAt,
+    payload: {
+      spanId: String(spanId),
+      spanSequence: seq,
+      startedAt,
+      endedAt,
+      durationMs,
+      ...stepPayload,
+      ...(args.parentSpanId === undefined
+        ? {}
+        : { parentSpanId: String(args.parentSpanId) }),
+      ...(args.metadata === undefined ? {} : { metadata: args.metadata }),
+    },
+  });
+
   return spanId;
 }
 
@@ -900,7 +997,12 @@ async function recordDecisionForOwner(
   args: any,
   userId: Id<"users">,
 ) {
-  const { trace } = await requireOwnedTrace(ctx, args.traceId, userId);
+  const { trace, session } = await requireOwnedTrace(
+    ctx,
+    args.traceId,
+    userId,
+  );
+  const recordedAt = Date.now();
   const decision = {
     decisionType: args.decisionType,
     statement: args.statement,
@@ -909,12 +1011,21 @@ async function recordDecisionForOwner(
     alternativesConsidered: args.alternativesConsidered ?? [],
     confidence: args.confidence,
     limitations: args.limitations ?? [],
-    recordedAt: Date.now(),
+    recordedAt,
   };
 
   const metadata = appendMetadataList(trace.metadata, "executionTraceDecisions", decision);
   metadata.decisions = metadata.executionTraceDecisions;
   await ctx.db.patch(args.traceId, { metadata });
+  await appendNodeKitRunEvent(ctx, {
+    sessionId: session._id,
+    traceId: args.traceId,
+    userId,
+    runId: trace.traceId,
+    eventType: "decision.recorded",
+    recordedAt,
+    payload: decision,
+  });
   return args.traceId;
 }
 
@@ -999,6 +1110,16 @@ async function recordVerificationForOwner(
     );
   }
 
+  await appendNodeKitRunEvent(ctx, {
+    sessionId: session._id,
+    traceId: args.traceId,
+    userId,
+    runId: trace.traceId,
+    eventType: "verification.recorded",
+    recordedAt: verification.recordedAt,
+    payload: verification,
+  });
+
   return args.traceId;
 }
 
@@ -1023,14 +1144,19 @@ async function attachEvidenceForOwner(
   args: any,
   userId: Id<"users">,
 ) {
-  const { trace } = await requireOwnedTrace(ctx, args.traceId, userId);
+  const { trace, session } = await requireOwnedTrace(
+    ctx,
+    args.traceId,
+    userId,
+  );
+  const recordedAt = Date.now();
   const evidence = {
     title: args.title,
     summary: args.summary,
     sourceRefs: args.sourceRefs,
     supportedClaims: args.supportedClaims ?? [],
     unsupportedClaims: args.unsupportedClaims ?? [],
-    recordedAt: Date.now(),
+    recordedAt,
   };
 
   const metadata = appendMetadataList(trace.metadata, "executionTraceEvidence", evidence);
@@ -1038,6 +1164,15 @@ async function attachEvidenceForOwner(
   const mergedSourceRefs = uniqueSourceRefs([...(trace.sourceRefs ?? []), ...args.sourceRefs]);
 
   await ctx.db.patch(args.traceId, { metadata, sourceRefs: mergedSourceRefs });
+  await appendNodeKitRunEvent(ctx, {
+    sessionId: session._id,
+    traceId: args.traceId,
+    userId,
+    runId: trace.traceId,
+    eventType: "evidence.attached",
+    recordedAt,
+    payload: evidence,
+  });
   return args.traceId;
 }
 
@@ -1063,14 +1198,17 @@ async function requestTraceApprovalForOwner(
   userId: Id<"users">,
 ) {
   const session = await requireOwnedSession(ctx, args.sessionId, userId);
+  let ownedTrace: Doc<"agentTaskTraces"> | null = null;
   if (args.traceId) {
     const { trace } = await requireOwnedTrace(ctx, args.traceId, userId);
     if (trace.sessionId !== args.sessionId) {
       throw new Error("Trace does not belong to session");
     }
+    ownedTrace = trace;
   }
 
   const threadId = session.agentThreadId ?? `task-session:${String(args.sessionId)}`;
+  const recordedAt = Date.now();
   const approvalId = await ctx.db.insert("toolApprovals", {
     userId,
     threadId,
@@ -1084,20 +1222,34 @@ async function requestTraceApprovalForOwner(
     status: "pending",
     riskLevel: args.riskLevel,
     reason: args.justification,
-    createdAt: Date.now(),
+    createdAt: recordedAt,
   });
 
-  if (args.traceId) {
-    const trace = await ctx.db.get(args.traceId) as Doc<"agentTaskTraces">;
-    const metadata = appendMetadataList(trace.metadata, "executionTraceApprovals", {
+  if (args.traceId && ownedTrace) {
+    const metadata = appendMetadataList(ownedTrace.metadata, "executionTraceApprovals", {
       approvalId: String(approvalId),
       toolName: args.toolName,
       riskLevel: args.riskLevel,
       justification: args.justification,
       status: "pending",
-      recordedAt: Date.now(),
+      recordedAt,
     });
     await ctx.db.patch(args.traceId, { metadata });
+    await appendNodeKitRunEvent(ctx, {
+      sessionId: session._id,
+      traceId: args.traceId,
+      userId,
+      runId: ownedTrace.traceId,
+      eventType: "approval.requested",
+      recordedAt,
+      payload: {
+        approvalId: String(approvalId),
+        toolName: args.toolName,
+        riskLevel: args.riskLevel,
+        justification: args.justification,
+        toolArgs: args.toolArgs ?? null,
+      },
+    });
   }
 
   return approvalId;
@@ -1271,6 +1423,11 @@ export const completeSpan = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuthenticatedUserId(ctx);
     const span = await requireOwnedSpan(ctx, args.spanId, userId);
+    const { trace, session } = await requireOwnedTrace(
+      ctx,
+      span.traceId,
+      userId,
+    );
 
     const now = Date.now();
 
@@ -1280,6 +1437,22 @@ export const completeSpan = mutation({
       durationMs: now - span.startedAt,
       data: args.data ?? span.data,
       error: args.error,
+    });
+    await appendNodeKitRunEvent(ctx, {
+      sessionId: session._id,
+      traceId: span.traceId,
+      userId,
+      runId: trace.traceId,
+      eventType: "span.completed",
+      recordedAt: now,
+      payload: {
+        spanId: String(args.spanId),
+        spanSequence: span.seq,
+        status: args.status,
+        durationMs: now - span.startedAt,
+        ...(args.data === undefined ? {} : { data: args.data }),
+        ...(args.error === undefined ? {} : { error: args.error }),
+      },
     });
   },
 });

--- a/backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts
@@ -1,0 +1,860 @@
+import type { Id } from "../../../_generated/dataModel";
+import type { MutationCtx } from "../../../_generated/server";
+
+export const NODEKIT_RUN_EVENT_CONTRACT_VERSION =
+  "nodekit.run-event/v1" as const;
+export const NODEKIT_SAFE_EVENT_PAYLOAD_VERSION =
+  "nodekit.safe-event-payload/v1" as const;
+export const NODEKIT_RUN_GENESIS_HASH = `sha256:${"0".repeat(64)}` as const;
+export const NODEKIT_RUN_MAX_EVENTS = 256;
+export const NODEKIT_RUN_MAX_REDACTED_SOURCE_BYTES = 32 * 1024;
+export const NODEKIT_RUN_MAX_STORED_PAYLOAD_BYTES = 2 * 1024;
+export const NODEKIT_RUN_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const NODEKIT_RUN_EVENT_TYPES = [
+  "run.started",
+  "span.started",
+  "span.completed",
+  "step.recorded",
+  "decision.recorded",
+  "verification.recorded",
+  "evidence.attached",
+  "approval.requested",
+  "run.completed",
+  "run.failed",
+] as const;
+
+export type NodeKitRunEventType = (typeof NODEKIT_RUN_EVENT_TYPES)[number];
+
+export type NodeKitSafeEventPayload = Readonly<{
+  projectionVersion: typeof NODEKIT_SAFE_EVENT_PAYLOAD_VERSION;
+  sourceDigest: string;
+  sourceBytes: number;
+  fields: Readonly<Record<string, string | number | boolean | null>>;
+}>;
+
+export type NodeKitRunEvent = Readonly<{
+  contractVersion: typeof NODEKIT_RUN_EVENT_CONTRACT_VERSION;
+  runId: string;
+  sequence: number;
+  eventType: NodeKitRunEventType;
+  recordedAt: number;
+  payload: NodeKitSafeEventPayload;
+  previousHash: string;
+  contentHash: string;
+}>;
+
+export class NodeKitRunContractError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "NodeKitRunContractError";
+    this.code = code;
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new NodeKitRunContractError(code, message);
+}
+
+const SENSITIVE_KEY_PATTERN =
+  /(?:authorization|cookie|credential|password|passphrase|secret|token|api.?key|private.?key|client.?secret)/i;
+
+const SAFE_FIELDS_BY_EVENT: Readonly<
+  Record<NodeKitRunEventType, readonly string[]>
+> = {
+  "run.started": [
+    "workflowName",
+    "origin",
+    "groupId",
+    "model",
+    "goalId",
+    "sessionType",
+    "sessionStartedAt",
+  ],
+  "span.started": [
+    "spanId",
+    "parentSpanId",
+    "spanSequence",
+    "depth",
+    "spanType",
+  ],
+  "span.completed": ["spanId", "spanSequence", "status", "durationMs"],
+  "step.recorded": [
+    "spanId",
+    "parentSpanId",
+    "spanSequence",
+    "stage",
+    "type",
+    "tool",
+    "durationMs",
+  ],
+  "decision.recorded": ["decisionType", "confidence"],
+  "verification.recorded": ["status"],
+  "evidence.attached": [],
+  "approval.requested": ["approvalId", "toolName", "riskLevel"],
+  "run.completed": [
+    "status",
+    "totalDurationMs",
+    "crossCheckStatus",
+    "dogfoodRunId",
+  ],
+  "run.failed": [
+    "status",
+    "totalDurationMs",
+    "crossCheckStatus",
+    "dogfoodRunId",
+  ],
+};
+
+const REQUIRED_FIELDS_BY_EVENT: Partial<
+  Record<NodeKitRunEventType, readonly string[]>
+> = {
+  "run.started": ["workflowName", "sessionType", "sessionStartedAt"],
+  "span.started": ["spanId"],
+  "span.completed": ["spanId"],
+  "run.completed": ["status"],
+  "run.failed": ["status"],
+};
+
+function assertTerminalPayloadStatus(
+  eventType: NodeKitRunEventType,
+  fields: Readonly<Record<string, unknown>>,
+  label: string,
+): void {
+  const expectedStatus =
+    eventType === "run.completed"
+      ? "completed"
+      : eventType === "run.failed"
+        ? "error"
+        : undefined;
+  if (expectedStatus !== undefined && fields.status !== expectedStatus) {
+    fail(
+      "terminal_status_mismatch",
+      `${label} requires status ${expectedStatus}.`,
+    );
+  }
+}
+
+function normalizeCanonicalValue(
+  input: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (
+    input === null ||
+    typeof input === "string" ||
+    typeof input === "boolean"
+  ) {
+    return input;
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) {
+      fail("non_finite_number", "Canonical JSON numbers must be finite.");
+    }
+    return input;
+  }
+  if (typeof input !== "object") {
+    fail(
+      "non_json_value",
+      `Canonical JSON cannot encode values of type ${typeof input}.`,
+    );
+  }
+  if (seen.has(input)) {
+    fail("cyclic_value", "Canonical JSON values must be acyclic.");
+  }
+  seen.add(input);
+  if (Array.isArray(input)) {
+    const result = input.map((value) => normalizeCanonicalValue(value, seen));
+    seen.delete(input);
+    return result;
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail("non_plain_object", "Canonical JSON objects must be plain objects.");
+  }
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(input as Record<string, unknown>).sort()) {
+    if ((input as Record<string, unknown>)[key] === undefined) continue;
+    result[key] = normalizeCanonicalValue(
+      (input as Record<string, unknown>)[key],
+      seen,
+    );
+  }
+  seen.delete(input);
+  return result;
+}
+
+export function canonicalNodeKitJson(value: unknown): string {
+  return JSON.stringify(normalizeCanonicalValue(value));
+}
+
+export async function sha256CanonicalNodeKitValue(
+  value: unknown,
+): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalNodeKitJson(value));
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return `sha256:${Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function redactSensitiveNodeKitValue(
+  input: unknown,
+  key: string | undefined,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+    return "[REDACTED]";
+  }
+  if (
+    input === null ||
+    typeof input === "string" ||
+    typeof input === "boolean" ||
+    typeof input === "number"
+  ) {
+    return normalizeCanonicalValue(input);
+  }
+  if (typeof input !== "object") {
+    return normalizeCanonicalValue(input);
+  }
+  if (seen.has(input)) {
+    fail("cyclic_value", "Event payloads must be acyclic.");
+  }
+  seen.add(input);
+  if (Array.isArray(input)) {
+    const result = input.map((value) =>
+      redactSensitiveNodeKitValue(value, undefined, seen),
+    );
+    seen.delete(input);
+    return result;
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail("non_plain_object", "Event payloads must be plain JSON objects.");
+  }
+  const result: Record<string, unknown> = {};
+  for (const childKey of Object.keys(input as Record<string, unknown>).sort()) {
+    const child = (input as Record<string, unknown>)[childKey];
+    if (child === undefined) continue;
+    result[childKey] = redactSensitiveNodeKitValue(child, childKey, seen);
+  }
+  seen.delete(input);
+  return result;
+}
+
+function safeScalar(
+  value: unknown,
+  field: string,
+): string | number | boolean | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value.length > 256) {
+      fail(
+        "payload_field_too_large",
+        `Safe event field ${field} exceeds 256 characters.`,
+      );
+    }
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+export async function projectNodeKitRunEventPayload(
+  eventType: NodeKitRunEventType,
+  sourcePayload: unknown,
+): Promise<NodeKitSafeEventPayload> {
+  const redacted = redactSensitiveNodeKitValue(sourcePayload, undefined);
+  const redactedJson = canonicalNodeKitJson(redacted);
+  const sourceBytes = new TextEncoder().encode(redactedJson).byteLength;
+  if (sourceBytes > NODEKIT_RUN_MAX_REDACTED_SOURCE_BYTES) {
+    fail(
+      "payload_too_large",
+      `Redacted event payload exceeds ${NODEKIT_RUN_MAX_REDACTED_SOURCE_BYTES} bytes.`,
+    );
+  }
+
+  const fields: Record<string, string | number | boolean | null> = {};
+  if (
+    sourcePayload &&
+    typeof sourcePayload === "object" &&
+    !Array.isArray(sourcePayload)
+  ) {
+    const record = sourcePayload as Record<string, unknown>;
+    for (const field of SAFE_FIELDS_BY_EVENT[eventType]) {
+      const value = safeScalar(record[field], field);
+      if (value !== undefined) fields[field] = value;
+    }
+  }
+  for (const required of REQUIRED_FIELDS_BY_EVENT[eventType] ?? []) {
+    if (!(required in fields)) {
+      fail(
+        "payload_field_missing",
+        `${eventType} requires the safe field ${required}.`,
+      );
+    }
+  }
+  assertTerminalPayloadStatus(eventType, fields, eventType);
+
+  const projection: NodeKitSafeEventPayload = {
+    projectionVersion: NODEKIT_SAFE_EVENT_PAYLOAD_VERSION,
+    sourceDigest: await sha256CanonicalNodeKitValue(redacted),
+    sourceBytes,
+    fields,
+  };
+  const storedBytes = new TextEncoder().encode(
+    canonicalNodeKitJson(projection),
+  ).byteLength;
+  if (storedBytes > NODEKIT_RUN_MAX_STORED_PAYLOAD_BYTES) {
+    fail(
+      "projected_payload_too_large",
+      `Projected event payload exceeds ${NODEKIT_RUN_MAX_STORED_PAYLOAD_BYTES} bytes.`,
+    );
+  }
+  return deepFreezeNodeKitValue(projection);
+}
+
+export function deepFreezeNodeKitValue<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreezeNodeKitValue(child);
+  }
+  return Object.freeze(value);
+}
+
+function assertHash(value: string, field: string): void {
+  if (!/^sha256:[a-f0-9]{64}$/.test(value)) {
+    fail("hash_invalid", `${field} must be a lowercase sha256: digest.`);
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const canonicalExpected = [...expected].sort();
+  if (
+    actual.length !== canonicalExpected.length ||
+    actual.some((key, index) => key !== canonicalExpected[index])
+  ) {
+    fail(
+      "shape_invalid",
+      `${label} keys must be exactly ${canonicalExpected.join(", ")}.`,
+    );
+  }
+}
+
+function assertSafeEventPayload(
+  value: unknown,
+  eventType: NodeKitRunEventType,
+  index: number,
+): asserts value is NodeKitSafeEventPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("payload_shape_invalid", `Event ${index} payload must be an object.`);
+  }
+  const payload = value as Record<string, unknown>;
+  assertExactKeys(
+    payload,
+    ["projectionVersion", "sourceDigest", "sourceBytes", "fields"],
+    `Event ${index} payload`,
+  );
+  if (payload.projectionVersion !== NODEKIT_SAFE_EVENT_PAYLOAD_VERSION) {
+    fail(
+      "payload_version_mismatch",
+      `Event ${index} has an unsupported safe-payload version.`,
+    );
+  }
+  assertHash(
+    String(payload.sourceDigest),
+    `events[${index}].payload.sourceDigest`,
+  );
+  if (
+    !Number.isSafeInteger(payload.sourceBytes) ||
+    (payload.sourceBytes as number) < 0 ||
+    (payload.sourceBytes as number) > NODEKIT_RUN_MAX_REDACTED_SOURCE_BYTES
+  ) {
+    fail(
+      "payload_size_invalid",
+      `Event ${index} sourceBytes exceeds the contract bound.`,
+    );
+  }
+  if (
+    !payload.fields ||
+    typeof payload.fields !== "object" ||
+    Array.isArray(payload.fields)
+  ) {
+    fail(
+      "payload_shape_invalid",
+      `Event ${index} payload.fields must be an object.`,
+    );
+  }
+  const fields = payload.fields as Record<string, unknown>;
+  const allowed = new Set(SAFE_FIELDS_BY_EVENT[eventType]);
+  for (const [field, fieldValue] of Object.entries(fields)) {
+    if (!allowed.has(field)) {
+      fail(
+        "payload_field_invalid",
+        `Event ${index} contains unsupported safe field ${field}.`,
+      );
+    }
+    if (
+      fieldValue !== null &&
+      typeof fieldValue !== "string" &&
+      typeof fieldValue !== "number" &&
+      typeof fieldValue !== "boolean"
+    ) {
+      fail(
+        "payload_field_invalid",
+        `Event ${index} safe field ${field} must be scalar.`,
+      );
+    }
+    if (
+      (typeof fieldValue === "string" && fieldValue.length > 256) ||
+      (typeof fieldValue === "number" && !Number.isFinite(fieldValue))
+    ) {
+      fail(
+        "payload_field_invalid",
+        `Event ${index} safe field ${field} exceeds its bound.`,
+      );
+    }
+  }
+  for (const required of REQUIRED_FIELDS_BY_EVENT[eventType] ?? []) {
+    if (!(required in fields)) {
+      fail(
+        "payload_field_missing",
+        `Event ${index} requires safe field ${required}.`,
+      );
+    }
+  }
+  assertTerminalPayloadStatus(eventType, fields, `Event ${index}`);
+  if (
+    new TextEncoder().encode(canonicalNodeKitJson(payload)).byteLength >
+    NODEKIT_RUN_MAX_STORED_PAYLOAD_BYTES
+  ) {
+    fail(
+      "projected_payload_too_large",
+      `Event ${index} payload exceeds the stored-size bound.`,
+    );
+  }
+}
+
+function assertEventShape(
+  value: unknown,
+  expectedRunId: string,
+  index: number,
+): asserts value is NodeKitRunEvent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("event_invalid", `Event ${index} must be an object.`);
+  }
+  const event = value as Record<string, unknown>;
+  assertExactKeys(
+    event,
+    [
+      "contractVersion",
+      "runId",
+      "sequence",
+      "eventType",
+      "recordedAt",
+      "payload",
+      "previousHash",
+      "contentHash",
+    ],
+    `Event ${index}`,
+  );
+  if (event.contractVersion !== NODEKIT_RUN_EVENT_CONTRACT_VERSION) {
+    fail(
+      "contract_version_mismatch",
+      `Event ${index} has an unsupported contract.`,
+    );
+  }
+  if (event.runId !== expectedRunId) {
+    fail("run_id_mismatch", `Event ${index} belongs to another run.`);
+  }
+  if (!Number.isSafeInteger(event.sequence) || (event.sequence as number) < 0) {
+    fail("sequence_invalid", `Event ${index} has an invalid sequence.`);
+  }
+  if (
+    !NODEKIT_RUN_EVENT_TYPES.includes(event.eventType as NodeKitRunEventType)
+  ) {
+    fail("event_type_invalid", `Event ${index} has an unsupported type.`);
+  }
+  if (
+    !Number.isSafeInteger(event.recordedAt) ||
+    (event.recordedAt as number) < 0
+  ) {
+    fail("recorded_at_invalid", `Event ${index} has an invalid timestamp.`);
+  }
+  assertHash(String(event.previousHash), `events[${index}].previousHash`);
+  assertHash(String(event.contentHash), `events[${index}].contentHash`);
+  assertSafeEventPayload(
+    event.payload,
+    event.eventType as NodeKitRunEventType,
+    index,
+  );
+}
+
+function eventHashBody(
+  event: Omit<NodeKitRunEvent, "contentHash">,
+): Omit<NodeKitRunEvent, "contentHash"> {
+  return {
+    contractVersion: NODEKIT_RUN_EVENT_CONTRACT_VERSION,
+    runId: event.runId,
+    sequence: event.sequence,
+    eventType: event.eventType,
+    recordedAt: event.recordedAt,
+    payload: event.payload,
+    previousHash: event.previousHash,
+  };
+}
+
+export async function buildNodeKitRunEvent(input: {
+  runId: string;
+  sequence: number;
+  eventType: NodeKitRunEventType;
+  recordedAt: number;
+  payload: unknown;
+  previousHash: string;
+}): Promise<NodeKitRunEvent> {
+  if (!input.runId.trim() || input.runId.length > 256) {
+    fail("run_id_invalid", "runId must contain 1-256 characters.");
+  }
+  if (!Number.isSafeInteger(input.sequence) || input.sequence < 0) {
+    fail("sequence_invalid", "sequence must be a non-negative safe integer.");
+  }
+  if (!NODEKIT_RUN_EVENT_TYPES.includes(input.eventType)) {
+    fail("event_type_invalid", `Unsupported event type: ${input.eventType}`);
+  }
+  if (!Number.isSafeInteger(input.recordedAt) || input.recordedAt < 0) {
+    fail(
+      "recorded_at_invalid",
+      "recordedAt must be a non-negative safe integer.",
+    );
+  }
+  assertHash(input.previousHash, "previousHash");
+  const projectedPayload = await projectNodeKitRunEventPayload(
+    input.eventType,
+    input.payload,
+  );
+
+  const body = eventHashBody({
+    contractVersion: NODEKIT_RUN_EVENT_CONTRACT_VERSION,
+    runId: input.runId,
+    sequence: input.sequence,
+    eventType: input.eventType,
+    recordedAt: input.recordedAt,
+    payload: projectedPayload,
+    previousHash: input.previousHash,
+  });
+  const event: NodeKitRunEvent = {
+    ...body,
+    contentHash: await sha256CanonicalNodeKitValue(body),
+  };
+  return deepFreezeNodeKitValue(event);
+}
+
+function eventField(
+  event: NodeKitRunEvent,
+  field: string,
+): string | number | boolean | null | undefined {
+  return event.payload.fields[field];
+}
+
+function assertNodeKitSpanLifecycle(
+  events: readonly NodeKitRunEvent[],
+  requireClosed: boolean,
+): ReadonlySet<string> {
+  const openSpans = new Set<string>();
+  const completedSpans = new Set<string>();
+  for (const event of events) {
+    if (event.eventType === "span.started") {
+      const spanId = eventField(event, "spanId");
+      if (typeof spanId !== "string" || !spanId) {
+        fail("span_id_missing", "span.started requires a non-empty spanId.");
+      }
+      if (openSpans.has(spanId) || completedSpans.has(spanId)) {
+        fail("span_duplicate_start", `Span ${spanId} was started twice.`);
+      }
+      openSpans.add(spanId);
+    }
+    if (event.eventType === "span.completed") {
+      const spanId = eventField(event, "spanId");
+      if (typeof spanId !== "string" || !spanId) {
+        fail("span_id_missing", "span.completed requires a non-empty spanId.");
+      }
+      if (!openSpans.has(spanId)) {
+        fail(
+          "span_completion_without_start",
+          `Span ${spanId} completed without an open start event.`,
+        );
+      }
+      openSpans.delete(spanId);
+      completedSpans.add(spanId);
+    }
+  }
+  if (requireClosed && openSpans.size > 0) {
+    fail(
+      "span_lifecycle_incomplete",
+      `Terminal runs cannot retain ${openSpans.size} open span(s).`,
+    );
+  }
+  return openSpans;
+}
+
+export async function verifyNodeKitRunEventPrefix(
+  inputEvents: readonly NodeKitRunEvent[],
+  expectedRunId: string,
+): Promise<{
+  eventCount: number;
+  chainHead: string;
+  terminalEventType: "run.completed" | "run.failed" | null;
+  openSpanIds: readonly string[];
+}> {
+  if (!Array.isArray(inputEvents) || inputEvents.length === 0) {
+    fail("start_event_missing", "A run prefix requires run.started.");
+  }
+  if (inputEvents.length > NODEKIT_RUN_MAX_EVENTS) {
+    fail(
+      "event_limit_exceeded",
+      `A run may contain at most ${NODEKIT_RUN_MAX_EVENTS} events.`,
+    );
+  }
+  inputEvents.forEach((event, index) =>
+    assertEventShape(event, expectedRunId, index),
+  );
+  for (let index = 0; index < inputEvents.length; index += 1) {
+    if (inputEvents[index].sequence !== index) {
+      fail(
+        "sequence_not_contiguous",
+        `Expected sequence ${index}, received ${inputEvents[index].sequence}.`,
+      );
+    }
+  }
+  if (inputEvents[0].eventType !== "run.started") {
+    fail("start_event_missing", "Sequence 0 must be run.started.");
+  }
+  if (inputEvents[0].previousHash !== NODEKIT_RUN_GENESIS_HASH) {
+    fail(
+      "previous_hash_mismatch",
+      "run.started must point to the NodeKit genesis hash.",
+    );
+  }
+  const terminalIndexes = inputEvents.flatMap((event, index) =>
+    event.eventType === "run.completed" || event.eventType === "run.failed"
+      ? [index]
+      : [],
+  );
+  if (
+    terminalIndexes.length > 1 ||
+    (terminalIndexes.length === 1 &&
+      terminalIndexes[0] !== inputEvents.length - 1)
+  ) {
+    fail(
+      "terminal_event_not_last",
+      "Exactly one terminal event must be the final event.",
+    );
+  }
+
+  for (let index = 0; index < inputEvents.length; index += 1) {
+    const event = inputEvents[index];
+    if (index > 0 && event.recordedAt < inputEvents[index - 1].recordedAt) {
+      fail(
+        "recorded_at_not_monotonic",
+        `Event ${index} was recorded before its predecessor.`,
+      );
+    }
+    const expectedPrevious =
+      index === 0
+        ? NODEKIT_RUN_GENESIS_HASH
+        : inputEvents[index - 1].contentHash;
+    if (event.previousHash !== expectedPrevious) {
+      fail(
+        "previous_hash_mismatch",
+        `Event ${index} does not point to the preceding content hash.`,
+      );
+    }
+    const expectedHash = await sha256CanonicalNodeKitValue(
+      eventHashBody(event),
+    );
+    if (event.contentHash !== expectedHash) {
+      fail(
+        "content_hash_mismatch",
+        `Event ${index} content does not match its hash.`,
+      );
+    }
+  }
+  const terminalEventType =
+    terminalIndexes.length === 1
+      ? (inputEvents[inputEvents.length - 1].eventType as
+          | "run.completed"
+          | "run.failed")
+      : null;
+  const openSpans = assertNodeKitSpanLifecycle(
+    inputEvents,
+    terminalEventType !== null,
+  );
+
+  const last = inputEvents[inputEvents.length - 1];
+  return {
+    eventCount: inputEvents.length,
+    chainHead: last.contentHash,
+    terminalEventType,
+    openSpanIds: [...openSpans].sort(),
+  };
+}
+
+export async function verifyNodeKitRunEventChain(
+  inputEvents: readonly NodeKitRunEvent[],
+  expectedRunId: string,
+): Promise<{
+  eventCount: number;
+  chainHead: string;
+  terminalEventType: "run.completed" | "run.failed";
+}> {
+  if (!Array.isArray(inputEvents) || inputEvents.length < 2) {
+    fail(
+      "terminal_event_missing",
+      "A complete run requires at least run.started and a terminal event.",
+    );
+  }
+  const prefix = await verifyNodeKitRunEventPrefix(inputEvents, expectedRunId);
+  if (prefix.terminalEventType === null) {
+    fail("terminal_event_missing", "The run has no terminal event.");
+  }
+  return {
+    eventCount: prefix.eventCount,
+    chainHead: prefix.chainHead,
+    terminalEventType: prefix.terminalEventType,
+  };
+}
+
+type NodeKitEventMutationCtx = Pick<MutationCtx, "db">;
+
+export async function appendNodeKitRunEvent(
+  ctx: NodeKitEventMutationCtx,
+  args: {
+    sessionId: Id<"agentTaskSessions">;
+    traceId: Id<"agentTaskTraces">;
+    userId: Id<"users">;
+    runId: string;
+    eventType: NodeKitRunEventType;
+    recordedAt: number;
+    payload: unknown;
+    allowLegacySkip?: boolean;
+  },
+): Promise<NodeKitRunEvent | null> {
+  const latest = await ctx.db
+    .query("nodeKitRunEvents")
+    .withIndex("by_trace_sequence", (q) => q.eq("traceId", args.traceId))
+    .order("desc")
+    .first();
+
+  if (!latest && args.eventType !== "run.started") {
+    if (args.allowLegacySkip ?? true) return null;
+    fail("start_event_missing", "Cannot append before run.started.");
+  }
+  if (latest && args.eventType === "run.started") {
+    fail("start_event_duplicate", "run.started already exists.");
+  }
+  if (
+    latest &&
+    (latest.eventType === "run.completed" || latest.eventType === "run.failed")
+  ) {
+    fail("run_already_terminal", "Cannot append after a terminal event.");
+  }
+  if (latest && latest.runId !== args.runId) {
+    fail("run_id_mismatch", "Stored events belong to another run.");
+  }
+  if (latest && args.recordedAt < latest.recordedAt) {
+    fail(
+      "recorded_at_not_monotonic",
+      "recordedAt cannot precede the latest stored event.",
+    );
+  }
+  if (
+    latest &&
+    (latest.sessionId !== args.sessionId || latest.userId !== args.userId)
+  ) {
+    fail(
+      "event_ownership_mismatch",
+      "Stored event ownership does not match the append request.",
+    );
+  }
+  const nextSequence = latest ? latest.sequence + 1 : 0;
+  if (nextSequence >= NODEKIT_RUN_MAX_EVENTS) {
+    fail(
+      "event_limit_exceeded",
+      `A run may contain at most ${NODEKIT_RUN_MAX_EVENTS} events.`,
+    );
+  }
+  if (
+    nextSequence === NODEKIT_RUN_MAX_EVENTS - 1 &&
+    args.eventType !== "run.completed" &&
+    args.eventType !== "run.failed"
+  ) {
+    fail(
+      "terminal_slot_required",
+      "The final bounded event slot is reserved for a terminal event.",
+    );
+  }
+
+  const event = await buildNodeKitRunEvent({
+    runId: args.runId,
+    sequence: nextSequence,
+    eventType: args.eventType,
+    recordedAt: args.recordedAt,
+    payload: args.payload,
+    previousHash: latest?.contentHash ?? NODEKIT_RUN_GENESIS_HASH,
+  });
+  const storedEvents = await ctx.db
+    .query("nodeKitRunEvents")
+    .withIndex("by_trace_sequence", (q) => q.eq("traceId", args.traceId))
+    .order("asc")
+    .take(NODEKIT_RUN_MAX_EVENTS + 1);
+  if (storedEvents.length > NODEKIT_RUN_MAX_EVENTS) {
+    fail(
+      "event_limit_exceeded",
+      `A run may contain at most ${NODEKIT_RUN_MAX_EVENTS} events.`,
+    );
+  }
+  const candidateChain = [
+    ...storedEvents.map((stored) => ({
+      contractVersion: stored.contractVersion,
+      runId: stored.runId,
+      sequence: stored.sequence,
+      eventType: stored.eventType,
+      recordedAt: stored.recordedAt,
+      payload: stored.payload as NodeKitSafeEventPayload,
+      previousHash: stored.previousHash,
+      contentHash: stored.contentHash,
+    })),
+    event,
+  ];
+  const prefix = await verifyNodeKitRunEventPrefix(candidateChain, args.runId);
+  if (prefix.terminalEventType === null) {
+    const remainingSlots = NODEKIT_RUN_MAX_EVENTS - prefix.eventCount;
+    const requiredSlots = prefix.openSpanIds.length + 1;
+    if (remainingSlots < requiredSlots) {
+      fail(
+        "event_capacity_reserved",
+        `The remaining ${remainingSlots} event slot(s) cannot close ${prefix.openSpanIds.length} open span(s) and terminate the run.`,
+      );
+    }
+  }
+  const storedEvent = {
+    sessionId: args.sessionId,
+    traceId: args.traceId,
+    userId: args.userId,
+    ...event,
+    ...(prefix.terminalEventType === null
+      ? {}
+      : { retentionExpiresAt: Date.now() + NODEKIT_RUN_RETENTION_MS }),
+  };
+  await ctx.db.insert("nodeKitRunEvents", storedEvent);
+  return event;
+}

--- a/backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  NodeKitRunContractError,
+  appendNodeKitRunEvent,
+  buildNodeKitRunEvent,
+  canonicalNodeKitJson,
+  sha256CanonicalNodeKitValue,
+  verifyNodeKitRunEventChain,
+  type NodeKitRunEvent,
+} from "./nodeKitRunEvents";
+import {
+  NODEKIT_RUN_EXPORT_SCHEMA_VERSION,
+  assertNodeKitRunExport,
+  buildCanonicalNodeKitRunExport,
+} from "./nodeKitRunExport";
+
+const RUN_ID = "trace_nodekit_export_contract";
+
+async function validEvents(): Promise<NodeKitRunEvent[]> {
+  const started = await buildNodeKitRunEvent({
+    runId: RUN_ID,
+    sequence: 0,
+    eventType: "run.started",
+    recordedAt: 1_725_000_000_000,
+    payload: {
+      workflowName: "Entity intelligence",
+      model: "gemini-3.5-flash",
+      sessionType: "agent",
+      sessionStartedAt: 1_724_999_999_000,
+    },
+    previousHash: NODEKIT_RUN_GENESIS_HASH,
+  });
+  const decision = await buildNodeKitRunEvent({
+    runId: RUN_ID,
+    sequence: 1,
+    eventType: "decision.recorded",
+    recordedAt: 1_725_000_000_010,
+    payload: {
+      statement: "Select the evidence-backed candidate",
+      basis: ["source:a", "source:b"],
+      nested: { z: 2, a: 1 },
+    },
+    previousHash: started.contentHash,
+  });
+  const completed = await buildNodeKitRunEvent({
+    runId: RUN_ID,
+    sequence: 2,
+    eventType: "run.completed",
+    recordedAt: 1_725_000_000_020,
+    payload: {
+      status: "completed",
+      crossCheckStatus: "aligned",
+    },
+    previousHash: decision.contentHash,
+  });
+  return [started, decision, completed];
+}
+
+describe("canonical NodeKit run export", () => {
+  it("emits an immutable ordered export with per-event and whole-export hashes", async () => {
+    const events = await validEvents();
+    const exportDoc = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events,
+    });
+
+    expect(exportDoc.schemaVersion).toBe(NODEKIT_RUN_EXPORT_SCHEMA_VERSION);
+    expect(exportDoc.events.map((event) => event.sequence)).toEqual([0, 1, 2]);
+    expect(exportDoc.completeness).toEqual({
+      eventChainComplete: true,
+      spanLifecycleComplete: true,
+      contractVersion: "nodekit.run-event/v1",
+      eventCount: 3,
+      firstSequence: 0,
+      lastSequence: 2,
+      terminalEventType: "run.completed",
+    });
+    expect(exportDoc.hashes.algorithm).toBe("sha256");
+    expect(exportDoc.hashes.chainHead).toBe(events[2].contentHash);
+    expect(exportDoc.hashes.exportHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(Object.isFrozen(exportDoc)).toBe(true);
+    expect(Object.isFrozen(exportDoc.events)).toBe(true);
+    expect(Object.isFrozen(exportDoc.events[1].payload)).toBe(true);
+    expect(() => {
+      (
+        exportDoc.events[0].payload.fields as {
+          workflowName: string;
+        }
+      ).workflowName = "mutated";
+    }).toThrow();
+
+    await expect(assertNodeKitRunExport(exportDoc)).resolves.toBe(exportDoc);
+  });
+
+  it("hashes canonical content independently of object key insertion order", async () => {
+    const first = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 0,
+      eventType: "run.started",
+      recordedAt: 42,
+      payload: {
+        b: 2,
+        a: { d: 4, c: 3 },
+        workflowName: "ordered",
+        sessionType: "agent",
+        sessionStartedAt: 1,
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+    const second = await buildNodeKitRunEvent({
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+      payload: {
+        sessionStartedAt: 1,
+        sessionType: "agent",
+        workflowName: "ordered",
+        a: { c: 3, d: 4 },
+        b: 2,
+      },
+      recordedAt: 42,
+      eventType: "run.started",
+      sequence: 0,
+      runId: RUN_ID,
+    });
+
+    expect(second.contentHash).toBe(first.contentHash);
+  });
+
+  it("matches the cross-language RFC 8785 number and key-order fixture", async () => {
+    const fixture = {
+      z: -0,
+      tiny: 1e-7,
+      threshold: 1e-6,
+      huge: 1e21,
+      fraction: 0.8,
+      nested: { "😀": 2, "\uE000": 1 },
+    };
+
+    expect(canonicalNodeKitJson(fixture)).toBe(
+      '{"fraction":0.8,"huge":1e+21,"nested":{"😀":2,"":1},"threshold":0.000001,"tiny":1e-7,"z":0}',
+    );
+    await expect(sha256CanonicalNodeKitValue(fixture)).resolves.toBe(
+      "sha256:d4f50ebd3e2d78d0975c68bafdbdf327b64a13c9acddd09cc95a747a1eaa1812",
+    );
+  });
+
+  it.each([
+    {
+      label: "sequence gap",
+      mutate: (events: NodeKitRunEvent[]) => {
+        events[1] = { ...events[1], sequence: 4 };
+      },
+      code: "sequence_not_contiguous",
+    },
+    {
+      label: "broken previous hash",
+      mutate: (events: NodeKitRunEvent[]) => {
+        events[1] = {
+          ...events[1],
+          previousHash: NODEKIT_RUN_GENESIS_HASH,
+        };
+      },
+      code: "previous_hash_mismatch",
+    },
+    {
+      label: "tampered payload",
+      mutate: (events: NodeKitRunEvent[]) => {
+        events[1] = {
+          ...events[1],
+          payload: {
+            ...events[1].payload,
+            sourceDigest: `sha256:${"f".repeat(64)}`,
+          },
+        };
+      },
+      code: "content_hash_mismatch",
+    },
+    {
+      label: "missing terminal event",
+      mutate: (events: NodeKitRunEvent[]) => {
+        events.pop();
+      },
+      code: "terminal_event_missing",
+    },
+    {
+      label: "event after terminal",
+      mutate: (events: NodeKitRunEvent[]) => {
+        events.push({ ...events[1], sequence: 3 });
+      },
+      code: "terminal_event_not_last",
+    },
+  ])("fails closed for a $label", async ({ mutate, code }) => {
+    const events = structuredClone(await validEvents());
+    mutate(events);
+
+    await expect(
+      verifyNodeKitRunEventChain(events, RUN_ID),
+    ).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code,
+    });
+  });
+
+  it("rejects a whole-export hash mismatch without normalizing it away", async () => {
+    const exportDoc = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events: await validEvents(),
+    });
+    const tampered = structuredClone(exportDoc);
+    (tampered.trace as { id: string }).id = "rewritten-after-export";
+
+    await expect(assertNodeKitRunExport(tampered)).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "export_hash_mismatch",
+    });
+  });
+
+  it("rejects a trace status that contradicts the terminal event", async () => {
+    const exportDoc = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events: await validEvents(),
+    });
+    const contradicted = structuredClone(exportDoc);
+    (contradicted.trace as { status: string }).status = "error";
+
+    await expect(assertNodeKitRunExport(contradicted)).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "terminal_status_mismatch",
+    });
+  });
+
+  it("binds export metadata only to immutable event snapshots", async () => {
+    const events = await validEvents();
+    const first = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events,
+    });
+    const second = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events,
+    });
+
+    expect(second).toEqual(first);
+    expect(second.hashes.exportHash).toBe(first.hashes.exportHash);
+    expect(second.session).toEqual({
+      id: "session_123",
+      typeAtRunStart: "agent",
+      startedAt: 1_724_999_999_000,
+    });
+    expect(second.session).not.toHaveProperty("title");
+    expect(second.session).not.toHaveProperty("status");
+  });
+
+  it("stores only a bounded redacted projection of arbitrary payloads", async () => {
+    const event = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 0,
+      eventType: "approval.requested",
+      recordedAt: 42,
+      payload: {
+        approvalId: "approval_1",
+        toolName: "publish",
+        riskLevel: "high",
+        justification: "contains customer context",
+        toolArgs: {
+          apiKey: "must-never-be-stored",
+          customerEmail: "private@example.com",
+        },
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+
+    expect(event.payload.fields).toEqual({
+      approvalId: "approval_1",
+      toolName: "publish",
+      riskLevel: "high",
+    });
+    expect(JSON.stringify(event)).not.toContain("must-never-be-stored");
+    expect(JSON.stringify(event)).not.toContain("private@example.com");
+    expect(JSON.stringify(event)).not.toContain("customer context");
+    expect(event.payload.sourceDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("rejects a terminal run while an explicit span remains open", async () => {
+    const [started] = await validEvents();
+    const spanStarted = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 1,
+      eventType: "span.started",
+      recordedAt: started.recordedAt + 1,
+      payload: { spanId: "span_open" },
+      previousHash: started.contentHash,
+    });
+    const completed = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 2,
+      eventType: "run.completed",
+      recordedAt: started.recordedAt + 2,
+      payload: { status: "completed" },
+      previousHash: spanStarted.contentHash,
+    });
+
+    await expect(
+      verifyNodeKitRunEventChain([started, spanStarted, completed], RUN_ID),
+    ).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "span_lifecycle_incomplete",
+    });
+  });
+
+  it.each([
+    {
+      eventType: "run.completed" as const,
+      status: "error",
+    },
+    {
+      eventType: "run.failed" as const,
+      status: "completed",
+    },
+  ])(
+    "rejects a $eventType event whose safe status is $status",
+    async ({ eventType, status }) => {
+      await expect(
+        buildNodeKitRunEvent({
+          runId: RUN_ID,
+          sequence: 0,
+          eventType,
+          recordedAt: 42,
+          payload: { status },
+          previousHash: NODEKIT_RUN_GENESIS_HASH,
+        }),
+      ).rejects.toMatchObject({
+        name: "NodeKitRunContractError",
+        code: "terminal_status_mismatch",
+      });
+    },
+  );
+
+  it("rejects a hash-valid chain whose event clock moves backwards", async () => {
+    const [started] = await validEvents();
+    const decision = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 1,
+      eventType: "decision.recorded",
+      recordedAt: started.recordedAt + 1_000,
+      payload: { decisionType: "future-decision" },
+      previousHash: started.contentHash,
+    });
+    const completed = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 2,
+      eventType: "run.completed",
+      recordedAt: started.recordedAt + 100,
+      payload: { status: "completed" },
+      previousHash: decision.contentHash,
+    });
+
+    await expect(
+      verifyNodeKitRunEventChain([started, decision, completed], RUN_ID),
+    ).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "recorded_at_not_monotonic",
+    });
+  });
+
+  it("reserves enough bounded capacity to close every open span and terminate", async () => {
+    const events: NodeKitRunEvent[] = [];
+    let previousHash: string = NODEKIT_RUN_GENESIS_HASH;
+    for (let sequence = 0; sequence < 254; sequence += 1) {
+      const event = await buildNodeKitRunEvent({
+        runId: RUN_ID,
+        sequence,
+        eventType: sequence === 0 ? "run.started" : "decision.recorded",
+        recordedAt: 1_725_000_000_000 + sequence,
+        payload:
+          sequence === 0
+            ? {
+                workflowName: "Capacity boundary",
+                sessionType: "agent",
+                sessionStartedAt: 1_725_000_000_000,
+              }
+            : { decisionType: `decision-${sequence}` },
+        previousHash,
+      });
+      events.push(event);
+      previousHash = event.contentHash;
+    }
+    const stored = events.map((event) => ({
+      ...event,
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      userId: "user_123",
+    }));
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              first: async () => stored.at(-1),
+              take: async () => stored,
+            }),
+          }),
+        }),
+        insert: async () => "must-not-insert",
+      },
+    };
+
+    await expect(
+      appendNodeKitRunEvent(ctx as never, {
+        sessionId: "session_123" as never,
+        traceId: "trace_record_123" as never,
+        userId: "user_123" as never,
+        runId: RUN_ID,
+        eventType: "span.started",
+        recordedAt: 1_725_000_000_254,
+        payload: { spanId: "span-that-cannot-fit" },
+      }),
+    ).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "event_capacity_reserved",
+    });
+  });
+
+  it("reserves the final bounded event slot for termination", async () => {
+    const latest = {
+      sequence: 254,
+      eventType: "decision.recorded",
+      runId: RUN_ID,
+      sessionId: "session_123",
+      userId: "user_123",
+      contentHash: `sha256:${"a".repeat(64)}`,
+    };
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              first: async () => latest,
+            }),
+          }),
+        }),
+      },
+    };
+
+    await expect(
+      appendNodeKitRunEvent(ctx as never, {
+        sessionId: "session_123" as never,
+        traceId: "trace_record_123" as never,
+        userId: "user_123" as never,
+        runId: RUN_ID,
+        eventType: "decision.recorded",
+        recordedAt: 42,
+        payload: { decisionType: "must-not-fit" },
+      }),
+    ).rejects.toMatchObject({
+      name: "NodeKitRunContractError",
+      code: "terminal_slot_required",
+    });
+  });
+
+  it("uses typed contract errors rather than partial exports", () => {
+    const error = new NodeKitRunContractError("legacy_trace", "No event chain");
+
+    expect(error.name).toBe("NodeKitRunContractError");
+    expect(error.code).toBe("legacy_trace");
+  });
+});

--- a/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
@@ -1,0 +1,483 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
+
+import type { Id } from "../../../_generated/dataModel";
+import { query } from "../../../_generated/server";
+import {
+  NODEKIT_RUN_EVENT_CONTRACT_VERSION,
+  NODEKIT_RUN_MAX_EVENTS,
+  NodeKitRunContractError,
+  deepFreezeNodeKitValue,
+  sha256CanonicalNodeKitValue,
+  verifyNodeKitRunEventChain,
+  type NodeKitRunEvent,
+  type NodeKitSafeEventPayload,
+} from "./nodeKitRunEvents";
+
+export const NODEKIT_RUN_EXPORT_SCHEMA_VERSION =
+  "nodekit.run-export/v1" as const;
+
+class ConvexError<T extends Record<string, unknown>> extends Error {
+  readonly data: T;
+
+  constructor(data: T) {
+    super(String(data.message ?? JSON.stringify(data)));
+    this.name = "ConvexError";
+    this.data = data;
+    (this as Record<PropertyKey, unknown>)[Symbol.for("ConvexError")] = true;
+  }
+}
+
+type SessionExport = Readonly<{
+  id: string;
+  typeAtRunStart: string;
+  startedAt: number;
+}>;
+
+type TraceExport = Readonly<{
+  id: string;
+  runId: string;
+  workflowName: string;
+  status: "completed" | "error";
+  startedAt: number;
+  endedAt: number;
+}>;
+
+export type CanonicalNodeKitRunExport = Readonly<{
+  schemaVersion: typeof NODEKIT_RUN_EXPORT_SCHEMA_VERSION;
+  runId: string;
+  session: SessionExport;
+  trace: TraceExport;
+  events: readonly NodeKitRunEvent[];
+  completeness: Readonly<{
+    eventChainComplete: true;
+    spanLifecycleComplete: true;
+    contractVersion: typeof NODEKIT_RUN_EVENT_CONTRACT_VERSION;
+    eventCount: number;
+    firstSequence: 0;
+    lastSequence: number;
+    terminalEventType: "run.completed" | "run.failed";
+  }>;
+  hashes: Readonly<{
+    algorithm: "sha256";
+    chainHead: string;
+    exportHash: string;
+  }>;
+}>;
+
+function fail(code: string, message: string): never {
+  throw new NodeKitRunContractError(code, message);
+}
+
+function assertObject(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("shape_invalid", `${label} must be an object.`);
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const canonicalExpected = [...expected].sort();
+  if (
+    actual.length !== canonicalExpected.length ||
+    actual.some((key, index) => key !== canonicalExpected[index])
+  ) {
+    fail(
+      "shape_invalid",
+      `${label} keys must be exactly ${canonicalExpected.join(", ")}.`,
+    );
+  }
+}
+
+function assertString(
+  value: unknown,
+  label: string,
+  options: { nonEmpty?: boolean; maxLength?: number } = {},
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    (options.nonEmpty && value.trim().length === 0) ||
+    (options.maxLength !== undefined && value.length > options.maxLength)
+  ) {
+    fail("shape_invalid", `${label} must be a valid string.`);
+  }
+}
+
+function assertTimestamp(
+  value: unknown,
+  label: string,
+): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    fail("shape_invalid", `${label} must be a non-negative safe integer.`);
+  }
+}
+
+function assertSessionExport(
+  value: Record<string, unknown>,
+): asserts value is Record<string, unknown> & SessionExport {
+  assertExactKeys(value, ["id", "typeAtRunStart", "startedAt"], "session");
+  assertString(value.id, "session.id", { nonEmpty: true });
+  assertString(value.typeAtRunStart, "session.typeAtRunStart", {
+    nonEmpty: true,
+    maxLength: 256,
+  });
+  assertTimestamp(value.startedAt, "session.startedAt");
+}
+
+function assertTraceExport(
+  value: Record<string, unknown>,
+): asserts value is Record<string, unknown> & TraceExport {
+  assertExactKeys(
+    value,
+    ["id", "runId", "workflowName", "status", "startedAt", "endedAt"],
+    "trace",
+  );
+  assertString(value.id, "trace.id", { nonEmpty: true });
+  assertString(value.runId, "trace.runId", {
+    nonEmpty: true,
+    maxLength: 256,
+  });
+  assertString(value.workflowName, "trace.workflowName", { nonEmpty: true });
+  if (value.status !== "completed" && value.status !== "error") {
+    fail("run_not_terminal", "trace.status must be completed or error.");
+  }
+  assertTimestamp(value.startedAt, "trace.startedAt");
+  assertTimestamp(value.endedAt, "trace.endedAt");
+  if (value.endedAt < value.startedAt) {
+    fail("shape_invalid", "trace.endedAt cannot precede startedAt.");
+  }
+}
+
+function exportHashBody(
+  exportDoc: Omit<CanonicalNodeKitRunExport, "hashes"> & {
+    hashes: Omit<CanonicalNodeKitRunExport["hashes"], "exportHash">;
+  },
+) {
+  return exportDoc;
+}
+
+function requiredStartField(
+  startEvent: NodeKitRunEvent,
+  field: string,
+): string | number {
+  const value = startEvent.payload.fields[field];
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "string" && value.trim().length === 0)
+  ) {
+    fail(
+      "start_snapshot_missing",
+      `run.started is missing the event-bound ${field} snapshot.`,
+    );
+  }
+  return value;
+}
+
+export async function buildCanonicalNodeKitRunExport(input: {
+  sessionId: string;
+  traceId: string;
+  events: readonly NodeKitRunEvent[];
+}): Promise<CanonicalNodeKitRunExport> {
+  assertString(input.sessionId, "sessionId", { nonEmpty: true });
+  assertString(input.traceId, "traceId", { nonEmpty: true });
+  const expectedRunId = input.events[0]?.runId;
+  assertString(expectedRunId, "events[0].runId", {
+    nonEmpty: true,
+    maxLength: 256,
+  });
+  const chain = await verifyNodeKitRunEventChain(input.events, expectedRunId);
+  const startEvent = input.events[0];
+  const terminalEvent = input.events[input.events.length - 1];
+  const workflowName = requiredStartField(startEvent, "workflowName");
+  const sessionType = requiredStartField(startEvent, "sessionType");
+  const sessionStartedAt = requiredStartField(startEvent, "sessionStartedAt");
+  if (
+    typeof workflowName !== "string" ||
+    typeof sessionType !== "string" ||
+    !Number.isSafeInteger(sessionStartedAt) ||
+    (sessionStartedAt as number) < 0
+  ) {
+    fail(
+      "start_snapshot_invalid",
+      "run.started has an invalid event-bound session/trace snapshot.",
+    );
+  }
+  const session: SessionExport = {
+    id: input.sessionId,
+    typeAtRunStart: sessionType,
+    startedAt: sessionStartedAt as number,
+  };
+  const trace: TraceExport = {
+    id: input.traceId,
+    runId: expectedRunId,
+    workflowName,
+    status: chain.terminalEventType === "run.completed" ? "completed" : "error",
+    startedAt: startEvent.recordedAt,
+    endedAt: terminalEvent.recordedAt,
+  };
+  assertSessionExport(session);
+  assertTraceExport(trace);
+  if (session.startedAt > trace.startedAt) {
+    fail(
+      "start_snapshot_invalid",
+      "Session start cannot follow the run.started event.",
+    );
+  }
+  const withoutExportHash = {
+    schemaVersion: NODEKIT_RUN_EXPORT_SCHEMA_VERSION,
+    runId: trace.runId,
+    session,
+    trace,
+    events: input.events,
+    completeness: {
+      eventChainComplete: true as const,
+      spanLifecycleComplete: true as const,
+      contractVersion: NODEKIT_RUN_EVENT_CONTRACT_VERSION,
+      eventCount: chain.eventCount,
+      firstSequence: 0 as const,
+      lastSequence: chain.eventCount - 1,
+      terminalEventType: chain.terminalEventType,
+    },
+    hashes: {
+      algorithm: "sha256" as const,
+      chainHead: chain.chainHead,
+    },
+  };
+  const result: CanonicalNodeKitRunExport = {
+    ...withoutExportHash,
+    hashes: {
+      ...withoutExportHash.hashes,
+      exportHash: await sha256CanonicalNodeKitValue(
+        exportHashBody(withoutExportHash),
+      ),
+    },
+  };
+  return deepFreezeNodeKitValue(result);
+}
+
+export async function assertNodeKitRunExport(
+  value: unknown,
+): Promise<CanonicalNodeKitRunExport> {
+  assertObject(value, "NodeKit run export");
+  assertExactKeys(
+    value,
+    [
+      "schemaVersion",
+      "runId",
+      "session",
+      "trace",
+      "events",
+      "completeness",
+      "hashes",
+    ],
+    "NodeKit run export",
+  );
+  if (value.schemaVersion !== NODEKIT_RUN_EXPORT_SCHEMA_VERSION) {
+    fail("export_schema_mismatch", "Unsupported NodeKit run export schema.");
+  }
+  if (typeof value.runId !== "string" || !value.runId.trim()) {
+    fail("run_id_invalid", "runId is required.");
+  }
+  assertObject(value.session, "session");
+  assertObject(value.trace, "trace");
+  assertObject(value.completeness, "completeness");
+  assertObject(value.hashes, "hashes");
+  assertSessionExport(value.session);
+  assertTraceExport(value.trace);
+  assertExactKeys(
+    value.completeness,
+    [
+      "eventChainComplete",
+      "spanLifecycleComplete",
+      "contractVersion",
+      "eventCount",
+      "firstSequence",
+      "lastSequence",
+      "terminalEventType",
+    ],
+    "completeness",
+  );
+  assertExactKeys(
+    value.hashes,
+    ["algorithm", "chainHead", "exportHash"],
+    "hashes",
+  );
+  if (!Array.isArray(value.events)) {
+    fail("events_invalid", "events must be an array.");
+  }
+  if (value.trace.runId !== value.runId) {
+    fail("run_id_mismatch", "Trace and export run IDs differ.");
+  }
+  const chain = await verifyNodeKitRunEventChain(
+    value.events as NodeKitRunEvent[],
+    value.runId,
+  );
+  const expectedTraceStatus =
+    chain.terminalEventType === "run.completed" ? "completed" : "error";
+  if (value.trace.status !== expectedTraceStatus) {
+    fail(
+      "terminal_status_mismatch",
+      `Trace status ${value.trace.status} does not match ${chain.terminalEventType}.`,
+    );
+  }
+  const startEvent = (value.events as NodeKitRunEvent[])[0];
+  const terminalEvent = (value.events as NodeKitRunEvent[])[
+    value.events.length - 1
+  ];
+  const workflowName = requiredStartField(startEvent, "workflowName");
+  const sessionType = requiredStartField(startEvent, "sessionType");
+  const sessionStartedAt = requiredStartField(startEvent, "sessionStartedAt");
+  if (
+    value.trace.workflowName !== workflowName ||
+    value.trace.startedAt !== startEvent.recordedAt ||
+    value.trace.endedAt !== terminalEvent.recordedAt ||
+    value.session.typeAtRunStart !== sessionType ||
+    value.session.startedAt !== sessionStartedAt ||
+    value.session.startedAt > value.trace.startedAt
+  ) {
+    fail(
+      "event_snapshot_mismatch",
+      "Session or trace metadata differs from the immutable event snapshots.",
+    );
+  }
+  if (
+    value.completeness.eventChainComplete !== true ||
+    value.completeness.spanLifecycleComplete !== true ||
+    value.completeness.contractVersion !== NODEKIT_RUN_EVENT_CONTRACT_VERSION ||
+    value.completeness.eventCount !== chain.eventCount ||
+    value.completeness.firstSequence !== 0 ||
+    value.completeness.lastSequence !== chain.eventCount - 1 ||
+    value.completeness.terminalEventType !== chain.terminalEventType
+  ) {
+    fail(
+      "completeness_mismatch",
+      "Completeness receipt does not match the verified event chain.",
+    );
+  }
+  if (
+    value.hashes.algorithm !== "sha256" ||
+    value.hashes.chainHead !== chain.chainHead
+  ) {
+    fail("chain_head_mismatch", "Export chain head does not match its events.");
+  }
+
+  const expectedExportHash = await sha256CanonicalNodeKitValue({
+    schemaVersion: value.schemaVersion,
+    runId: value.runId,
+    session: value.session,
+    trace: value.trace,
+    events: value.events,
+    completeness: value.completeness,
+    hashes: {
+      algorithm: value.hashes.algorithm,
+      chainHead: value.hashes.chainHead,
+    },
+  });
+  if (value.hashes.exportHash !== expectedExportHash) {
+    fail(
+      "export_hash_mismatch",
+      "Run export content does not match exportHash.",
+    );
+  }
+  return deepFreezeNodeKitValue(value as CanonicalNodeKitRunExport);
+}
+
+async function requireOwnerId(ctx: unknown): Promise<Id<"users">> {
+  const raw = await getAuthUserId(ctx as never);
+  if (!raw) fail("not_authenticated", "Authentication is required.");
+  const normalized =
+    typeof raw === "string" && raw.includes("|") ? raw.split("|")[0] : raw;
+  if (!normalized) fail("not_authenticated", "Authentication is required.");
+  return normalized as Id<"users">;
+}
+
+function throwConvexBoundaryError(error: unknown): never {
+  if (error instanceof NodeKitRunContractError) {
+    throw new ConvexError({
+      code: error.code,
+      message: error.message.slice(error.message.indexOf(":") + 1).trim(),
+    });
+  }
+  throw error;
+}
+
+export const exportNodeKitRun = query({
+  args: {
+    traceId: v.id("agentTaskTraces"),
+  },
+  handler: async (ctx, args) => {
+    try {
+      const ownerId = await requireOwnerId(ctx);
+      const trace = await ctx.db.get(args.traceId);
+      if (!trace) fail("trace_not_found", "Trace not found or unauthorized.");
+      const session = await ctx.db.get(trace.sessionId);
+      if (!session || session.userId !== ownerId) {
+        fail("trace_not_found", "Trace not found or unauthorized.");
+      }
+      if (trace.status === "running") {
+        fail("run_not_terminal", "A running trace cannot be exported.");
+      }
+      const storedEvents = await ctx.db
+        .query("nodeKitRunEvents")
+        .withIndex("by_trace_sequence", (q) => q.eq("traceId", args.traceId))
+        .order("asc")
+        .take(NODEKIT_RUN_MAX_EVENTS + 1);
+      if (storedEvents.length === 0) {
+        fail(
+          "run_history_unavailable",
+          "Canonical run history is unavailable because it is legacy, expired, or deleted.",
+        );
+      }
+      if (storedEvents.length > NODEKIT_RUN_MAX_EVENTS) {
+        fail(
+          "event_limit_exceeded",
+          `Run exceeds the ${NODEKIT_RUN_MAX_EVENTS}-event export bound.`,
+        );
+      }
+      if (
+        storedEvents.some(
+          (event) =>
+            event.userId !== ownerId ||
+            event.sessionId !== session._id ||
+            event.runId !== trace.traceId,
+        )
+      ) {
+        fail(
+          "event_ownership_mismatch",
+          "Stored event ownership does not match the trace.",
+        );
+      }
+
+      const exportDoc = await buildCanonicalNodeKitRunExport({
+        sessionId: String(session._id),
+        traceId: String(trace._id),
+        events: storedEvents.map((event) => ({
+          contractVersion: event.contractVersion,
+          runId: event.runId,
+          sequence: event.sequence,
+          eventType: event.eventType,
+          recordedAt: event.recordedAt,
+          payload: event.payload as NodeKitSafeEventPayload,
+          previousHash: event.previousHash,
+          contentHash: event.contentHash,
+        })),
+      });
+      if (trace.status !== exportDoc.trace.status) {
+        fail(
+          "trace_state_mismatch",
+          "Stored trace status differs from the terminal event snapshot.",
+        );
+      }
+      return exportDoc;
+    } catch (error) {
+      throwConvexBoundaryError(error);
+    }
+  },
+});

--- a/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
@@ -1,0 +1,547 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  buildNodeKitRunEvent,
+  type NodeKitRunEvent,
+} from "./nodeKitRunEvents";
+import { exportNodeKitRun } from "./nodeKitRunExport";
+import {
+  deleteOwnedNodeKitRunHistory,
+  purgeExpiredNodeKitRunEvents,
+} from "./nodeKitRunRetention";
+
+type Row = Record<string, any> & { _id: string };
+type Tables = Record<string, Row[]>;
+
+class MockQuery {
+  private rows: Row[];
+  private indexName = "";
+
+  constructor(rows: Row[]) {
+    this.rows = [...rows];
+  }
+
+  withIndex(
+    name: string,
+    apply: (q: {
+      eq: (field: string, value: unknown) => any;
+      lte: (field: string, value: number) => any;
+    }) => unknown,
+  ) {
+    this.indexName = name;
+    const builder = {
+      eq: (field: string, value: unknown) => {
+        this.rows = this.rows.filter((row) => row[field] === value);
+        return builder;
+      },
+      lte: (field: string, value: number) => {
+        this.rows = this.rows.filter(
+          (row) => typeof row[field] === "number" && row[field] <= value,
+        );
+        return builder;
+      },
+    };
+    apply(builder);
+    return this;
+  }
+
+  order(direction: "asc" | "desc") {
+    const fields = this.indexName.includes("status_started")
+      ? ["startedAt"]
+      : this.indexName.includes("retention")
+        ? ["retentionExpiresAt"]
+        : ["sequence"];
+    this.rows.sort((left, right) => {
+      for (const field of fields) {
+        const delta = Number(left[field] ?? 0) - Number(right[field] ?? 0);
+        if (delta !== 0) return direction === "asc" ? delta : -delta;
+      }
+      return String(left._id).localeCompare(String(right._id));
+    });
+    return this;
+  }
+
+  async first() {
+    return this.rows[0] ?? null;
+  }
+
+  async take(limit: number) {
+    return this.rows.slice(0, limit);
+  }
+}
+
+class MockDb {
+  readonly tables: Tables;
+  private nextId = 0;
+
+  constructor(tables: Tables) {
+    this.tables = structuredClone(tables);
+  }
+
+  async get(id: string) {
+    for (const rows of Object.values(this.tables)) {
+      const row = rows.find((candidate) => candidate._id === id);
+      if (row) return row;
+    }
+    return null;
+  }
+
+  query(table: string) {
+    return new MockQuery(this.tables[table] ?? []);
+  }
+
+  async insert(table: string, value: Record<string, unknown>) {
+    const id = `${table}:inserted-${this.nextId++}`;
+    (this.tables[table] ??= []).push({ _id: id, ...structuredClone(value) });
+    return id;
+  }
+
+  async patch(id: string, value: Record<string, unknown>) {
+    const row = await this.get(id);
+    if (!row) throw new Error(`missing row ${id}`);
+    Object.assign(row, structuredClone(value));
+  }
+
+  async delete(id: string) {
+    for (const rows of Object.values(this.tables)) {
+      const index = rows.findIndex((candidate) => candidate._id === id);
+      if (index >= 0) {
+        rows.splice(index, 1);
+        return;
+      }
+    }
+  }
+}
+
+function createCtx(tables: Tables, subject: string | null = "owner-a") {
+  const scheduled: Array<{ delay: number; args: unknown }> = [];
+  return {
+    db: new MockDb(tables),
+    auth: {
+      getUserIdentity: async () => (subject ? { subject } : null),
+    },
+    scheduler: {
+      runAfter: async (delay: number, _fn: unknown, args: unknown) => {
+        scheduled.push({ delay, args });
+      },
+    },
+    scheduled,
+  };
+}
+
+function terminalHistory(overrides: Partial<Row> = {}): Tables {
+  return {
+    agentTaskSessions: [
+      {
+        _id: "session-a",
+        userId: "owner-a",
+        type: "agent",
+        startedAt: 1,
+      },
+    ],
+    agentTaskTraces: [
+      {
+        _id: "trace-a",
+        sessionId: "session-a",
+        traceId: "run-a",
+        workflowName: "Owner workflow",
+        status: "completed",
+        startedAt: 1,
+        endedAt: 2,
+      },
+    ],
+    nodeKitRunEvents: [
+      {
+        _id: "event-a-0",
+        traceId: "trace-a",
+        sessionId: "session-a",
+        userId: "owner-a",
+        runId: "run-a",
+        sequence: 0,
+        eventType: "run.started",
+        ...overrides,
+      },
+      {
+        _id: "event-a-1",
+        traceId: "trace-a",
+        sessionId: "session-a",
+        userId: "owner-a",
+        runId: "run-a",
+        sequence: 1,
+        eventType: "run.completed",
+        ...overrides,
+      },
+    ],
+  };
+}
+
+describe("NodeKit owner-scoped deletion", () => {
+  it("rejects anonymous and cross-owner deletion without removing rows", async () => {
+    for (const [subject, code] of [
+      [null, "not_authenticated"],
+      ["owner-b", "trace_not_found"],
+    ] as const) {
+      const ctx = createCtx(terminalHistory(), subject);
+      await expect(
+        (deleteOwnedNodeKitRunHistory as any)._handler(ctx, {
+          traceId: "trace-a",
+        }),
+      ).rejects.toMatchObject({ data: { code } });
+      expect(ctx.db.tables.nodeKitRunEvents).toHaveLength(2);
+    }
+  });
+
+  it("deletes the complete terminal chain for its owner", async () => {
+    const ctx = createCtx(terminalHistory());
+    await expect(
+      (deleteOwnedNodeKitRunHistory as any)._handler(ctx, {
+        traceId: "trace-a",
+      }),
+    ).resolves.toEqual({ deleted: 2 });
+    expect(ctx.db.tables.nodeKitRunEvents).toEqual([]);
+  });
+
+  it("rejects corrupt cross-owner history without a partial delete", async () => {
+    const tables = terminalHistory();
+    tables.nodeKitRunEvents[1].userId = "owner-b";
+    const ctx = createCtx(tables);
+
+    await expect(
+      (deleteOwnedNodeKitRunHistory as any)._handler(ctx, {
+        traceId: "trace-a",
+      }),
+    ).rejects.toMatchObject({
+      data: { code: "event_ownership_mismatch" },
+    });
+    expect(ctx.db.tables.nodeKitRunEvents).toHaveLength(2);
+  });
+
+  it("reports deleted or expired canonical history truthfully", async () => {
+    const ctx = createCtx(terminalHistory());
+    await (deleteOwnedNodeKitRunHistory as any)._handler(ctx, {
+      traceId: "trace-a",
+    });
+
+    await expect(
+      (exportNodeKitRun as any)._handler(ctx, { traceId: "trace-a" }),
+    ).rejects.toMatchObject({
+      data: { code: "run_history_unavailable" },
+    });
+  });
+});
+
+describe("NodeKit bounded retention maintenance", () => {
+  it("closes a stale running trace, including its open span, before retention", async () => {
+    const now = Date.now();
+    const runId = "stale-run";
+    const started = await buildNodeKitRunEvent({
+      runId,
+      sequence: 0,
+      eventType: "run.started",
+      recordedAt: now - 31 * 24 * 60 * 60 * 1000,
+      payload: {
+        workflowName: "Stale workflow",
+        sessionType: "agent",
+        sessionStartedAt: now - 31 * 24 * 60 * 60 * 1000,
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+    const spanStarted = await buildNodeKitRunEvent({
+      runId,
+      sequence: 1,
+      eventType: "span.started",
+      recordedAt: started.recordedAt + 1,
+      payload: { spanId: "span-open" },
+      previousHash: started.contentHash,
+    });
+    const rows = [started, spanStarted].map((event, index) => ({
+      _id: `stale-event-${index}`,
+      sessionId: "stale-session",
+      traceId: "stale-trace",
+      userId: "owner-a",
+      ...event,
+    }));
+    const ctx = createCtx({
+      agentTaskSessions: [
+        {
+          _id: "stale-session",
+          userId: "owner-a",
+          type: "agent",
+          startedAt: started.recordedAt,
+        },
+      ],
+      agentTaskTraces: [
+        {
+          _id: "stale-trace",
+          sessionId: "stale-session",
+          traceId: runId,
+          workflowName: "Stale workflow",
+          status: "running",
+          startedAt: started.recordedAt,
+        },
+      ],
+      agentTaskSpans: [
+        {
+          _id: "span-open",
+          traceId: "stale-trace",
+          status: "running",
+          startedAt: spanStarted.recordedAt,
+        },
+      ],
+      nodeKitRunEvents: rows,
+    });
+
+    const result = await (purgeExpiredNodeKitRunEvents as any)._handler(
+      ctx,
+      {},
+    );
+
+    expect(result).toMatchObject({ staleClosed: 1, staleCorruptPurged: 0 });
+    expect((await ctx.db.get("stale-trace"))?.status).toBe("error");
+    expect((await ctx.db.get("span-open"))?.status).toBe("error");
+    expect(ctx.db.tables.nodeKitRunEvents.at(-1)?.eventType).toBe("run.failed");
+    expect(
+      ctx.db.tables.nodeKitRunEvents.at(-1)?.retentionExpiresAt,
+    ).toBeGreaterThan(now);
+  });
+
+  it("purges a corrupt stale chain without forging a terminal receipt", async () => {
+    const now = Date.now();
+    const started = await buildNodeKitRunEvent({
+      runId: "corrupt-stale-run",
+      sequence: 0,
+      eventType: "run.started",
+      recordedAt: now - 31 * 24 * 60 * 60 * 1000,
+      payload: {
+        workflowName: "Corrupt stale workflow",
+        sessionType: "agent",
+        sessionStartedAt: now - 31 * 24 * 60 * 60 * 1000,
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+    const ctx = createCtx({
+      agentTaskSessions: [
+        {
+          _id: "corrupt-session",
+          userId: "owner-a",
+          type: "agent",
+          startedAt: started.recordedAt,
+        },
+      ],
+      agentTaskTraces: [
+        {
+          _id: "corrupt-trace",
+          sessionId: "corrupt-session",
+          traceId: "corrupt-stale-run",
+          workflowName: "Corrupt stale workflow",
+          status: "running",
+          startedAt: started.recordedAt,
+        },
+      ],
+      agentTaskSpans: [],
+      nodeKitRunEvents: [
+        {
+          _id: "corrupt-event",
+          sessionId: "corrupt-session",
+          traceId: "corrupt-trace",
+          userId: "owner-a",
+          ...started,
+          contentHash: `sha256:${"f".repeat(64)}`,
+        },
+      ],
+    });
+
+    const result = await (purgeExpiredNodeKitRunEvents as any)._handler(
+      ctx,
+      {},
+    );
+
+    expect(result).toMatchObject({ staleClosed: 0, staleCorruptPurged: 1 });
+    expect((await ctx.db.get("corrupt-trace"))?.status).toBe("error");
+    expect(ctx.db.tables.nodeKitRunEvents).toEqual([]);
+    expect(
+      ctx.db.tables.nodeKitRunEvents.some(
+        (event) => event.eventType === "run.failed",
+      ),
+    ).toBe(false);
+  });
+
+  it("drains accumulated legacy spans in bounded stale-run continuations", async () => {
+    const now = Date.now();
+    const ctx = createCtx({
+      agentTaskSessions: [
+        {
+          _id: "legacy-session",
+          userId: "owner-a",
+          type: "agent",
+          startedAt: now - 31 * 24 * 60 * 60 * 1000,
+        },
+      ],
+      agentTaskTraces: [
+        {
+          _id: "legacy-trace",
+          sessionId: "legacy-session",
+          traceId: "legacy-run",
+          workflowName: "Accumulated legacy workflow",
+          status: "running",
+          startedAt: now - 31 * 24 * 60 * 60 * 1000,
+        },
+      ],
+      agentTaskSpans: Array.from({ length: 300 }, (_, seq) => ({
+        _id: `legacy-span-${seq}`,
+        traceId: "legacy-trace",
+        seq,
+        status: "running",
+        startedAt: now - 10_000,
+      })),
+      nodeKitRunEvents: [],
+    });
+
+    const first = await (purgeExpiredNodeKitRunEvents as any)._handler(ctx, {});
+    expect(first).toMatchObject({
+      stalePending: 1,
+      staleCorruptPurged: 0,
+      continuationScheduled: true,
+    });
+    expect((await ctx.db.get("legacy-trace"))?.status).toBe("running");
+    expect(
+      ctx.db.tables.agentTaskSpans.filter((span) => span.status === "running"),
+    ).toHaveLength(44);
+    expect(ctx.scheduled).toHaveLength(1);
+
+    const second = await (purgeExpiredNodeKitRunEvents as any)._handler(
+      ctx,
+      {},
+    );
+    expect(second).toMatchObject({
+      stalePending: 0,
+      staleCorruptPurged: 1,
+      continuationScheduled: false,
+    });
+    expect((await ctx.db.get("legacy-trace"))?.status).toBe("error");
+    expect(
+      ctx.db.tables.agentTaskSpans.filter((span) => span.status === "running"),
+    ).toEqual([]);
+  });
+
+  it("bypasses expired nonterminal rows and drains a sustained terminal backlog in continuations", async () => {
+    const now = Date.now();
+    const tables: Tables = {
+      agentTaskSessions: [],
+      agentTaskTraces: [
+        {
+          _id: "still-running",
+          sessionId: "running-session",
+          traceId: "still-running",
+          status: "running",
+          startedAt: now,
+        },
+      ],
+      nodeKitRunEvents: Array.from({ length: 128 }, (_, sequence) => ({
+        _id: `running-${sequence}`,
+        traceId: "still-running",
+        sessionId: "running-session",
+        userId: "owner-a",
+        runId: "still-running",
+        sequence,
+        eventType: sequence === 0 ? "run.started" : "decision.recorded",
+        retentionExpiresAt: now - 10_000,
+      })),
+    };
+    for (let traceIndex = 0; traceIndex < 5; traceIndex += 1) {
+      const traceId = `terminal-trace-${traceIndex}`;
+      tables.agentTaskTraces.push({
+        _id: traceId,
+        sessionId: `terminal-session-${traceIndex}`,
+        traceId,
+        status: "completed",
+        startedAt: now - 20_000,
+      });
+      for (let sequence = 0; sequence < 256; sequence += 1) {
+        tables.nodeKitRunEvents.push({
+          _id: `${traceId}-${sequence}`,
+          traceId,
+          sessionId: `terminal-session-${traceIndex}`,
+          userId: "owner-a",
+          runId: traceId,
+          sequence,
+          eventType: sequence === 255 ? "run.completed" : "decision.recorded",
+          ...(sequence === 255
+            ? { retentionExpiresAt: now - 1_000 + traceIndex }
+            : {}),
+        });
+      }
+    }
+    const ctx = createCtx(tables);
+
+    const first = await (purgeExpiredNodeKitRunEvents as any)._handler(ctx, {});
+    expect(first).toMatchObject({
+      deleted: 1024,
+      continuationScheduled: true,
+    });
+    expect(ctx.scheduled).toHaveLength(1);
+    expect(
+      ctx.db.tables.nodeKitRunEvents.filter((row) =>
+        String(row.traceId).startsWith("terminal-trace-"),
+      ),
+    ).toHaveLength(256);
+    expect(
+      ctx.db.tables.nodeKitRunEvents.filter(
+        (row) => row.traceId === "still-running",
+      ),
+    ).toHaveLength(128);
+
+    const second = await (purgeExpiredNodeKitRunEvents as any)._handler(
+      ctx,
+      {},
+    );
+    expect(second).toMatchObject({
+      deleted: 256,
+      continuationScheduled: false,
+    });
+    expect(
+      ctx.db.tables.nodeKitRunEvents.filter((row) =>
+        String(row.traceId).startsWith("terminal-trace-"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not spin continuations for a full but non-progressing corrupt batch", async () => {
+    const now = Date.now();
+    const ctx = createCtx({
+      agentTaskSessions: [],
+      agentTaskTraces: [
+        {
+          _id: "contradictory-running-trace",
+          sessionId: "missing-session",
+          traceId: "contradictory-running-run",
+          status: "running",
+          startedAt: now,
+        },
+      ],
+      nodeKitRunEvents: Array.from({ length: 128 }, (_, sequence) => ({
+        _id: `contradictory-terminal-${sequence}`,
+        traceId: "contradictory-running-trace",
+        sessionId: "missing-session",
+        userId: "owner-a",
+        runId: "contradictory-running-run",
+        sequence,
+        eventType: "run.completed",
+        retentionExpiresAt: now - 1_000,
+      })),
+    });
+
+    const result = await (purgeExpiredNodeKitRunEvents as any)._handler(
+      ctx,
+      {},
+    );
+
+    expect(result).toMatchObject({
+      deleted: 0,
+      skippedRunning: 1,
+      continuationScheduled: false,
+    });
+    expect(ctx.scheduled).toEqual([]);
+  });
+});

--- a/backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts
@@ -1,0 +1,375 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
+
+import { internal } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
+import { internalMutation, mutation } from "../../../_generated/server";
+import {
+  NODEKIT_RUN_MAX_EVENTS,
+  NODEKIT_RUN_RETENTION_MS,
+  NodeKitRunContractError,
+  appendNodeKitRunEvent,
+  verifyNodeKitRunEventPrefix,
+  type NodeKitRunEvent,
+  type NodeKitSafeEventPayload,
+} from "./nodeKitRunEvents";
+
+const RETENTION_TERMINAL_BATCH = 128;
+const RETENTION_DELETE_BUDGET = NODEKIT_RUN_MAX_EVENTS * 4;
+const STALE_TRACE_BATCH = 16;
+const RETENTION_CONTINUATION_DELAY_MS = 1_000;
+
+class ConvexError<T extends Record<string, unknown>> extends Error {
+  readonly data: T;
+
+  constructor(data: T) {
+    super(String(data.message ?? JSON.stringify(data)));
+    this.name = "ConvexError";
+    this.data = data;
+    (this as Record<PropertyKey, unknown>)[Symbol.for("ConvexError")] = true;
+  }
+}
+
+function boundaryError(code: string, message: string): never {
+  throw new ConvexError({ code, message });
+}
+
+async function requireOwnerId(ctx: unknown): Promise<Id<"users">> {
+  const raw = await getAuthUserId(ctx as never);
+  const normalized =
+    typeof raw === "string" && raw.includes("|") ? raw.split("|")[0] : raw;
+  if (!normalized) {
+    boundaryError("not_authenticated", "Authentication is required.");
+  }
+  return normalized as Id<"users">;
+}
+
+function asRunEvent(event: Record<string, unknown>): NodeKitRunEvent {
+  return {
+    contractVersion:
+      event.contractVersion as NodeKitRunEvent["contractVersion"],
+    runId: event.runId as string,
+    sequence: event.sequence as number,
+    eventType: event.eventType as NodeKitRunEvent["eventType"],
+    recordedAt: event.recordedAt as number,
+    payload: event.payload as NodeKitSafeEventPayload,
+    previousHash: event.previousHash as string,
+    contentHash: event.contentHash as string,
+  };
+}
+
+async function loadBoundedTraceEvents(
+  ctx: { db: any },
+  traceId: Id<"agentTaskTraces">,
+) {
+  const events = await ctx.db
+    .query("nodeKitRunEvents")
+    .withIndex("by_trace_sequence", (q: any) => q.eq("traceId", traceId))
+    .order("asc")
+    .take(NODEKIT_RUN_MAX_EVENTS + 1);
+  if (events.length > NODEKIT_RUN_MAX_EVENTS) {
+    boundaryError(
+      "event_limit_exceeded",
+      "Run history exceeds the bounded retention contract.",
+    );
+  }
+  return events;
+}
+
+async function markTraceAndSpansError(
+  ctx: { db: any },
+  trace: Record<string, any>,
+  now: number,
+): Promise<boolean> {
+  const spans = await ctx.db
+    .query("agentTaskSpans")
+    .withIndex("by_trace_status", (q: any) =>
+      q.eq("traceId", trace._id).eq("status", "running"),
+    )
+    .order("asc")
+    .take(NODEKIT_RUN_MAX_EVENTS + 1);
+  const hasMoreSpans = spans.length > NODEKIT_RUN_MAX_EVENTS;
+  for (const span of spans.slice(0, NODEKIT_RUN_MAX_EVENTS)) {
+    await ctx.db.patch(span._id, {
+      status: "error",
+      endedAt: now,
+      durationMs: Math.max(0, now - span.startedAt),
+      error: {
+        message: "Stale NodeKit run closed by retention maintenance.",
+        code: "stale_run_timeout",
+      },
+    });
+  }
+  if (hasMoreSpans) return false;
+  await ctx.db.patch(trace._id, {
+    status: "error",
+    endedAt: now,
+    totalDurationMs: Math.max(0, now - trace.startedAt),
+  });
+  return true;
+}
+
+async function closeStaleTrace(
+  ctx: { db: any },
+  trace: Record<string, any>,
+  now: number,
+): Promise<"closed" | "corrupt_purged" | "pending"> {
+  const session = await ctx.db.get(trace.sessionId);
+  const storedEvents = await loadBoundedTraceEvents(ctx, trace._id);
+  const ownershipValid =
+    session &&
+    storedEvents.length > 0 &&
+    storedEvents.every(
+      (event: Record<string, any>) =>
+        event.traceId === trace._id &&
+        event.sessionId === session._id &&
+        event.userId === session.userId &&
+        event.runId === trace.traceId,
+    );
+
+  let prefix:
+    | Awaited<ReturnType<typeof verifyNodeKitRunEventPrefix>>
+    | undefined;
+  if (ownershipValid) {
+    try {
+      prefix = await verifyNodeKitRunEventPrefix(
+        storedEvents.map(asRunEvent),
+        trace.traceId,
+      );
+    } catch (error) {
+      if (!(error instanceof NodeKitRunContractError)) throw error;
+    }
+  }
+
+  if (!prefix || prefix.terminalEventType !== null) {
+    for (const event of storedEvents) {
+      await ctx.db.delete(event._id);
+    }
+    const maintenanceComplete = await markTraceAndSpansError(ctx, trace, now);
+    return maintenanceComplete ? "corrupt_purged" : "pending";
+  }
+
+  let recordedAt = Math.max(
+    now,
+    storedEvents[storedEvents.length - 1].recordedAt,
+  );
+  for (const spanId of prefix.openSpanIds) {
+    const span = await ctx.db.get(spanId as Id<"agentTaskSpans">);
+    const durationMs =
+      span && span.traceId === trace._id && typeof span.startedAt === "number"
+        ? Math.max(0, recordedAt - span.startedAt)
+        : 0;
+    await appendNodeKitRunEvent(ctx as never, {
+      sessionId: session._id,
+      traceId: trace._id,
+      userId: session.userId,
+      runId: trace.traceId,
+      eventType: "span.completed",
+      recordedAt,
+      payload: {
+        spanId,
+        status: "error",
+        durationMs,
+      },
+      allowLegacySkip: false,
+    });
+  }
+  recordedAt = Math.max(recordedAt, now);
+  await appendNodeKitRunEvent(ctx as never, {
+    sessionId: session._id,
+    traceId: trace._id,
+    userId: session.userId,
+    runId: trace.traceId,
+    eventType: "run.failed",
+    recordedAt,
+    payload: {
+      status: "error",
+      totalDurationMs: Math.max(0, recordedAt - trace.startedAt),
+    },
+    allowLegacySkip: false,
+  });
+  const maintenanceComplete = await markTraceAndSpansError(
+    ctx,
+    trace,
+    recordedAt,
+  );
+  return maintenanceComplete ? "closed" : "pending";
+}
+
+/**
+ * Privacy deletion for an owner-scoped terminal run.
+ *
+ * Events are immutable while retained, but they are not immortal. Deleting the
+ * complete chain deliberately makes future export fail as a legacy/expired run.
+ */
+export const deleteOwnedNodeKitRunHistory = mutation({
+  args: {
+    traceId: v.id("agentTaskTraces"),
+  },
+  returns: v.object({
+    deleted: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const ownerId = await requireOwnerId(ctx);
+    const trace = await ctx.db.get(args.traceId);
+    if (!trace) {
+      boundaryError("trace_not_found", "Trace not found or unauthorized.");
+    }
+    const session = await ctx.db.get(trace.sessionId);
+    if (!session || session.userId !== ownerId) {
+      boundaryError("trace_not_found", "Trace not found or unauthorized.");
+    }
+    if (trace.status === "running") {
+      boundaryError(
+        "run_not_terminal",
+        "Running trace history cannot be deleted.",
+      );
+    }
+    const events = await ctx.db
+      .query("nodeKitRunEvents")
+      .withIndex("by_trace_sequence", (q) => q.eq("traceId", args.traceId))
+      .order("asc")
+      .take(NODEKIT_RUN_MAX_EVENTS + 1);
+    if (events.length > NODEKIT_RUN_MAX_EVENTS) {
+      boundaryError(
+        "event_limit_exceeded",
+        "Run history exceeds the bounded deletion contract.",
+      );
+    }
+    for (const event of events) {
+      if (event.userId !== ownerId || event.sessionId !== session._id) {
+        boundaryError(
+          "event_ownership_mismatch",
+          "Stored event ownership does not match the trace.",
+        );
+      }
+    }
+    for (const event of events) {
+      await ctx.db.delete(event._id);
+    }
+    return { deleted: events.length };
+  },
+});
+
+/**
+ * Bounded retention sweep.
+ *
+ * Only terminal events carry expiry timestamps, and terminal-type indexes keep
+ * legacy nonterminal expiry rows from starving eligible runs. Stale running
+ * traces are explicitly failed (including open spans) before their terminal
+ * event starts the retention clock. Corrupt stale chains are removed rather
+ * than being converted into forged complete receipts.
+ */
+export const purgeExpiredNodeKitRunEvents = internalMutation({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    deleted: v.number(),
+    skippedRunning: v.number(),
+    staleScanned: v.number(),
+    staleClosed: v.number(),
+    staleCorruptPurged: v.number(),
+    stalePending: v.number(),
+    continuationScheduled: v.boolean(),
+  }),
+  handler: async (ctx) => {
+    const now = Date.now();
+    const expiredByType = await Promise.all(
+      (["run.completed", "run.failed"] as const).map((eventType) =>
+        ctx.db
+          .query("nodeKitRunEvents")
+          .withIndex("by_type_retention_expiration", (q) =>
+            q.eq("eventType", eventType).lte("retentionExpiresAt", now),
+          )
+          .order("asc")
+          .take(RETENTION_TERMINAL_BATCH),
+      ),
+    );
+    const expired = expiredByType
+      .flat()
+      .sort(
+        (left, right) =>
+          (left.retentionExpiresAt ?? 0) - (right.retentionExpiresAt ?? 0) ||
+          String(left._id).localeCompare(String(right._id)),
+      );
+    let deleted = 0;
+    let skippedRunning = 0;
+    let terminalBacklogRemains = false;
+    const visitedTraces = new Set<string>();
+    for (const candidate of expired) {
+      const traceKey = String(candidate.traceId);
+      if (visitedTraces.has(traceKey)) continue;
+      visitedTraces.add(traceKey);
+      const trace = await ctx.db.get(candidate.traceId);
+      if (trace?.status === "running") {
+        skippedRunning += 1;
+        continue;
+      }
+      const traceEvents = await loadBoundedTraceEvents(ctx, candidate.traceId);
+      const terminal = traceEvents[traceEvents.length - 1];
+      if (
+        !terminal ||
+        (terminal.eventType !== "run.completed" &&
+          terminal.eventType !== "run.failed") ||
+        terminal.retentionExpiresAt === undefined ||
+        terminal.retentionExpiresAt > now
+      ) {
+        continue;
+      }
+      if (deleted + traceEvents.length > RETENTION_DELETE_BUDGET) {
+        terminalBacklogRemains = true;
+        break;
+      }
+      for (const event of traceEvents) {
+        await ctx.db.delete(event._id);
+      }
+      deleted += traceEvents.length;
+    }
+
+    const staleBefore = now - NODEKIT_RUN_RETENTION_MS;
+    const staleTraces = await ctx.db
+      .query("agentTaskTraces")
+      .withIndex("by_status_started", (q) =>
+        q.eq("status", "running").lte("startedAt", staleBefore),
+      )
+      .order("asc")
+      .take(STALE_TRACE_BATCH);
+    let staleClosed = 0;
+    let staleCorruptPurged = 0;
+    let stalePending = 0;
+    for (const trace of staleTraces) {
+      const outcome = await closeStaleTrace(ctx, trace, now);
+      if (outcome === "closed") staleClosed += 1;
+      else if (outcome === "corrupt_purged") staleCorruptPurged += 1;
+      else stalePending += 1;
+    }
+
+    const continuationScheduled =
+      terminalBacklogRemains ||
+      (deleted > 0 &&
+        expiredByType.some(
+          (events) => events.length === RETENTION_TERMINAL_BATCH,
+        )) ||
+      (staleClosed + staleCorruptPurged > 0 &&
+        staleTraces.length === STALE_TRACE_BATCH) ||
+      stalePending > 0;
+    if (continuationScheduled) {
+      await ctx.scheduler.runAfter(
+        RETENTION_CONTINUATION_DELAY_MS,
+        (internal as any).domains.operations.taskManager.nodeKitRunRetention
+          .purgeExpiredNodeKitRunEvents,
+        {},
+      );
+    }
+    return {
+      scanned: expired.length,
+      deleted,
+      skippedRunning,
+      staleScanned: staleTraces.length,
+      staleClosed,
+      staleCorruptPurged,
+      stalePending,
+      continuationScheduled,
+    };
+  },
+});

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -12931,6 +12931,7 @@ export default defineSchema({
     metadata: v.optional(v.any()),
   })
     .index("by_session", ["sessionId", "startedAt"])
+    .index("by_status_started", ["status", "startedAt"])
     .index("by_trace_id", ["traceId"]),
 
   agentTaskSpans: defineTable({
@@ -12968,7 +12969,49 @@ export default defineSchema({
     ),
   })
     .index("by_trace", ["traceId", "seq"])
+    .index("by_trace_status", ["traceId", "status", "seq"])
     .index("by_parent", ["parentSpanId", "seq"]),
+
+  /**
+   * Canonical NodeKit run-event chain.
+   *
+   * Rows are immutable while retained: this repository exposes no patch path.
+   * Owner-scoped deletion and bounded expiry are implemented only by
+   * nodeKitRunRetention.ts. Each event commits to the preceding event hash,
+   * giving an owner-scoped export a deterministic chain and tamper check
+   * without reconstructing decisions or evidence from mutable trace metadata.
+   */
+  nodeKitRunEvents: defineTable({
+    sessionId: v.id("agentTaskSessions"),
+    traceId: v.id("agentTaskTraces"),
+    userId: v.id("users"),
+    contractVersion: v.literal("nodekit.run-event/v1"),
+    runId: v.string(),
+    sequence: v.number(),
+    eventType: v.union(
+      v.literal("run.started"),
+      v.literal("span.started"),
+      v.literal("span.completed"),
+      v.literal("step.recorded"),
+      v.literal("decision.recorded"),
+      v.literal("verification.recorded"),
+      v.literal("evidence.attached"),
+      v.literal("approval.requested"),
+      v.literal("run.completed"),
+      v.literal("run.failed"),
+    ),
+    recordedAt: v.number(),
+    payload: v.any(),
+    previousHash: v.string(),
+    contentHash: v.string(),
+    retentionExpiresAt: v.optional(v.number()),
+  })
+    .index("by_trace_sequence", ["traceId", "sequence"])
+    .index("by_owner_run_sequence", ["userId", "runId", "sequence"])
+    .index("by_type_retention_expiration", [
+      "eventType",
+      "retentionExpiresAt",
+    ]),
 
   /* ================================================================== */
   /* DATA COMPLETENESS & OBSERVABILITY - P0/P1 TABLES                   */

--- a/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
+++ b/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
@@ -1,0 +1,363 @@
+# NodeKit ActiveGraph offline canary
+
+- **Status:** Experimental, offline, fail-closed, and non-authoritative
+- **Decision date:** 2026-07-28
+- **Implementation:** [`evals/activegraph/`](../../evals/activegraph/) and
+  [`scripts/nodekit/runActiveGraphCanary.mjs`](../../scripts/nodekit/runActiveGraphCanary.mjs)
+- **Upstream:** [yoheinakajima/activegraph](https://github.com/yoheinakajima/activegraph)
+
+## Decision
+
+NodeBench now has the smallest safe ActiveGraph integration slice discussed in
+the July 25–28 NodeKit thread:
+
+1. new owner-scoped execution traces append one immutable-while-retained,
+   ordered, content-hashed `nodekit.run-event/v1` chain containing only bounded
+   sensitivity-redacted projections;
+2. an owner-scoped query exports a terminal chain as
+   `nodekit.run-export/v1`;
+3. a Node wrapper validates the source export before any canary write, stages a
+   disposable copy, strips production credentials, and launches a digest-pinned
+   Docker image with networking disabled, a read-only root, dropped
+   capabilities, resource bounds, and one writable evidence mount;
+4. the Python adapter validates the copy independently, writes an isolated
+   SQLite event log, reloads it, and requires exact event-payload parity; and
+5. the report is evidence only. It cannot answer, approve, mutate, or replace
+   NodeBench state.
+
+This is not a decision to adopt ActiveGraph as NodeBench's runtime, event store,
+graph store, scheduler, or orchestration layer. Convex and the existing
+NodeBench harness remain authoritative.
+
+## What changed from the reconnaissance canary
+
+The original lane characterized ActiveGraph with one synthetic graph-hop fork:
+semantic-heavy and graph-heavy policies had to produce a deterministic winner
+flip, inspectable traversal, diff, and persistence/reload parity.
+
+That synthetic golden remains useful and unchanged in authority. A second lane
+now consumes a real canonical NodeKit export contract. It deliberately does not
+interpret or rewrite events into invented ActiveGraph domain objects. Each
+verified NodeKit event is stored as the exact `nodekit_event` payload of an
+ActiveGraph `nodekit.event`, then compared byte-for-data after a fresh reload.
+
+This proves storage and replay parity for the exported sequence. It does not
+prove that ActiveGraph should execute NodeBench decisions.
+
+## Canonical export contract
+
+### Immutable, bounded source
+
+`backend/convex/schema.ts` defines `nodeKitRunEvents`. The repository exposes no
+patch function for that table. Newly created owner-scoped execution traces
+append:
+
+- `run.started`;
+- `span.started` and `span.completed`;
+- `step.recorded`;
+- `decision.recorded`;
+- `verification.recorded`;
+- `evidence.attached`;
+- trace-bound `approval.requested`; and
+- exactly one `run.completed` or `run.failed`.
+
+Each event commits to:
+
+- its run ID and contiguous sequence number;
+- its type, nondecreasing timestamp, and
+  `nodekit.safe-event-payload/v1` projection;
+- the previous event's SHA-256 hash; and
+- its own SHA-256 content hash over RFC 8785-compatible canonical JSON.
+
+The append happens in the same Convex transaction as the owning mutation. A
+failed append fails that mutation rather than silently producing incomplete
+history.
+
+The source payload is sensitivity-redacted before hashing and is never stored.
+The stored projection contains only an event-specific allowlist of bounded
+structural scalars plus the redacted source digest and byte count. Raw
+`toolArgs`, span data, evidence and decision text, errors, and arbitrary
+metadata are excluded. A redacted source is capped at 32 KiB, a stored
+projection at 2 KiB, and a run at 256 events.
+
+Explicit `span.started` and `span.completed` events form a checked lifecycle:
+duplicate starts, completion without a start, and terminal runs with open spans
+fail the owning transaction. Every nonterminal append must leave enough bounded
+slots for all currently open span completions plus one terminal event.
+`run.completed` requires payload status `completed`; `run.failed` requires
+payload status `error`. `step.recorded` remains a self-contained completed step
+and is not misrepresented as an open explicit span.
+
+Only terminal events carry the 30-day expiry timestamp. The daily
+`nodekit run-event retention` sweep queries terminal-type expiry indexes,
+deletes only whole expired terminal histories within a 1,024-row mutation
+budget, and schedules one bounded continuation while a backlog remains. A
+running trace older than the same threshold is explicitly failed: open spans
+receive error completions, the chain receives `run.failed`, and only then does
+its retention clock begin. A corrupt stale chain is boundedly removed instead
+of being converted into a forged complete receipt. An authenticated owner can
+also call
+`domains/operations/taskManager/nodeKitRunRetention:deleteOwnedNodeKitRunHistory`
+for a terminal run. Deletion deliberately makes future export unavailable; it
+never rewrites a retained chain.
+
+### Owner-scoped terminal export
+
+`domains/operations/taskManager/nodeKitRunExport:exportNodeKitRun` requires an
+authenticated owner, a terminal trace, an exact owner/session/run match, a
+contiguous valid chain of at most 256 events, balanced explicit spans, one final
+terminal event, and a matching trace status.
+It returns:
+
+- session and trace metadata derived only from `run.started`, the terminal
+  event, and immutable Convex IDs;
+- the ordered event array;
+- an explicit event-chain and span-lifecycle receipt;
+- the event-chain head; and
+- a SHA-256 hash over the complete export.
+
+The same retained event chain therefore always produces the same export hash,
+even if mutable session status, title, or completion fields later change.
+Traces created before this contract, ownerless QA traces, expired histories,
+and owner-deleted histories have no available canonical chain. They return the
+truthful client-visible error code `run_history_unavailable`; the exporter does
+not guess whether absence means legacy, expiry, or deletion and never
+reconstructs events from mutable trace metadata. Boundary errors use Convex's
+structured error protocol, while not-found and unauthorized traces remain
+deliberately indistinguishable.
+
+## Offline process boundary
+
+The supported evaluator entrypoint is:
+
+```powershell
+$BuildMetadata = node scripts/nodekit/runActiveGraphCanary.mjs `
+  --print-build-metadata | ConvertFrom-Json
+
+docker build `
+  --file evals/activegraph/Dockerfile `
+  --tag nodebench-activegraph-canary:local `
+  --build-arg "NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256=$($BuildMetadata.buildInputsHash)" `
+  --build-arg "NODEBENCH_CANDIDATE_COMMIT=$($BuildMetadata.nodebenchCandidateCommit)" `
+  --build-arg "NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256=$($BuildMetadata.upstreamHash)" `
+  evals/activegraph
+
+$SandboxImage = docker image inspect `
+  --format "{{.Id}}" `
+  nodebench-activegraph-canary:local
+$ImageAttestation = ".tmp\activegraph-canary\image-attestation.json"
+node scripts/nodekit/runActiveGraphCanary.mjs `
+  --attestation-output $ImageAttestation `
+  --sandbox-image $SandboxImage
+node scripts/nodekit/runActiveGraphCanary.mjs `
+  --input .tmp\nodekit-export.json `
+  --evidence-root .tmp\activegraph-canary\nodekit `
+  --sandbox-image $SandboxImage `
+  --image-attestation $ImageAttestation
+```
+
+The wrapper:
+
+1. reads and verifies the source export before creating an evidence directory;
+2. requires an immutable Docker image ID or repository digest plus a canonical
+   image attestation binding the exact Dockerfile, dependency pins, source
+   tree, `UPSTREAM.json`, and NodeBench candidate commit;
+3. creates a new, exclusive run directory and canonical disposable copy;
+4. starts Docker with `--network none`, `--read-only`, `--cap-drop ALL`,
+   `no-new-privileges`, PID/CPU/memory limits, and only the run directory
+   mounted at `/evidence`;
+5. does not mount the source export or repository and passes no Convex, MCP,
+   model, cloud, or application credentials;
+6. recomputes the canonical build-input hash, verifies the candidate commit and
+   audited upstream record, and inspects exact labels on the selected image;
+7. requires the child to detect Docker, pinned ActiveGraph 1.10.0,
+   `NODEBENCH_ACTIVEGRAPH_MODE=offline-observer`, and the full image-attestation
+   environment;
+8. accepts only a passing report bound to that image, attestation, run ID,
+   export hash, event count, chain head, and canonical replayed-event digest;
+9. bounds input, report, SQLite, child output, and child runtime; requires
+   exactly three non-empty regular files; and reads only the SQLite header; and
+10. rechecks both the source and disposable export bytes after execution.
+
+The only allowed outputs are inside the selected evidence run directory:
+
+```text
+nodekit-run-export.json
+activegraph.sqlite3
+report.json
+```
+
+Existing run directories are never reused. Invalid or tampered exports fail
+before Docker is spawned. Missing Docker, a mutable image reference, nonzero
+child result, host-only Python invocation, extra artifact, symlink, empty file,
+mutated export, or non-SQLite database fails closed and cannot become a pass.
+The local attestation prevents accidental or arbitrary digest substitution; it
+is not signed supply-chain provenance. An actor who controls both the Docker
+daemon and the attestation file can forge matching labels, so any production
+bridge would still require a trusted builder/signature policy.
+
+## Authority boundary
+
+| Surface                                 | Authority                                                 | Rule                                          |
+| --------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| NodeBench application and durable state | Owner-scoped Convex functions and tables                  | Canonical; no ActiveGraph dual-write          |
+| `nodeKitRunEvents`                      | Bounded, redacted, immutable-while-retained owner history | Source of the exported facts                  |
+| `nodekit.run-export/v1`                 | Immutable terminal-run transfer document                  | Read-only input to evaluators                 |
+| ActiveGraph SQLite event log            | One disposable offline run                                | Local evaluator truth only                    |
+| ActiveGraph graph projection            | Derived from that disposable log                          | Rebuildable and non-authoritative             |
+| Replay report                           | Evaluation evidence                                       | Cannot drive answers, approvals, or mutations |
+| Synthetic graph-hop report              | Library-characterization evidence                         | Separate from canonical run replay            |
+
+“Event log is the source of truth” remains scoped to ActiveGraph's internal
+replay model. It does not transfer authority away from NodeBench or Convex.
+
+## Canary flow
+
+```mermaid
+flowchart LR
+    A["Owner's terminal NodeKit trace"] --> B["Bounded redacted hash chain"]
+    B --> C["Owner-scoped canonical export"]
+    C --> D{"JS validation"}
+    D -->|"fail"| X["Stop before write/spawn"]
+    D -->|"pass"| E["Disposable canonical copy"]
+    E --> F["Locked digest-pinned Docker sandbox"]
+    F --> G{"Python validation"}
+    G -->|"fail"| Y["Fail; no SQLite history"]
+    G -->|"pass"| H["ActiveGraph 1.10.0 persist + reload"]
+    H --> I{"Exact payload parity"}
+    I -->|"fail"| Z["Fail report / no promotion"]
+    I -->|"pass"| J["Offline evidence receipt"]
+    J --> K["Separate corpus + adoption decision"]
+```
+
+## Upstream pin and current discussion
+
+The canary installs exact direct pins:
+
+- `activegraph==1.10.0`
+- `jsonschema==4.26.0`
+- `pytest==9.1.1`
+- `rfc8785==0.1.4`
+
+| Reference                     | Revision                                   | Use                                      |
+| ----------------------------- | ------------------------------------------ | ---------------------------------------- |
+| `v1.10.0` annotated tag object | `3fbcd8fc56a45ae68622d4e2b18a6d5844180527` | Release-tag provenance                   |
+| `v1.10.0` release commit      | `148e12c2969f18fa12a1a3c2e75f3affd9aa0616` | Executable dependency contract           |
+| Audited upstream `main`       | `8aedb1866cf5dce056af97529152ffd6f468a1ed` | Repository and issue inspection boundary |
+
+The audited `main` revision and any features discussed upstream are provenance
+and research data only; they confer no NodeBench authority. The evaluator does
+not install a floating Git revision. `evals/activegraph/UPSTREAM.json` records
+the release commit, annotated tag object, and inspected main revision
+machine-readably.
+
+At the pinned release, the upstream
+[`CHANGELOG.md`](https://github.com/yoheinakajima/activegraph/blob/148e12c2969f18fa12a1a3c2e75f3affd9aa0616/CHANGELOG.md#1100--2026-07-12)
+describes three v1.10 additions/changes: cooperative bounded drains through
+`Runtime.run_quantum`, opt-in bounded `context.read` tracing, and loud rejection
+of reserved top-level field collisions. This canary enables context-read
+tracing only inside its disposable observer runtime. It does not adopt
+`run_quantum`, ActiveGraph authority, or upstream reserved-field semantics for
+NodeBench; those release notes are upstream data, while local tests and replay
+receipts are the only evidence claimed here.
+
+### Issue #67: mutable accepted payload
+
+[ActiveGraph issue #67](https://github.com/yoheinakajima/activegraph/issues/67)
+remains a production blocker. `Graph.emit()` can retain a caller-owned nested
+payload in memory while SQLite stores its serialized value. The adapters
+therefore deep-copy every accepted payload and test live/persisted/reloaded
+parity.
+
+That containment proves this evaluator boundary, not an upstream fix.
+ActiveGraph cannot become production authority until either upstream provides
+an immutable snapshot boundary or NodeBench separately reviews and proves a
+complete immutability adapter.
+
+### Issue #70: Temporal proposal
+
+[ActiveGraph issue #70](https://github.com/yoheinakajima/activegraph/issues/70)
+is research input, not an architecture decision. Its maintainer acceptance,
+async ordering, deterministic replay, truncation, and fork semantics remain
+unresolved. NodeBench's existing Temporal stack does not answer those upstream
+questions. This slice adds no Temporal dependency.
+
+## Acceptance gates
+
+### Gate 1 — synthetic mechanics: implemented
+
+The existing golden must keep proving deterministic fork/diff behavior,
+explicit topology traversal, winner-flip explanation, persistence/reload
+parity, canonical report bytes, and issue #67 containment.
+
+### Gate 2 — canonical export: implemented for new owner-scoped traces
+
+The TypeScript contract tests must prove ordering, per-event hashes,
+whole-export stability, redacted/bounded payloads, lifecycle completeness,
+retention boundaries, and fail-closed tamper behavior. The wrapper tests must
+prove disposable-copy staging, credential stripping, immutable-image
+enforcement, locked Docker arguments, source immutability, exact artifact sets,
+exclusive evidence directories, and failure propagation. The Python tests must
+prove independent validation, host-execution refusal, and real ActiveGraph
+persistence/reload parity through the explicit unit-test seam.
+
+The Docker Desktop daemon was unavailable in the implementation checkout, so a
+real container launch was not fabricated as proof. Runtime invocation remains
+fail-closed until Docker is running and the locked image has been built; the
+exact build/replay commands are in `evals/activegraph/README.md`.
+
+This gate does not backfill legacy traces and does not authorize production
+adoption.
+
+### Gate 3 — representative corpus: deferred
+
+Replay roughly 20 representative owner-authorized exports. Stop if:
+
+- any export is incomplete or cannot be represented without reconstruction;
+- persistence/reload parity differs;
+- median end-to-end latency exceeds 2× the equivalent existing harness; or
+- the resulting graph/diff evidence adds no material explanatory value.
+
+Passing Gate 3 authorizes only a separate adoption-or-rejection ADR.
+
+### Gate 4 — production bridge: not authorized
+
+A production bridge would still require a threat model, owner and tenant
+isolation proof, issue #67 disposition, migration and rollback plans, and
+explicit approval. No result from this canary may automatically promote that
+path.
+
+## NodeKit alignment
+
+The evaluator is declared as `nodebench-activegraph-canary` in the flat v1
+`nodeagent.yaml` evaluation plan. The still-valid manifest, policy-path, pack,
+evaluation-binding, and configured-Convex-path changes from draft PR #592 were
+reapplied selectively to current `main`.
+
+The conflicted PR branch and its generated `.nodeagent/**` snapshot were not
+merged. Compiler output must be regenerated from the current tree when needed.
+
+## Explicit non-goals
+
+This slice does not add:
+
+- a live ActiveGraph `EventSink`;
+- a TypeScript ActiveGraph runtime;
+- an MCP ingestion path;
+- a Temporal backend;
+- a production worker or dual-write;
+- a corpus-based adoption decision; or
+- any ActiveGraph role in user-visible answers or approval decisions.
+
+## Reproduction
+
+Use the pinned virtual-environment setup and exact test commands in
+[`evals/activegraph/README.md`](../../evals/activegraph/README.md).
+
+## Related
+
+- [ActiveGraph v1.10.0 release](https://github.com/yoheinakajima/activegraph/releases/tag/v1.10.0)
+- [ActiveGraph issue #67](https://github.com/yoheinakajima/activegraph/issues/67)
+- [ActiveGraph issue #70](https://github.com/yoheinakajima/activegraph/issues/70)
+- [NodeBench × NodeKit standard repository tree](./STANDARD_REPO_TREE.md)
+- [Draft NodeBench PR #592](https://github.com/HomenShum/NodeBenchAI/pull/592)

--- a/docs/architecture/STANDARD_REPO_TREE.md
+++ b/docs/architecture/STANDARD_REPO_TREE.md
@@ -1,75 +1,142 @@
-# NodeBench × NodeKit Standard Repo Tree
+# NodeBench × NodeKit standard repository tree
 
-Status: **Phase 0 adopted** (declarative — manifests + authored surface, zero
-file moves). This doc is the mapping between the NodeKit Agent Application
-Standard tree and where each concern lives in this repo, plus the staged plan
-for physical conformance.
+Status: **Phase 2 physically migrated; flat v1 contracts aligned.**
 
-Prior art: NodeKit Agent Application Standard (node-platform); Eve
-filesystem-first authoring (`apps/eve-agent/agent/`); 2026-07-19 harness audit
-of eve / NodeAgent / NodeRoom.
+PRs #589 and #590 established the authored surface and moved the application
+into the standard physical tree. The July 28 alignment selectively carries
+forward the still-valid contract changes from draft PR #592 without merging its
+stale generated `.nodeagent/` snapshot or its conflicting branch wholesale.
 
-## Phase 0 (this PR) — declarative adoption
+The alignment does not replace the production runtime. NodeBench remains a
+brownfield application whose live execution engine is
+`repo-local-nodebench`.
 
-Added, all additive and runtime-inert:
+## Current standard surface
 
+```text
+nodekit.yaml                         repository contract (`nodekit.repo/v1`)
+nodeagent.yaml                       application contract (`nodeagent.application/v1`)
+agent/                               filesystem-authored brownfield projection
+packs/entity-intelligence/
+├── pack.yaml                        logical capability ownership
+└── SKILL.md                         usage contract and live-source map
+apps/web/                            Vite application
+backend/convex/                      Convex functions and durable state
+workers/node/                        Node workers, routes, and pipeline
+evals/                               tests and NodeAgent evaluation bindings
+proof/ui-contract/                   UI contracts and captured evidence
+adw/                                 improvement workflows and goal governance
 ```
-nodekit.yaml                      repo identity, ownership, lifecycle, layout map, honest conformance flags
-nodeagent.yaml                    app composition: authoring dir, runtime, backend, pack, required evals
-agent/                            authored surface (md/yaml only; code stays source of truth)
-├── README.md                     phase-0 rules — no fake compiled output, Source: pointers mandatory
-├── instructions.md               orchestrator instructions (mirrors chatRuns.ts)
-├── policies/{approvals,egress,budgets}.yaml
-├── subagents/README.md           index → convex/domains/agents orchestrator-workers
-└── tools/README.md               index → packages/mcp-local (304 tools) + verb-taxonomy map
-packs/entity-intelligence/pack.yaml   capability declared at current locations
-```
 
-Explicit non-goals of phase 0: no `.nodeagent/` (no compiler exists — we do not
-fake generated output), no `.ts` under `agent/` (tsconfig excludes it; nothing
-may import it), no file moves.
+The root `public/`, `api/`, environment files, and build output intentionally
+remain at repository root. NodeBench-specific packages such as
+`packages/mcp-local` remain first-class distribution artifacts.
 
-## Full mapping (standard slot → today)
+`.nodeagent/` is compiler-owned output. This alignment deliberately does not
+copy the generated snapshot from PR #592 because its discovery graph was based
+on an older branch and conflicts with current `main`. Generate it from the
+current authored tree when a workflow explicitly requires it; never hand-edit
+or use a stale snapshot as runtime authority.
 
-Legend: `✓` conformant · `◐` exists at non-standard location · `✗` missing
+## Mapping and authority
 
-| Standard | State | Today |
-|---|---|---|
-| `nodekit.yaml` / `nodeagent.yaml` | ✓ (phase 0) | repo root |
-| `AGENTS.md`, `README.md`, `components.json` | ✓ | repo root |
-| `.claude/` agents·skills·rules | ✓ | richest in the family |
-| `agent/` authored surface | ◐ | phase-0 mirror; truth in `convex/domains/redesign/chatRuns.ts`, `convex/domains/agents/**`, `server/pipeline/**` |
-| `packs/` | ◐ | `packs/entity-intelligence/pack.yaml` declares content spread across convex/, packages/, server/ |
-| `integrations/pi-ai` | ✗ | provider seam = `shared/llm/modelCatalog.ts` direct |
-| `apps/web/src` | ◐ | `src/` at root (Vite root) |
-| `backend/convex` | ◐ | `convex/` at root (Convex CLI default) |
-| `evals/{benchmark,conformance,production,smoke}` | ◐ | `packages/mcp-local/src/benchmarks`, `tests/e2e`, `scripts/verify-live.ts`, dogfood scripts |
-| `proof/` | ◐ | `docs/design/ui-contract/` (evidence folders + `manifest.schema.json`) |
-| `adw/` | ◐ | `scripts/improvement-loop/` + `goals/` (+ `HARD_GATES.md`) |
-| `fixtures/` | ◐ | spread through test dirs; deterministic fixtures exist |
-| `workers/` | ◐ | `server/` (voice, gateway) |
-| `.nodeagent/` generated | ✗ | blocked on the manifest compiler (deliberate) |
-| `packages/mcp-local` etc. | ★ keep | NodeBench-specific distribution artifact; standard-compatible |
+Legend: `✓` standard location, `◐` mapped but not runtime-authoritative,
+`✗` missing.
 
-## Known conformance violations (declared, not hidden)
+| Standard concern                        | State | Current authority                                                                     |
+| --------------------------------------- | ----: | ------------------------------------------------------------------------------------- |
+| Repository and application manifests    |     ✓ | flat `nodekit.repo/v1` and `nodeagent.application/v1` files at root                   |
+| Web application                         |     ✓ | `apps/web/`                                                                           |
+| Production backend                      |     ✓ | `backend/convex/`; `convex.json` points to it                                         |
+| Node workers                            |     ✓ | `workers/node/`                                                                       |
+| Evaluation tree                         |     ✓ | `evals/`, including five top-level NodeAgent bindings                                 |
+| Proof tree                              |     ✓ | `proof/ui-contract/` plus other proof artifacts                                       |
+| ADW tree                                |     ✓ | `adw/improvement-loop/` and `adw/goals/`                                              |
+| Authored agent surface                  |     ◐ | `agent/` mirrors runtime truth in backend and worker code                             |
+| Entity-intelligence pack                |     ◐ | logical pack at `packs/entity-intelligence/`; implementations remain distributed      |
+| Canonical NodeKit run export            |     ◐ | append-only owner-scoped chain in `backend/convex/domains/operations/taskManager/`    |
+| ActiveGraph replay                      |     ◐ | isolated evaluator under `evals/activegraph/`; never application authority            |
+| Compiled application definition         |     ◐ | generated on demand from current source; no stale snapshot is committed by this slice |
+| Pi AI provider adapter                  |     ✗ | live product path uses direct Gemini REST                                             |
+| Canonical NodeAgent runtime consumption |     ✗ | production still runs `repo-local-nodebench`                                          |
 
-1. **Repo-local runtime** — this repo's harness predates NodeAgent and is a
-   *migration source*, not a vendored copy (`forbidVendoredRuntime: false`).
-   Flips after the ecosystem phase-2 extraction (NodeRoom runtime → NodeAgent)
-   and this repo consumes `@nodeagent/runtime`.
-2. **Hand-maintained global tool registry** (`toolRegistry.ts`) — standard
-   rule 4; resolved by the generated-registry compiler, not by hand.
-3. **modelCatalog duplication** — copies exist in NodeRoom and NodeAgent;
-   resolved by `@nodeagent/providers` extraction.
+## Brownfield conformance level
 
-## Physical phases (each gated, none started)
+Current level: **L2 — physically mapped with flat v1 authored contracts.**
 
-| Phase | Move | Constraint to respect |
-|---|---|---|
-| 1 | `evals/`, `proof/`, `fixtures/`, `adw/` consolidation | script/CI path updates only — low risk, do first |
-| 2 | `src/` → `apps/web/src`; `convex/` → `backend/convex` | Vite root + Vercel config + tsconfig paths + `convex.json` functions path; import churn across hundreds of files; MUST follow expand-contract discipline and land between deploys |
-| 3 | `agent/` becomes compiled truth; `.nodeagent/` generated | blocked on `@nodeagent` manifest compiler |
-| 4 | pack extraction (`packs/entity-intelligence` gains real content) | mirrors NodeSlide layering: core/pack/adapter/react split |
+- **L1 registered:** the repository contract uses the platform's canonical flat
+  schema dialect.
+- **L2 mapped:** application, provider, backend, pack, policies, and existing
+  evaluation commands resolve through current standard-tree paths.
+- **L3 wrapped is partial:** new execution traces emit a canonical,
+  append-only `nodekit.run-event/v1` chain and expose
+  `nodekit.run-export/v1`, but the production runtime is not otherwise replaced.
+- **L4 shadowing starts offline only:** ActiveGraph may read a validated,
+  disposable export copy. It cannot write NodeBench state, answer for
+  production, or approve an action.
+- **L5 hybrid through L7 enforced remain:** promote no runtime path without a
+  separate corpus, security, migration, and rollback decision.
 
-Rule for all phases: **build every new capability against the standard
-locations from now on**; never move files and change behavior in the same PR.
+The immutable export advances a proof boundary; it is not a claim that
+ActiveGraph or the canonical NodeAgent runtime now executes production work.
+
+## NodeKit run-export boundary
+
+For newly created execution traces, every meaningful step, decision,
+verification, evidence attachment, approval request, span lifecycle event, and
+terminal outcome is appended to `nodeKitRunEvents` in the same Convex
+transaction as the owning mutation. Events have:
+
+- a contiguous sequence;
+- a previous-event hash;
+- a canonical SHA-256 content hash;
+- a required `run.started` event; and
+- exactly one terminal `run.completed` or `run.failed` event.
+
+The owner-scoped query
+`domains/operations/taskManager/nodeKitRunExport:exportNodeKitRun` exports only
+terminal runs and verifies order, chain integrity, ownership, completeness, and
+the whole-export hash. Legacy traces without the append-only chain fail closed;
+the exporter never synthesizes missing history from mutable metadata.
+
+## NodeAgent evaluation bindings
+
+The manifest requires these repository-local bindings:
+
+| ID                              | Role                                                                |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `nodebench-conformance`         | UI contract conformance                                             |
+| `nodebench-smoke`               | local dogfood smoke verification                                    |
+| `nodebench-entity-intelligence` | search-quality benchmark                                            |
+| `nodebench-production`          | live production verification                                        |
+| `nodebench-activegraph-canary`  | offline export validation and ActiveGraph persistence/reload parity |
+
+The ActiveGraph binding is an evaluator, not a runtime selection.
+
+## Known gaps, declared rather than hidden
+
+1. **Repo-local runtime:** the mature NodeBench harness remains the migration
+   source. `nodeagent-native` is the target, not a current fact.
+2. **Manual tool registry:** `packages/mcp-local/src/toolRegistry.ts` remains
+   hand-maintained; generated registry authority is future work.
+3. **Compiled/runtime split:** a compiler projection proves authored
+   consistency, not that production consumes the same path.
+4. **Provider portability:** the current product path uses direct Gemini REST;
+   provider adapters need an independent runtime migration.
+5. **ProofLoop receipt:** `nodekit.run-export/v1` is a NodeBench execution
+   export, not a claim to implement `proofloop.receipt/v1`.
+6. **Existing traces:** traces created before the append-only chain are not
+   backfilled. They intentionally return a typed `legacy_trace` export error.
+
+## Next migration gates
+
+| Gate                          | Change                                                                                | Proof required                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 3 — complete wrapper coverage | Prove every production execution entrypoint starts and terminates the canonical chain | mutation/source audit plus end-to-end owner tests                     |
+| 4 — shadow corpus             | Replay about 20 representative immutable exports with all writes prohibited           | output, evidence, mutation, cost, and latency receipts                |
+| 5 — decide                    | Write a separate adoption or rejection ADR                                            | corpus result, issue #67 disposition, threat model, rollback          |
+| 6 — extract                   | Move stable pack implementations only when a second consumer needs them               | pack conformance in two hosts                                         |
+| 7 — enforce                   | Retire legacy paths and reject new forks in CI                                        | same current compiled definition in local, eval, and production paths |
+
+Rule for later work: preserve the physical tree, build through declared
+boundaries, and do not combine broad path moves with behavioral changes.

--- a/evals/activegraph/.dockerignore
+++ b/evals/activegraph/.dockerignore
@@ -1,0 +1,8 @@
+*
+!requirements.in
+!UPSTREAM.json
+!src/
+!src/nodebench_activegraph_canary/
+!src/nodebench_activegraph_canary/**
+**/__pycache__/
+**/*.pyc

--- a/evals/activegraph/Dockerfile
+++ b/evals/activegraph/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12.11-slim
+
+ARG NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256
+ARG NODEBENCH_CANDIDATE_COMMIT
+ARG NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256
+
+RUN printf '%s\n' "${NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256}" \
+      | grep -Eq '^sha256:[0-9a-f]{64}$' \
+    && printf '%s\n' "${NODEBENCH_CANDIDATE_COMMIT}" \
+      | grep -Eq '^[0-9a-f]{40}$' \
+    && printf '%s\n' "${NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256}" \
+      | grep -Eq '^sha256:[0-9a-f]{64}$'
+
+LABEL ai.nodebench.activegraph.build-inputs-sha256="${NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256}" \
+      ai.nodebench.candidate-commit="${NODEBENCH_CANDIDATE_COMMIT}" \
+      ai.nodebench.activegraph.upstream-sha256="${NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256}"
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.in /tmp/nodebench-activegraph-requirements.txt
+RUN python -m pip install --requirement /tmp/nodebench-activegraph-requirements.txt
+
+COPY UPSTREAM.json /usr/local/share/nodebench-activegraph/UPSTREAM.json
+COPY src/nodebench_activegraph_canary \
+  /usr/local/lib/python3.12/site-packages/nodebench_activegraph_canary
+
+WORKDIR /work

--- a/evals/activegraph/README.md
+++ b/evals/activegraph/README.md
@@ -1,0 +1,296 @@
+# ActiveGraph offline canaries
+
+Status: **evaluation only; never a production runtime or source of truth**
+
+This directory contains two pinned ActiveGraph 1.10.0 lanes:
+
+1. **Synthetic graph-hop golden.** Characterizes deterministic fork, traversal,
+   diff, persistence, reload, and issue #67 payload containment.
+2. **Canonical NodeKit replay.** Accepts only a complete
+   `nodekit.run-export/v1` document, persists the exact ordered event payloads
+   into disposable SQLite, reloads them, and requires exact parity.
+
+Neither lane calls an LLM, MCP tool, Convex function, or network service during
+execution. NodeBench's owner-scoped Convex runtime remains authoritative.
+
+See
+[`NODEKIT_ACTIVEGRAPH_CANARY.md`](../../docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md)
+for the authority boundary and adoption gates.
+
+## Safety boundary
+
+The supported real-export entrypoint is the Node wrapper:
+
+[`scripts/nodekit/runActiveGraphCanary.mjs`](../../scripts/nodekit/runActiveGraphCanary.mjs)
+
+It validates the original export before creating canary output, writes a
+canonical disposable copy into a new exclusive evidence directory, and invokes
+an immutable Docker image with no network, a read-only root filesystem, all
+Linux capabilities dropped, resource limits, and only that evidence directory
+mounted writable. The source export and repository are not mounted. The source
+export is never modified. ActiveGraph outputs cannot feed an answer, approval,
+or NodeBench mutation.
+
+The Python adapter independently verifies:
+
+- exact contract shape;
+- contiguous order beginning with `run.started`;
+- exactly one terminal event in the final position;
+- balanced explicit span lifecycles;
+- every previous-event and content hash;
+- the event-chain and span-lifecycle receipt;
+- the chain head; and
+- the whole-export hash.
+
+Validation finishes before the SQLite path is created. A malformed, incomplete,
+oversized, or tampered export fails closed. The CLI also refuses to execute
+outside Docker; the host-only path exists solely as a private unit-test seam.
+
+Every stored event contains only `nodekit.safe-event-payload/v1`: a bounded
+allowlist of structural scalar fields plus the digest and byte count of a
+sensitivity-redacted source payload. Raw `toolArgs`, span data, evidence text,
+decision text, and arbitrary metadata are never copied into the
+immutable-while-retained event table or the ActiveGraph database.
+
+The contract caps each redacted source at 32 KiB, each stored projection at
+2 KiB, and each run at 256 events. Every append reserves enough capacity to
+close all open spans plus write a terminal event. Only that terminal event gets
+an expiry timestamp. The bounded sweep follows terminal-only indexes, drains up
+to 1,024 event rows per mutation, schedules one continuation while a backlog
+remains, and fails stale running traces before starting their 30-day retention
+clock. Owners also have an explicit terminal-history deletion mutation.
+
+## Upstream pin
+
+`requirements.in` pins the direct dependencies exactly:
+
+- `activegraph==1.10.0`
+- `jsonschema==4.26.0`
+- `pytest==9.1.1`
+- `rfc8785==0.1.4`
+
+ActiveGraph requires Python 3.11 or newer.
+The RFC 8785 pin makes Python reproduce ECMAScript number serialization and
+UTF-16 property ordering used by the TypeScript exporter.
+
+| Reference                                  | Immutable revision                         |
+| ------------------------------------------ | ------------------------------------------ |
+| Annotated tag object `v1.10.0`             | `3fbcd8fc56a45ae68622d4e2b18a6d5844180527` |
+| Released tag `v1.10.0` commit              | `148e12c2969f18fa12a1a3c2e75f3affd9aa0616` |
+| Upstream `main` inspected during the audit | `8aedb1866cf5dce056af97529152ffd6f468a1ed` |
+
+`UPSTREAM.json` records the provenance. The executable dependency is the
+released package, never a floating Git revision. Upstream features and claims
+are audit data only; they do not grant ActiveGraph authority over NodeBench.
+
+## Setup
+
+Run from the repository root:
+
+```powershell
+$ActiveGraphVenv = Join-Path (Get-Location) ".tmp\venvs\activegraph-canary"
+New-Item -ItemType Directory -Force (Split-Path $ActiveGraphVenv) | Out-Null
+python -m venv $ActiveGraphVenv
+& "$ActiveGraphVenv\Scripts\python.exe" -m pip install -r evals/activegraph/requirements.in
+& "$ActiveGraphVenv\Scripts\python.exe" -m pip check
+$env:PYTHONPATH = (Resolve-Path "evals/activegraph/src").Path
+```
+
+Dependency installation may contact the configured package index. The test and
+run commands below must not make live calls.
+
+## Run the complete evaluator test suite
+
+```powershell
+& "$ActiveGraphVenv\Scripts\python.exe" -m pytest evals/activegraph/tests -q
+```
+
+The suite covers both schemas, contract validation, deterministic topology and
+winner flip, diff explanation, canonical bytes, live-to-reload parity, CLI
+failure semantics, caller-payload mutation containment, real NodeKit event
+replay, and no-write failure paths.
+
+## Build the locked evaluator image
+
+The runtime wrapper accepts only an immutable Docker image ID or repository
+digest carrying labels for the exact committed build-input hash, NodeBench
+candidate commit, and audited upstream record. Generate those values from a
+clean commit, build the image, resolve its ID, and write the image attestation:
+
+```powershell
+$ActiveGraphBuild = node scripts/nodekit/runActiveGraphCanary.mjs `
+  --print-build-metadata | ConvertFrom-Json
+
+docker build `
+  --file evals/activegraph/Dockerfile `
+  --tag nodebench-activegraph-canary:local `
+  --build-arg "NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256=$($ActiveGraphBuild.buildInputsHash)" `
+  --build-arg "NODEBENCH_CANDIDATE_COMMIT=$($ActiveGraphBuild.nodebenchCandidateCommit)" `
+  --build-arg "NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256=$($ActiveGraphBuild.upstreamHash)" `
+  evals/activegraph
+$ActiveGraphSandboxImage = docker image inspect `
+  --format "{{.Id}}" `
+  nodebench-activegraph-canary:local
+if ($ActiveGraphSandboxImage -notmatch '^sha256:[a-f0-9]{64}$') {
+  throw "ActiveGraph sandbox image is not immutable"
+}
+
+$ActiveGraphImageAttestation = Join-Path `
+  (Resolve-Path ".tmp").Path `
+  "activegraph-canary\image-attestation.json"
+node scripts/nodekit/runActiveGraphCanary.mjs `
+  --attestation-output $ActiveGraphImageAttestation `
+  --sandbox-image $ActiveGraphSandboxImage
+if ($LASTEXITCODE -ne 0) {
+  throw "ActiveGraph image attestation failed"
+}
+```
+
+Dependency installation occurs at image-build time. The replay itself runs
+with Docker networking disabled. Metadata/attestation generation rejects dirty
+canonical image inputs. Replay independently recomputes those inputs, checks the
+current candidate commit, inspects the image labels, and rejects arbitrary
+immutable digests that lack the exact attestation.
+
+This is local provenance, not a signed supply-chain attestation. A party that
+controls both Docker and the attestation file can forge matching labels; that
+threat remains a production-adoption gate.
+
+## Replay a canonical NodeKit export
+
+First obtain an owner-authorized terminal export from:
+
+```text
+domains/operations/taskManager/nodeKitRunExport:exportNodeKitRun
+```
+
+Save that returned JSON unchanged, then run:
+
+```powershell
+$NodeKitExport = (Resolve-Path ".tmp\nodekit-export.json").Path
+$ActiveGraphEvidence = Join-Path (Resolve-Path ".tmp").Path "activegraph-canary\nodekit"
+
+node scripts/nodekit/runActiveGraphCanary.mjs `
+  --input $NodeKitExport `
+  --evidence-root $ActiveGraphEvidence `
+  --sandbox-image $ActiveGraphSandboxImage `
+  --image-attestation $ActiveGraphImageAttestation
+if ($LASTEXITCODE -ne 0) {
+  throw "NodeKit ActiveGraph replay failed with exit code $LASTEXITCODE"
+}
+```
+
+The wrapper prints the newly created evidence directory. It contains only:
+
+```text
+nodekit-run-export.json
+activegraph.sqlite3
+report.json
+```
+
+The report passes only when the reloaded ActiveGraph event payloads exactly
+equal the exported NodeKit event array and the report binds the same export
+hash, chain head, event count, canonical replayed-event digest, run ID,
+immutable sandbox image, build-input hash, candidate commit, upstream hash, and
+image-attestation hash. The wrapper also caps the source export at 1 MiB, the
+report at 64 KiB, SQLite at 64 MiB, child output at 1 MiB, and runtime at 120
+seconds. It requires exactly three non-empty regular artifacts and reads only
+the 16-byte SQLite 3 header for the file check.
+
+Do not invoke the Python replay CLI directly. It rejects host execution. The
+Node wrapper is the boundary that enforces source immutability, exclusive
+output placement, credential stripping, Docker isolation, and exact artifact
+placement.
+
+## Run the synthetic graph-hop golden twice
+
+The synthetic lane uses fixed IDs and clocks. Two independent databases must
+produce byte-identical reports:
+
+```powershell
+$ActiveGraphRunRoot = Join-Path ".tmp\activegraph-canary" ([guid]::NewGuid().ToString("N"))
+$ActiveGraphFixture = (Resolve-Path "evals/activegraph/fixtures/golden-selection-flip.input.v1.json").Path
+New-Item -ItemType Directory -Force $ActiveGraphRunRoot | Out-Null
+
+& "$ActiveGraphVenv\Scripts\python.exe" -m nodebench_activegraph_canary `
+  --input $ActiveGraphFixture `
+  --output "$ActiveGraphRunRoot\run-1.json" `
+  --db "$ActiveGraphRunRoot\run-1.sqlite"
+if ($LASTEXITCODE -ne 0) {
+  throw "First ActiveGraph golden run failed with exit code $LASTEXITCODE"
+}
+
+& "$ActiveGraphVenv\Scripts\python.exe" -m nodebench_activegraph_canary `
+  --input $ActiveGraphFixture `
+  --output "$ActiveGraphRunRoot\run-2.json" `
+  --db "$ActiveGraphRunRoot\run-2.sqlite"
+if ($LASTEXITCODE -ne 0) {
+  throw "Second ActiveGraph golden run failed with exit code $LASTEXITCODE"
+}
+
+$ActiveGraphHash1 = (Get-FileHash -Algorithm SHA256 -LiteralPath "$ActiveGraphRunRoot\run-1.json").Hash
+$ActiveGraphHash2 = (Get-FileHash -Algorithm SHA256 -LiteralPath "$ActiveGraphRunRoot\run-2.json").Hash
+$ActiveGraphExpectedHash = "C07439CB9B90B7A8511739C8BC8F2184523ED74C557169A53129E09A00FCE9EE"
+if ($ActiveGraphHash1 -ne $ActiveGraphHash2 -or $ActiveGraphHash1 -ne $ActiveGraphExpectedHash) {
+  throw "ActiveGraph hash gate failed: run1=$ActiveGraphHash1 run2=$ActiveGraphHash2 expected=$ActiveGraphExpectedHash"
+}
+
+$ActiveGraphReport = Get-Content -Raw -LiteralPath "$ActiveGraphRunRoot\run-1.json" | ConvertFrom-Json
+$ActiveGraphFailedAssertions = @($ActiveGraphReport.assertions | Where-Object { -not $_.passed })
+if (
+  $ActiveGraphReport.verdict -ne "pass" `
+  -or $ActiveGraphFailedAssertions.Count -ne 0 `
+  -or @($ActiveGraphReport.assertions).Count -ne 7 `
+  -or $ActiveGraphReport.runs.baseline.event_count -ne 17 `
+  -or $ActiveGraphReport.runs.variant.event_count -ne 17
+) {
+  throw "ActiveGraph golden report did not pass every assertion"
+}
+$ActiveGraphHash1
+```
+
+The synthetic lane models explicit query-to-candidate hop paths, materializes
+them as `graph_hop` relations, traverses those relations to derive graph scores,
+and compares a semantic-heavy parent with a graph-heavy fork. Its normalized
+report exposes the changed policy, weights, ranking, selected relation, and
+evidence paths.
+
+## Issue #67 containment
+
+[ActiveGraph issue #67](https://github.com/yoheinakajima/activegraph/issues/67)
+shows that a caller can mutate a nested payload after `Graph.emit()`, causing
+live memory and serialized SQLite history to diverge. Both adapters deep-copy
+payloads at their boundary. The regression compares live, persisted, and
+freshly reloaded values.
+
+This proves the local containment, not an upstream fix or production readiness.
+
+## Files
+
+| Path                                                 | Purpose                                                |
+| ---------------------------------------------------- | ------------------------------------------------------ |
+| `requirements.in`                                    | Exact direct dependency pins                           |
+| `UPSTREAM.json`                                      | Audited release and source revision                    |
+| `schemas/graph-hop-*.schema.json`                    | Synthetic fixture and report contracts                 |
+| `schemas/nodekit-*.schema.json`                      | Canonical export and replay-report contracts           |
+| `fixtures/golden-selection-flip.input.v1.json`       | Fixed synthetic graph-hop case                         |
+| `src/nodebench_activegraph_canary/runtime.py`        | Synthetic fork/diff runtime                            |
+| `src/nodebench_activegraph_canary/nodekit_replay.py` | Canonical export validator and replay                  |
+| `tests/`                                             | Contract, determinism, persistence, and boundary tests |
+
+## Gates
+
+- **Gate 1, synthetic mechanics:** implemented and required to stay green.
+- **Gate 2, immutable export and exact replay:** implemented for newly created
+  owner-scoped execution traces; legacy and ownerless traces fail closed.
+- **Gate 3, representative corpus and latency:** deferred. Replay about 20
+  owner-authorized exports and stop on any parity failure, more than 2× median
+  latency, or no material explanatory gain.
+- **Gate 4, production bridge:** not authorized. It requires a separate ADR,
+  threat model, issue #67 disposition, ownership proof, migration, and rollback.
+
+## Explicit non-goals
+
+This evaluator does not add a live `EventSink`, TypeScript ActiveGraph runtime,
+MCP ingestion, Temporal backend, production worker, dual-write, or any role for
+ActiveGraph in user-visible answers or approval decisions.

--- a/evals/activegraph/UPSTREAM.json
+++ b/evals/activegraph/UPSTREAM.json
@@ -1,0 +1,17 @@
+{
+  "name": "Active Graph",
+  "package": "activegraph",
+  "repository": "https://github.com/yoheinakajima/activegraph",
+  "license": "Apache-2.0",
+  "pinned_version": "1.10.0",
+  "release_tag": "v1.10.0",
+  "release_commit": "148e12c2969f18fa12a1a3c2e75f3affd9aa0616",
+  "annotated_tag_object": "3fbcd8fc56a45ae68622d4e2b18a6d5844180527",
+  "inspected_ref": "8aedb1866cf5dce056af97529152ffd6f468a1ed",
+  "inspected_at": "2026-07-28T00:00:00Z",
+  "test_dependencies": {
+    "jsonschema": "4.26.0",
+    "pytest": "9.1.1"
+  },
+  "scope": "Deterministic, test-only graph-hop fork-and-diff canary"
+}

--- a/evals/activegraph/fixtures/golden-selection-flip.input.v1.json
+++ b/evals/activegraph/fixtures/golden-selection-flip.input.v1.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "nodebench.activegraph.graph-hop-input.v1",
+  "case_id": "golden-selection-flip",
+  "determinism": {
+    "timestamp_iso": "2026-07-28t00:00:00z",
+    "parent_run_id": "01J00000000000000000000001",
+    "fork_run_id": "01J00000000000000000000002"
+  },
+  "query": {
+    "query_id": "q1",
+    "text": "Which candidate should the graph-hop policy select?"
+  },
+  "candidates": [
+    {
+      "candidate_id": "cand_a",
+      "label": "Semantic leader",
+      "semantic_score_bp": 9500,
+      "source_quality_bp": 8000,
+      "hop_path": [
+        {
+          "source_id": "query:q1",
+          "target_id": "evidence:semantic_a",
+          "evidence_id": "ev_a_query_signal",
+          "graph_score_bp": 3000
+        },
+        {
+          "source_id": "evidence:semantic_a",
+          "target_id": "candidate:cand_a",
+          "evidence_id": "ev_a_signal_candidate",
+          "graph_score_bp": 3000
+        }
+      ]
+    },
+    {
+      "candidate_id": "cand_b",
+      "label": "Graph leader",
+      "semantic_score_bp": 7000,
+      "source_quality_bp": 9000,
+      "hop_path": [
+        {
+          "source_id": "query:q1",
+          "target_id": "evidence:graph_b",
+          "evidence_id": "ev_b_query_signal",
+          "graph_score_bp": 9500
+        },
+        {
+          "source_id": "evidence:graph_b",
+          "target_id": "candidate:cand_b",
+          "evidence_id": "ev_b_signal_candidate",
+          "graph_score_bp": 9500
+        }
+      ]
+    }
+  ],
+  "policies": {
+    "baseline": {
+      "policy_id": "semantic_v1",
+      "weights_bp": {
+        "semantic_score_bp": 8000,
+        "graph_score_bp": 1000,
+        "source_quality_bp": 1000
+      }
+    },
+    "variant": {
+      "policy_id": "graph_v1",
+      "weights_bp": {
+        "semantic_score_bp": 3000,
+        "graph_score_bp": 6000,
+        "source_quality_bp": 1000
+      }
+    }
+  },
+  "expected": {
+    "baseline_winner_id": "cand_a",
+    "variant_winner_id": "cand_b"
+  }
+}

--- a/evals/activegraph/requirements.in
+++ b/evals/activegraph/requirements.in
@@ -1,0 +1,4 @@
+activegraph==1.10.0
+jsonschema==4.26.0
+pytest==9.1.1
+rfc8785==0.1.4

--- a/evals/activegraph/schemas/graph-hop-input.v1.schema.json
+++ b/evals/activegraph/schemas/graph-hop-input.v1.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nodebench.ai/schemas/activegraph/graph-hop-input.v1.schema.json",
+  "title": "NodeBench ActiveGraph Graph Hop Canary Input v1",
+  "description": "Deterministic inputs for a baseline run and a policy-weight fork. Graph scores are derived from explicit contiguous hop-edge evidence, never supplied as a candidate scalar. Candidate and evidence ID uniqueness, path connectivity and endpoints, equal per-path graph evidence scores, and policy weight sums are semantic invariants enforced by the runner.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "case_id",
+    "determinism",
+    "query",
+    "candidates",
+    "policies",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "nodebench.activegraph.graph-hop-input.v1"
+    },
+    "case_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$"
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["timestamp_iso", "parent_run_id", "fork_run_id"],
+      "properties": {
+        "timestamp_iso": {
+          "type": "string",
+          "description": "RFC 3339 date-time. The contract accepts the RFC-permitted lowercase t and z forms.",
+          "format": "date-time"
+        },
+        "parent_run_id": {
+          "$ref": "#/$defs/runId"
+        },
+        "fork_run_id": {
+          "$ref": "#/$defs/runId"
+        }
+      }
+    },
+    "query": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query_id", "text"],
+      "properties": {
+        "query_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "label",
+          "semantic_score_bp",
+          "source_quality_bp",
+          "hop_path"
+        ],
+        "properties": {
+          "candidate_id": {
+            "$ref": "#/$defs/domainId"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "semantic_score_bp": {
+            "$ref": "#/$defs/basisPoints"
+          },
+          "source_quality_bp": {
+            "$ref": "#/$defs/basisPoints"
+          },
+          "hop_path": {
+            "type": "array",
+            "description": "Ordered edge evidence forming one contiguous query:<query_id> to candidate:<candidate_id> path. The runner requires globally unique evidence_id values and one common graph_score_bp across a candidate path.",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "$ref": "#/$defs/hopEdge"
+            }
+          }
+        }
+      }
+    },
+    "policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline", "variant"],
+      "properties": {
+        "baseline": {
+          "$ref": "#/$defs/policy"
+        },
+        "variant": {
+          "$ref": "#/$defs/policy"
+        }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline_winner_id", "variant_winner_id"],
+      "properties": {
+        "baseline_winner_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "variant_winner_id": {
+          "$ref": "#/$defs/domainId"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "basisPoints": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10000
+    },
+    "domainId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:#/-]*$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "hopEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "target_id", "evidence_id", "graph_score_bp"],
+      "properties": {
+        "source_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "target_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "evidence_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "graph_score_bp": {
+          "$ref": "#/$defs/basisPoints"
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "weights_bp"],
+      "properties": {
+        "policy_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "weights_bp": {
+          "type": "object",
+          "description": "The three integer weights MUST total exactly 10000; the runner enforces this cross-field invariant.",
+          "additionalProperties": false,
+          "required": [
+            "semantic_score_bp",
+            "graph_score_bp",
+            "source_quality_bp"
+          ],
+          "properties": {
+            "semantic_score_bp": {
+              "$ref": "#/$defs/basisPoints"
+            },
+            "graph_score_bp": {
+              "$ref": "#/$defs/basisPoints"
+            },
+            "source_quality_bp": {
+              "$ref": "#/$defs/basisPoints"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/evals/activegraph/schemas/graph-hop-output.v1.schema.json
+++ b/evals/activegraph/schemas/graph-hop-output.v1.schema.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nodebench.ai/schemas/activegraph/graph-hop-output.v1.schema.json",
+  "title": "NodeBench ActiveGraph Graph Hop Canary Output v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "activegraph",
+    "case_id",
+    "input_sha256",
+    "fork_point",
+    "runs",
+    "diff",
+    "assertions",
+    "verdict",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "nodebench.activegraph.graph-hop-output.v1"
+    },
+    "activegraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "inspected_ref"],
+      "properties": {
+        "version": {
+          "const": "1.10.0"
+        },
+        "inspected_ref": {
+          "const": "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+        }
+      }
+    },
+    "case_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "input_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "fork_point": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_id", "event_type", "object_id"],
+      "properties": {
+        "event_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "event_type": {
+          "$ref": "#/$defs/domainId"
+        },
+        "object_id": {
+          "$ref": "#/$defs/domainId"
+        }
+      }
+    },
+    "runs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline", "variant"],
+      "properties": {
+        "baseline": {
+          "$ref": "#/$defs/run"
+        },
+        "variant": {
+          "$ref": "#/$defs/run"
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "is_identical",
+        "shared_events",
+        "parent_only_events",
+        "fork_only_events",
+        "decision_delta",
+        "divergent_objects",
+        "divergent_relations"
+      ],
+      "properties": {
+        "is_identical": {
+          "type": "boolean"
+        },
+        "shared_events": {
+          "$ref": "#/$defs/eventSummaries"
+        },
+        "parent_only_events": {
+          "$ref": "#/$defs/eventSummaries"
+        },
+        "fork_only_events": {
+          "$ref": "#/$defs/eventSummaries"
+        },
+        "decision_delta": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["baseline", "variant"],
+          "properties": {
+            "baseline": {
+              "$ref": "#/$defs/decisionResult"
+            },
+            "variant": {
+              "$ref": "#/$defs/decisionResult"
+            }
+          }
+        },
+        "divergent_objects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/objectDivergence"
+          }
+        },
+        "divergent_relations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/relationDivergence"
+          }
+        }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "passed", "expected", "actual"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "expected": {},
+          "actual": {}
+        }
+      }
+    },
+    "verdict": {
+      "enum": ["pass", "fail"]
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "contains": {
+        "const": "This synthetic golden case characterizes fork/diff mechanics only; canonical NodeKit export replay is evaluated by the separate offline replay lane."
+      },
+      "minContains": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "domainId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:#/-]*$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "rankingEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_id", "score_bp"],
+      "properties": {
+        "candidate_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "score_bp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "policy_id",
+        "winner_candidate_id",
+        "ranking",
+        "weights_bp",
+        "event_count",
+        "event_log_sha256"
+      ],
+      "properties": {
+        "run_id": {
+          "$ref": "#/$defs/runId"
+        },
+        "policy_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "winner_candidate_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "ranking": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/rankingEntry"
+          }
+        },
+        "weights_bp": {
+          "$ref": "#/$defs/weightsBp"
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "event_log_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "eventSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "type": {
+          "$ref": "#/$defs/domainId"
+        }
+      }
+    },
+    "eventSummaries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/eventSummary"
+      }
+    },
+    "weightsBp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["semantic_score_bp", "graph_score_bp", "source_quality_bp"],
+      "properties": {
+        "semantic_score_bp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "graph_score_bp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "source_quality_bp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        }
+      }
+    },
+    "graphEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "graph_score_bp",
+        "node_ids",
+        "relation_ids",
+        "evidence_ids"
+      ],
+      "properties": {
+        "candidate_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "graph_score_bp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "node_ids": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/domainId"
+          }
+        },
+        "relation_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/domainId"
+          }
+        },
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/domainId"
+          }
+        }
+      }
+    },
+    "decisionResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_id",
+        "winner_candidate_id",
+        "ranking",
+        "weights_bp",
+        "graph_evidence"
+      ],
+      "properties": {
+        "policy_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "winner_candidate_id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "ranking": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/rankingEntry"
+          }
+        },
+        "weights_bp": {
+          "$ref": "#/$defs/weightsBp"
+        },
+        "graph_evidence": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/graphEvidence"
+          }
+        }
+      }
+    },
+    "objectSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "data", "version"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "type": {
+          "$ref": "#/$defs/domainId"
+        },
+        "data": {
+          "type": "object"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "relationSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "target", "type", "data"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "source": {
+          "$ref": "#/$defs/domainId"
+        },
+        "target": {
+          "$ref": "#/$defs/domainId"
+        },
+        "type": {
+          "$ref": "#/$defs/domainId"
+        },
+        "data": {
+          "type": "object"
+        }
+      }
+    },
+    "nullableObjectSnapshot": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/objectSnapshot"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nullableRelationSnapshot": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/relationSnapshot"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "objectDivergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "in_parent", "in_fork"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "in_parent": {
+          "$ref": "#/$defs/nullableObjectSnapshot"
+        },
+        "in_fork": {
+          "$ref": "#/$defs/nullableObjectSnapshot"
+        }
+      }
+    },
+    "relationDivergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "in_parent", "in_fork"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/domainId"
+        },
+        "in_parent": {
+          "$ref": "#/$defs/nullableRelationSnapshot"
+        },
+        "in_fork": {
+          "$ref": "#/$defs/nullableRelationSnapshot"
+        }
+      }
+    }
+  }
+}

--- a/evals/activegraph/schemas/image-attestation.v1.schema.json
+++ b/evals/activegraph/schemas/image-attestation.v1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nodebench.ai/schemas/activegraph-image-attestation.v1.schema.json",
+  "title": "NodeBench ActiveGraph image attestation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "image",
+    "buildInputsHash",
+    "nodebenchCandidateCommit",
+    "upstream",
+    "upstreamHash",
+    "attestationHash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "nodebench.activegraph-image-attestation/v1"
+    },
+    "image": {
+      "type": "string",
+      "pattern": "^(?:[a-z0-9._/-]+@)?sha256:[a-f0-9]{64}$"
+    },
+    "buildInputsHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "nodebenchCandidateCommit": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "upstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "package",
+        "version",
+        "releaseTag",
+        "releaseCommit",
+        "annotatedTagObject",
+        "inspectedRef"
+      ],
+      "properties": {
+        "package": { "const": "activegraph" },
+        "version": { "const": "1.10.0" },
+        "releaseTag": { "const": "v1.10.0" },
+        "releaseCommit": {
+          "const": "148e12c2969f18fa12a1a3c2e75f3affd9aa0616"
+        },
+        "annotatedTagObject": {
+          "const": "3fbcd8fc56a45ae68622d4e2b18a6d5844180527"
+        },
+        "inspectedRef": {
+          "const": "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+        }
+      }
+    },
+    "upstreamHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "attestationHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/evals/activegraph/schemas/nodekit-replay-output.v1.schema.json
+++ b/evals/activegraph/schemas/nodekit-replay-output.v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nodebench.ai/schemas/nodekit-replay-output.v1.schema.json",
+  "title": "NodeKit ActiveGraph replay canary output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "activegraph",
+    "isolation",
+    "mode",
+    "run_id",
+    "input_export_sha256",
+    "event_count",
+    "nodekit_chain_head",
+    "replayed_events_sha256",
+    "persisted_reload_parity",
+    "verdict",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "nodebench.activegraph.nodekit-replay-output.v1"
+    },
+    "activegraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "release_commit",
+        "annotated_tag_object",
+        "inspected_ref"
+      ],
+      "properties": {
+        "version": { "const": "1.10.0" },
+        "release_commit": {
+          "const": "148e12c2969f18fa12a1a3c2e75f3affd9aa0616"
+        },
+        "annotated_tag_object": {
+          "const": "3fbcd8fc56a45ae68622d4e2b18a6d5844180527"
+        },
+        "inspected_ref": {
+          "const": "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+        }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "image",
+        "network",
+        "rootFilesystem",
+        "writableMount",
+        "buildInputsHash",
+        "nodebenchCandidateCommit",
+        "upstreamHash",
+        "imageAttestationHash"
+      ],
+      "properties": {
+        "runtime": { "const": "docker" },
+        "image": {
+          "type": "string",
+          "pattern": "^(?:[a-z0-9._/-]+@)?sha256:[a-f0-9]{64}$"
+        },
+        "network": { "const": "none" },
+        "rootFilesystem": { "const": "read-only" },
+        "writableMount": { "const": "/evidence" },
+        "buildInputsHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "nodebenchCandidateCommit": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "upstreamHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "imageAttestationHash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "mode": { "const": "offline-observer" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "input_export_sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "event_count": { "type": "integer", "minimum": 2 },
+    "nodekit_chain_head": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "replayed_events_sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "persisted_reload_parity": { "type": "boolean" },
+    "verdict": { "enum": ["pass", "fail"] },
+    "limitations": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "string", "minLength": 1 },
+      "contains": {
+        "const": "Offline observer only: this disposable SQLite history cannot answer, approve, mutate, or replace NodeBench state."
+      }
+    }
+  }
+}

--- a/evals/activegraph/schemas/nodekit-run-export.v1.schema.json
+++ b/evals/activegraph/schemas/nodekit-run-export.v1.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nodebench.ai/schemas/nodekit-run-export.v1.schema.json",
+  "title": "Canonical NodeKit run export",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "session",
+    "trace",
+    "events",
+    "completeness",
+    "hashes"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "nodekit.run-export/v1" },
+    "runId": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "typeAtRunStart", "startedAt"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "typeAtRunStart": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "startedAt": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "runId",
+        "workflowName",
+        "status",
+        "startedAt",
+        "endedAt"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "runId": { "type": "string", "minLength": 1 },
+        "workflowName": { "type": "string" },
+        "status": { "enum": ["completed", "error"] },
+        "startedAt": { "type": "integer", "minimum": 0 },
+        "endedAt": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "events": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/event" }
+    },
+    "completeness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventChainComplete",
+        "spanLifecycleComplete",
+        "contractVersion",
+        "eventCount",
+        "firstSequence",
+        "lastSequence",
+        "terminalEventType"
+      ],
+      "properties": {
+        "eventChainComplete": { "const": true },
+        "spanLifecycleComplete": { "const": true },
+        "contractVersion": { "const": "nodekit.run-event/v1" },
+        "eventCount": { "type": "integer", "minimum": 2 },
+        "firstSequence": { "const": 0 },
+        "lastSequence": { "type": "integer", "minimum": 1 },
+        "terminalEventType": {
+          "enum": ["run.completed", "run.failed"]
+        }
+      }
+    },
+    "hashes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "chainHead", "exportHash"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "chainHead": { "$ref": "#/$defs/hash" },
+        "exportHash": { "$ref": "#/$defs/hash" }
+      }
+    }
+  },
+  "$defs": {
+    "hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contractVersion",
+        "runId",
+        "sequence",
+        "eventType",
+        "recordedAt",
+        "payload",
+        "previousHash",
+        "contentHash"
+      ],
+      "properties": {
+        "contractVersion": { "const": "nodekit.run-event/v1" },
+        "runId": { "type": "string", "minLength": 1 },
+        "sequence": { "type": "integer", "minimum": 0 },
+        "eventType": {
+          "enum": [
+            "run.started",
+            "span.started",
+            "span.completed",
+            "step.recorded",
+            "decision.recorded",
+            "verification.recorded",
+            "evidence.attached",
+            "approval.requested",
+            "run.completed",
+            "run.failed"
+          ]
+        },
+        "recordedAt": { "type": "integer", "minimum": 0 },
+        "payload": { "$ref": "#/$defs/safePayload" },
+        "previousHash": { "$ref": "#/$defs/hash" },
+        "contentHash": { "$ref": "#/$defs/hash" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "eventType": { "const": "run.completed" }
+            },
+            "required": ["eventType"]
+          },
+          "then": {
+            "properties": {
+              "payload": {
+                "properties": {
+                  "fields": {
+                    "properties": {
+                      "status": { "const": "completed" }
+                    },
+                    "required": ["status"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "eventType": { "const": "run.failed" }
+            },
+            "required": ["eventType"]
+          },
+          "then": {
+            "properties": {
+              "payload": {
+                "properties": {
+                  "fields": {
+                    "properties": {
+                      "status": { "const": "error" }
+                    },
+                    "required": ["status"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "safePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "projectionVersion",
+        "sourceDigest",
+        "sourceBytes",
+        "fields"
+      ],
+      "properties": {
+        "projectionVersion": {
+          "const": "nodekit.safe-event-payload/v1"
+        },
+        "sourceDigest": { "$ref": "#/$defs/hash" },
+        "sourceBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 32768
+        },
+        "fields": {
+          "type": "object",
+          "maxProperties": 7,
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "null"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/evals/activegraph/src/nodebench_activegraph_canary/__init__.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/__init__.py
@@ -1,0 +1,24 @@
+"""Deterministic NodeBench canary for ActiveGraph fork/diff evaluation."""
+
+from .canonical import canonical_json_bytes, canonical_sha256
+from .runtime import (
+    DeterministicRunIDGen,
+    inspect_payload_isolation,
+    run_canary,
+)
+from .nodekit_replay import (
+    NodeKitReplayContractError,
+    run_nodekit_replay_canary,
+    validate_nodekit_export,
+)
+
+__all__ = [
+    "DeterministicRunIDGen",
+    "canonical_json_bytes",
+    "canonical_sha256",
+    "inspect_payload_isolation",
+    "NodeKitReplayContractError",
+    "run_canary",
+    "run_nodekit_replay_canary",
+    "validate_nodekit_export",
+]

--- a/evals/activegraph/src/nodebench_activegraph_canary/__main__.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/__main__.py
@@ -1,0 +1,52 @@
+"""Command-line entry point for the offline ActiveGraph canary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .canonical import canonical_json_bytes
+from .runtime import run_canary
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic NodeBench ActiveGraph canary."
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--db", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    input_path: Path = args.input
+    output_path: Path = args.output
+    db_path: Path = args.db
+
+    resolved_paths = {
+        input_path.resolve(),
+        output_path.resolve(),
+        db_path.resolve(),
+    }
+    if len(resolved_paths) != 3:
+        raise ValueError("--input, --output, and --db must be distinct paths")
+
+    try:
+        input_doc = json.loads(input_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unable to read JSON input {input_path}: {exc}") from exc
+
+    output = run_canary(input_doc, db_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(canonical_json_bytes(output))
+    # Stable contract for CI: the report is always written, while a failed
+    # canary uses exit code 2 so two byte-identical failures cannot look green.
+    return 0 if output["verdict"] == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/activegraph/src/nodebench_activegraph_canary/canonical.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/canonical.py
@@ -1,0 +1,26 @@
+"""Canonical JSON helpers shared by the canary API and CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Encode JSON with stable key order, compact separators, UTF-8, and LF."""
+
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{encoded}\n".encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    """Return the lowercase SHA-256 hex digest of canonical JSON bytes."""
+
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()

--- a/evals/activegraph/src/nodebench_activegraph_canary/nodekit_replay.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/nodekit_replay.py
@@ -1,0 +1,742 @@
+"""Fail-closed replay of a canonical NodeKit run export in ActiveGraph.
+
+The input is a disposable file copy staged by the Node wrapper. This module
+never imports a NodeBench client and never writes back to the source runtime.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import os
+from pathlib import Path
+import re
+from typing import Any
+
+import activegraph
+from activegraph import Event, FrozenClock, Graph, Runtime
+import rfc8785
+
+
+EXPORT_SCHEMA_VERSION = "nodekit.run-export/v1"
+EVENT_SCHEMA_VERSION = "nodekit.run-event/v1"
+SAFE_PAYLOAD_SCHEMA_VERSION = "nodekit.safe-event-payload/v1"
+OUTPUT_SCHEMA_VERSION = "nodebench.activegraph.nodekit-replay-output.v1"
+ACTIVEGRAPH_VERSION = "1.10.0"
+ACTIVEGRAPH_RELEASE_COMMIT = "148e12c2969f18fa12a1a3c2e75f3affd9aa0616"
+ACTIVEGRAPH_ANNOTATED_TAG_OBJECT = (
+    "3fbcd8fc56a45ae68622d4e2b18a6d5844180527"
+)
+ACTIVEGRAPH_INSPECTED_REF = "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+GENESIS_HASH = f"sha256:{'0' * 64}"
+OFFLINE_MODE = "offline-observer"
+SANDBOX_IMAGE_ENV = "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE"
+BUILD_INPUTS_HASH_ENV = "NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256"
+UPSTREAM_HASH_ENV = "NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256"
+IMAGE_ATTESTATION_HASH_ENV = (
+    "NODEBENCH_ACTIVEGRAPH_IMAGE_ATTESTATION_SHA256"
+)
+CANDIDATE_COMMIT_ENV = "NODEBENCH_CANDIDATE_COMMIT"
+MAX_EVENTS = 256
+MAX_REDACTED_SOURCE_BYTES = 32 * 1024
+MAX_STORED_PAYLOAD_BYTES = 2 * 1024
+EVENT_TYPES = frozenset(
+    {
+        "run.started",
+        "span.started",
+        "span.completed",
+        "step.recorded",
+        "decision.recorded",
+        "verification.recorded",
+        "evidence.attached",
+        "approval.requested",
+        "run.completed",
+        "run.failed",
+    }
+)
+TERMINAL_TYPES = frozenset({"run.completed", "run.failed"})
+SAFE_FIELDS_BY_EVENT = {
+    "run.started": frozenset(
+        {
+            "workflowName",
+            "origin",
+            "groupId",
+            "model",
+            "goalId",
+            "sessionType",
+            "sessionStartedAt",
+        }
+    ),
+    "span.started": frozenset(
+        {"spanId", "parentSpanId", "spanSequence", "depth", "spanType"}
+    ),
+    "span.completed": frozenset(
+        {"spanId", "spanSequence", "status", "durationMs"}
+    ),
+    "step.recorded": frozenset(
+        {
+            "spanId",
+            "parentSpanId",
+            "spanSequence",
+            "stage",
+            "type",
+            "tool",
+            "durationMs",
+        }
+    ),
+    "decision.recorded": frozenset({"decisionType", "confidence"}),
+    "verification.recorded": frozenset({"status"}),
+    "evidence.attached": frozenset(),
+    "approval.requested": frozenset(
+        {"approvalId", "toolName", "riskLevel"}
+    ),
+    "run.completed": frozenset(
+        {"status", "totalDurationMs", "crossCheckStatus", "dogfoodRunId"}
+    ),
+    "run.failed": frozenset(
+        {"status", "totalDurationMs", "crossCheckStatus", "dogfoodRunId"}
+    ),
+}
+REQUIRED_FIELDS_BY_EVENT = {
+    "run.started": frozenset(
+        {"workflowName", "sessionType", "sessionStartedAt"}
+    ),
+    "span.started": frozenset({"spanId"}),
+    "span.completed": frozenset({"spanId"}),
+    "run.completed": frozenset({"status"}),
+    "run.failed": frozenset({"status"}),
+}
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+class NodeKitReplayContractError(ValueError):
+    """Typed fail-closed error for malformed or incomplete exports."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+def _fail(code: str, message: str) -> None:
+    raise NodeKitReplayContractError(code, message)
+
+
+def canonical_json_text(value: Any) -> str:
+    """RFC 8785 bytes shared with the TypeScript/ECMAScript exporter."""
+
+    try:
+        return rfc8785.dumps(value).decode("utf-8")
+    except (TypeError, ValueError, rfc8785.CanonicalizationError) as exc:
+        _fail("non_json_value", f"Value is not canonical JSON: {exc}")
+
+
+def canonical_hash(value: Any) -> str:
+    encoded = canonical_json_text(value).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _expect_object(value: Any, path: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        _fail("shape_invalid", f"{path} must be an object")
+    return value
+
+
+def _expect_exact_keys(
+    value: dict[str, Any],
+    path: str,
+    expected: set[str],
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        _fail(
+            "shape_invalid",
+            f"{path} keys differ: missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}",
+        )
+
+
+def _expect_hash(value: Any, path: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.startswith("sha256:")
+        or len(value) != 71
+        or any(character not in "0123456789abcdef" for character in value[7:])
+    ):
+        _fail("hash_invalid", f"{path} must be a lowercase sha256: digest")
+    return value
+
+
+def _expect_string(
+    value: Any,
+    path: str,
+    *,
+    non_empty: bool = False,
+    max_length: int | None = None,
+) -> str:
+    if (
+        not isinstance(value, str)
+        or (non_empty and not value.strip())
+        or (max_length is not None and len(value) > max_length)
+    ):
+        _fail("shape_invalid", f"{path} must be a valid string")
+    return value
+
+
+def _expect_timestamp(value: Any, path: str) -> int:
+    if (
+        type(value) is not int
+        or value < 0
+        or value > 9_007_199_254_740_991
+    ):
+        _fail(
+            "shape_invalid",
+            f"{path} must be a non-negative JavaScript-safe integer",
+        )
+    return value
+
+
+def _expect_safe_payload(
+    value: Any,
+    path: str,
+    event_type: str,
+) -> dict[str, Any]:
+    payload = _expect_object(value, path)
+    _expect_exact_keys(
+        payload,
+        path,
+        {"projectionVersion", "sourceDigest", "sourceBytes", "fields"},
+    )
+    if payload["projectionVersion"] != SAFE_PAYLOAD_SCHEMA_VERSION:
+        _fail("payload_version_mismatch", f"{path} version is unsupported")
+    _expect_hash(payload["sourceDigest"], f"{path}.sourceDigest")
+    source_bytes = payload["sourceBytes"]
+    if (
+        type(source_bytes) is not int
+        or source_bytes < 0
+        or source_bytes > MAX_REDACTED_SOURCE_BYTES
+    ):
+        _fail("payload_size_invalid", f"{path}.sourceBytes exceeds its bound")
+    fields = _expect_object(payload["fields"], f"{path}.fields")
+    allowed = SAFE_FIELDS_BY_EVENT[event_type]
+    for field, field_value in fields.items():
+        if field not in allowed:
+            _fail(
+                "payload_field_invalid",
+                f"{path}.fields.{field} is not allowed",
+            )
+        if (
+            field_value is not None
+            and type(field_value) not in {str, int, float, bool}
+        ):
+            _fail(
+                "payload_field_invalid",
+                f"{path}.fields.{field} must be scalar",
+            )
+        if (
+            isinstance(field_value, str)
+            and len(field_value) > 256
+        ) or (
+            type(field_value) is float
+            and not (-float("inf") < field_value < float("inf"))
+        ):
+            _fail(
+                "payload_field_invalid",
+                f"{path}.fields.{field} exceeds its bound",
+            )
+    missing = REQUIRED_FIELDS_BY_EVENT.get(event_type, frozenset()) - set(
+        fields
+    )
+    if missing:
+        _fail(
+            "payload_field_missing",
+            f"{path} is missing safe fields {sorted(missing)}",
+        )
+    expected_terminal_status = {
+        "run.completed": "completed",
+        "run.failed": "error",
+    }.get(event_type)
+    if (
+        expected_terminal_status is not None
+        and fields.get("status") != expected_terminal_status
+    ):
+        _fail(
+            "terminal_status_mismatch",
+            f"{path} requires status {expected_terminal_status}",
+        )
+    if len(canonical_json_text(payload).encode("utf-8")) > MAX_STORED_PAYLOAD_BYTES:
+        _fail("projected_payload_too_large", f"{path} exceeds its stored bound")
+    return payload
+
+
+def _event_hash_body(event: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "contractVersion": event["contractVersion"],
+        "runId": event["runId"],
+        "sequence": event["sequence"],
+        "eventType": event["eventType"],
+        "recordedAt": event["recordedAt"],
+        "payload": event["payload"],
+        "previousHash": event["previousHash"],
+    }
+
+
+def validate_nodekit_export(value: Any) -> dict[str, Any]:
+    """Validate exact shape, order, hash-chain, completeness, and export hash."""
+
+    document = _expect_object(deepcopy(value), "$")
+    _expect_exact_keys(
+        document,
+        "$",
+        {
+            "schemaVersion",
+            "runId",
+            "session",
+            "trace",
+            "events",
+            "completeness",
+            "hashes",
+        },
+    )
+    if document["schemaVersion"] != EXPORT_SCHEMA_VERSION:
+        _fail("export_schema_mismatch", "Unsupported NodeKit export schema")
+    run_id = document["runId"]
+    if (
+        not isinstance(run_id, str)
+        or not run_id.strip()
+        or len(run_id) > 256
+    ):
+        _fail("run_id_invalid", "$.runId must contain 1-256 characters")
+    session = _expect_object(document["session"], "$.session")
+    trace = _expect_object(document["trace"], "$.trace")
+    completeness = _expect_object(document["completeness"], "$.completeness")
+    hashes = _expect_object(document["hashes"], "$.hashes")
+    _expect_exact_keys(
+        session,
+        "$.session",
+        {"id", "typeAtRunStart", "startedAt"},
+    )
+    _expect_exact_keys(
+        trace,
+        "$.trace",
+        {"id", "runId", "workflowName", "status", "startedAt", "endedAt"},
+    )
+    _expect_exact_keys(
+        completeness,
+        "$.completeness",
+        {
+            "eventChainComplete",
+            "spanLifecycleComplete",
+            "contractVersion",
+            "eventCount",
+            "firstSequence",
+            "lastSequence",
+            "terminalEventType",
+        },
+    )
+    _expect_string(session["id"], "$.session.id", non_empty=True)
+    _expect_string(
+        session["typeAtRunStart"],
+        "$.session.typeAtRunStart",
+        non_empty=True,
+        max_length=256,
+    )
+    session_started_at = _expect_timestamp(
+        session["startedAt"],
+        "$.session.startedAt",
+    )
+    _expect_string(trace["id"], "$.trace.id", non_empty=True)
+    _expect_string(
+        trace["runId"],
+        "$.trace.runId",
+        non_empty=True,
+        max_length=256,
+    )
+    _expect_string(
+        trace["workflowName"],
+        "$.trace.workflowName",
+        non_empty=True,
+    )
+    if trace["status"] not in {"completed", "error"}:
+        _fail("run_not_terminal", "$.trace.status must be completed or error")
+    trace_started_at = _expect_timestamp(
+        trace["startedAt"],
+        "$.trace.startedAt",
+    )
+    trace_ended_at = _expect_timestamp(
+        trace["endedAt"],
+        "$.trace.endedAt",
+    )
+    if trace_ended_at < trace_started_at:
+        _fail(
+            "shape_invalid",
+            "$.trace.endedAt cannot precede startedAt",
+        )
+    if trace.get("runId") != run_id:
+        _fail("run_id_mismatch", "Trace and export run IDs differ")
+    events = document["events"]
+    if not isinstance(events, list) or len(events) < 2:
+        _fail(
+            "terminal_event_missing",
+            "A complete run requires start and terminal events",
+        )
+    if len(events) > MAX_EVENTS:
+        _fail(
+            "event_limit_exceeded",
+            f"Run exceeds the {MAX_EVENTS}-event bound",
+        )
+
+    previous_hash = GENESIS_HASH
+    terminal_indexes: list[int] = []
+    event_keys = {
+        "contractVersion",
+        "runId",
+        "sequence",
+        "eventType",
+        "recordedAt",
+        "payload",
+        "previousHash",
+        "contentHash",
+    }
+    open_spans: set[str] = set()
+    completed_spans: set[str] = set()
+    for index, candidate in enumerate(events):
+        event = _expect_object(candidate, f"$.events[{index}]")
+        _expect_exact_keys(event, f"$.events[{index}]", event_keys)
+        if event["contractVersion"] != EVENT_SCHEMA_VERSION:
+            _fail(
+                "contract_version_mismatch",
+                f"$.events[{index}] contract is unsupported",
+            )
+        if event["runId"] != run_id:
+            _fail("run_id_mismatch", f"$.events[{index}] belongs to another run")
+        if type(event["sequence"]) is not int or event["sequence"] != index:
+            _fail(
+                "sequence_not_contiguous",
+                f"Expected sequence {index}, received {event['sequence']!r}",
+            )
+        if event["eventType"] not in EVENT_TYPES:
+            _fail(
+                "event_type_invalid",
+                f"$.events[{index}].eventType is unsupported",
+            )
+        payload = _expect_safe_payload(
+            event["payload"],
+            f"$.events[{index}].payload",
+            event["eventType"],
+        )
+        recorded_at = _expect_timestamp(
+            event["recordedAt"],
+            f"$.events[{index}].recordedAt",
+        )
+        if index > 0 and recorded_at < events[index - 1]["recordedAt"]:
+            _fail(
+                "recorded_at_not_monotonic",
+                f"$.events[{index}] was recorded before its predecessor",
+            )
+        _expect_hash(event["previousHash"], f"$.events[{index}].previousHash")
+        _expect_hash(event["contentHash"], f"$.events[{index}].contentHash")
+        if event["previousHash"] != previous_hash:
+            _fail(
+                "previous_hash_mismatch",
+                f"$.events[{index}] does not point to the preceding event",
+            )
+        if event["contentHash"] != canonical_hash(_event_hash_body(event)):
+            _fail(
+                "content_hash_mismatch",
+                f"$.events[{index}] content does not match its hash",
+            )
+        if event["eventType"] in TERMINAL_TYPES:
+            terminal_indexes.append(index)
+        if event["eventType"] == "span.started":
+            span_id = payload["fields"].get("spanId")
+            if (
+                not isinstance(span_id, str)
+                or not span_id
+                or span_id in open_spans
+                or span_id in completed_spans
+            ):
+                _fail(
+                    "span_duplicate_start",
+                    f"Invalid start for span {span_id!r}",
+                )
+            open_spans.add(span_id)
+        if event["eventType"] == "span.completed":
+            span_id = payload["fields"].get("spanId")
+            if not isinstance(span_id, str) or span_id not in open_spans:
+                _fail(
+                    "span_completion_without_start",
+                    f"Invalid completion for span {span_id!r}",
+                )
+            open_spans.remove(span_id)
+            completed_spans.add(span_id)
+        previous_hash = event["contentHash"]
+
+    if events[0]["eventType"] != "run.started":
+        _fail("start_event_missing", "Sequence 0 must be run.started")
+    if events[0]["previousHash"] != GENESIS_HASH:
+        _fail(
+            "previous_hash_mismatch",
+            "run.started must point to the genesis hash",
+        )
+    if not terminal_indexes:
+        _fail("terminal_event_missing", "The event chain has no terminal event")
+    if terminal_indexes != [len(events) - 1]:
+        _fail(
+            "terminal_event_not_last",
+            "Exactly one terminal event must be last",
+        )
+    if open_spans:
+        _fail(
+            "span_lifecycle_incomplete",
+            f"Terminal run retains {len(open_spans)} open span(s)",
+        )
+
+    terminal_type = events[-1]["eventType"]
+    expected_trace_status = (
+        "completed" if terminal_type == "run.completed" else "error"
+    )
+    if trace["status"] != expected_trace_status:
+        _fail(
+            "terminal_status_mismatch",
+            f"Trace status {trace['status']} does not match {terminal_type}",
+        )
+    start_fields = events[0]["payload"]["fields"]
+    if (
+        trace["workflowName"] != start_fields["workflowName"]
+        or trace["startedAt"] != events[0]["recordedAt"]
+        or trace["endedAt"] != events[-1]["recordedAt"]
+        or session["typeAtRunStart"] != start_fields["sessionType"]
+        or session["startedAt"] != start_fields["sessionStartedAt"]
+        or session_started_at > trace_started_at
+    ):
+        _fail(
+            "event_snapshot_mismatch",
+            "Session or trace metadata differs from immutable event snapshots",
+        )
+    expected_completeness = {
+        "eventChainComplete": True,
+        "spanLifecycleComplete": True,
+        "contractVersion": EVENT_SCHEMA_VERSION,
+        "eventCount": len(events),
+        "firstSequence": 0,
+        "lastSequence": len(events) - 1,
+        "terminalEventType": terminal_type,
+    }
+    if completeness != expected_completeness:
+        _fail(
+            "completeness_mismatch",
+            "Completeness receipt does not match the event chain",
+        )
+    _expect_exact_keys(
+        hashes,
+        "$.hashes",
+        {"algorithm", "chainHead", "exportHash"},
+    )
+    if hashes["algorithm"] != "sha256" or hashes["chainHead"] != previous_hash:
+        _fail("chain_head_mismatch", "Export chain head does not match events")
+    _expect_hash(hashes["exportHash"], "$.hashes.exportHash")
+    expected_export_hash = canonical_hash(
+        {
+            "schemaVersion": document["schemaVersion"],
+            "runId": run_id,
+            "session": session,
+            "trace": trace,
+            "events": events,
+            "completeness": completeness,
+            "hashes": {
+                "algorithm": hashes["algorithm"],
+                "chainHead": hashes["chainHead"],
+            },
+        }
+    )
+    if hashes["exportHash"] != expected_export_hash:
+        _fail("export_hash_mismatch", "Export content does not match exportHash")
+    return document
+
+
+def _activegraph_run_id(nodekit_run_id: str) -> str:
+    """Map a NodeKit run ID deterministically into a valid 128-bit ULID string."""
+
+    value = int.from_bytes(
+        hashlib.sha256(nodekit_run_id.encode("utf-8")).digest()[:16],
+        "big",
+    )
+    output = []
+    for _ in range(26):
+        output.append(_CROCKFORD[value & 31])
+        value >>= 5
+    return "".join(reversed(output))
+
+
+def _clock_iso(recorded_at_ms: int) -> str:
+    return datetime.fromtimestamp(
+        recorded_at_ms / 1000,
+        tz=timezone.utc,
+    ).isoformat().replace("+00:00", "Z")
+
+
+def _close_runtime(runtime: Runtime | None) -> None:
+    if runtime is None:
+        return
+    store = runtime.graph.store
+    if store is not None:
+        store.close()
+
+
+def _nodekit_payloads(runtime: Runtime) -> list[dict[str, Any]]:
+    return [
+        deepcopy(event.payload["nodekit_event"])
+        for event in runtime.graph.events
+        if event.type == "nodekit.event"
+    ]
+
+
+def run_nodekit_replay_canary(
+    input_doc: dict[str, Any],
+    db_path: Path,
+    *,
+    _test_only_allow_host_runtime: bool = False,
+) -> dict[str, Any]:
+    """Persist and reload an exact canonical export in isolated ActiveGraph."""
+
+    if os.environ.get("NODEBENCH_ACTIVEGRAPH_MODE") != OFFLINE_MODE:
+        _fail(
+            "offline_mode_required",
+            "NODEBENCH_ACTIVEGRAPH_MODE=offline-observer is required",
+        )
+    sandbox_image = os.environ.get(SANDBOX_IMAGE_ENV, "")
+    if re.fullmatch(
+        r"(?:[a-z0-9._/-]+@)?sha256:[a-f0-9]{64}",
+        sandbox_image,
+    ) is None:
+        _fail(
+            "sandbox_image_required",
+            f"{SANDBOX_IMAGE_ENV} must identify an immutable Docker image",
+        )
+    attested_digests: dict[str, str] = {}
+    for name in (
+        BUILD_INPUTS_HASH_ENV,
+        UPSTREAM_HASH_ENV,
+        IMAGE_ATTESTATION_HASH_ENV,
+    ):
+        value = os.environ.get(name, "")
+        if re.fullmatch(r"sha256:[a-f0-9]{64}", value) is None:
+            _fail(
+                "image_attestation_required",
+                f"{name} must be an attested sha256 digest",
+            )
+        attested_digests[name] = value
+    nodebench_candidate_commit = os.environ.get(CANDIDATE_COMMIT_ENV, "")
+    if re.fullmatch(r"[a-f0-9]{40}", nodebench_candidate_commit) is None:
+        _fail(
+            "image_attestation_required",
+            f"{CANDIDATE_COMMIT_ENV} must be a full Git SHA-1",
+        )
+    if (
+        not _test_only_allow_host_runtime
+        and not Path("/.dockerenv").is_file()
+    ):
+        _fail(
+            "sandbox_runtime_required",
+            "The replay CLI must execute inside its locked Docker boundary",
+        )
+    if activegraph.__version__ != ACTIVEGRAPH_VERSION:
+        raise RuntimeError(
+            "ActiveGraph version mismatch: "
+            f"expected {ACTIVEGRAPH_VERSION}, got {activegraph.__version__}"
+        )
+    if not isinstance(db_path, Path):
+        raise TypeError("db_path must be a pathlib.Path")
+    document = validate_nodekit_export(input_doc)
+    if db_path.exists():
+        _fail("db_exists", f"db_path already exists: {db_path}")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    live_runtime: Runtime | None = None
+    reloaded_runtime: Runtime | None = None
+    try:
+        graph = Graph(
+            clock=FrozenClock(_clock_iso(document["events"][0]["recordedAt"])),
+            run_id=_activegraph_run_id(document["runId"]),
+        )
+        live_runtime = Runtime(
+            graph,
+            behaviors=[],
+            persist_to=str(db_path),
+            seed=0,
+            trace_context_reads=True,
+        )
+        for event in document["events"]:
+            graph.emit(
+                Event(
+                    id=graph.ids.event(),
+                    type="nodekit.event",
+                    payload={"nodekit_event": deepcopy(event)},
+                    actor="nodebench-offline-observer",
+                    timestamp=_clock_iso(event["recordedAt"]),
+                )
+            )
+        live_runtime.run_until_idle()
+        live_payloads = _nodekit_payloads(live_runtime)
+
+        _close_runtime(live_runtime)
+        reloaded_runtime = Runtime.load(
+            str(db_path),
+            run_id=live_runtime.run_id,
+            behaviors=[],
+            seed=0,
+            trace_context_reads=True,
+        )
+        reloaded_payloads = _nodekit_payloads(reloaded_runtime)
+        parity = (
+            live_payloads == document["events"]
+            and reloaded_payloads == document["events"]
+        )
+        return {
+            "schema_version": OUTPUT_SCHEMA_VERSION,
+            "activegraph": {
+                "version": ACTIVEGRAPH_VERSION,
+                "release_commit": ACTIVEGRAPH_RELEASE_COMMIT,
+                "annotated_tag_object": ACTIVEGRAPH_ANNOTATED_TAG_OBJECT,
+                "inspected_ref": ACTIVEGRAPH_INSPECTED_REF,
+            },
+            "isolation": {
+                "runtime": "docker",
+                "image": sandbox_image,
+                "network": "none",
+                "rootFilesystem": "read-only",
+                "writableMount": "/evidence",
+                "buildInputsHash": attested_digests[BUILD_INPUTS_HASH_ENV],
+                "nodebenchCandidateCommit": nodebench_candidate_commit,
+                "upstreamHash": attested_digests[UPSTREAM_HASH_ENV],
+                "imageAttestationHash": attested_digests[
+                    IMAGE_ATTESTATION_HASH_ENV
+                ],
+            },
+            "mode": OFFLINE_MODE,
+            "run_id": document["runId"],
+            "input_export_sha256": document["hashes"]["exportHash"],
+            "event_count": len(document["events"]),
+            "nodekit_chain_head": document["hashes"]["chainHead"],
+            "replayed_events_sha256": canonical_hash(reloaded_payloads),
+            "persisted_reload_parity": parity,
+            "verdict": "pass" if parity else "fail",
+            "limitations": [
+                (
+                    "Offline observer only: this disposable SQLite history "
+                    "cannot answer, approve, mutate, or replace NodeBench state."
+                ),
+                (
+                    "A passing replay proves exact persistence/reload parity "
+                    "for this exported event sequence, not production adoption."
+                ),
+                (
+                    "ActiveGraph upstream issue #67 remains an adoption blocker; "
+                    "the adapter deep-copies every accepted event payload."
+                ),
+            ],
+        }
+    finally:
+        _close_runtime(reloaded_runtime)
+        _close_runtime(live_runtime)

--- a/evals/activegraph/src/nodebench_activegraph_canary/nodekit_replay_cli.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/nodekit_replay_cli.py
@@ -1,0 +1,81 @@
+"""CLI for the disposable-copy-only NodeKit replay canary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import stat
+from typing import Sequence
+
+from .canonical import canonical_json_bytes
+from .nodekit_replay import (
+    NodeKitReplayContractError,
+    run_nodekit_replay_canary,
+)
+
+
+MAX_EXPORT_BYTES = 1024 * 1024
+MAX_REPORT_BYTES = 64 * 1024
+MAX_SQLITE_BYTES = 64 * 1024 * 1024
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay a canonical NodeKit run export in offline ActiveGraph."
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--db", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    resolved = {
+        args.input.resolve(),
+        args.output.resolve(),
+        args.db.resolve(),
+    }
+    if len(resolved) != 3:
+        raise ValueError("--input, --output, and --db must be distinct paths")
+    try:
+        source_stat = args.input.lstat()
+        if (
+            not stat.S_ISREG(source_stat.st_mode)
+            or stat.S_ISLNK(source_stat.st_mode)
+            or source_stat.st_size < 1
+        ):
+            raise NodeKitReplayContractError(
+                "export_read_failed",
+                "input must be a non-empty regular file",
+            )
+        if source_stat.st_size > MAX_EXPORT_BYTES:
+            raise NodeKitReplayContractError(
+                "export_too_large",
+                f"input exceeds {MAX_EXPORT_BYTES} bytes",
+            )
+        document = json.loads(args.input.read_bytes().decode("utf-8"))
+    except NodeKitReplayContractError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unable to read JSON input {args.input}: {exc}") from exc
+    report = run_nodekit_replay_canary(document, args.db)
+    if args.db.stat().st_size > MAX_SQLITE_BYTES:
+        raise NodeKitReplayContractError(
+            "artifact_too_large",
+            f"SQLite output exceeds {MAX_SQLITE_BYTES} bytes",
+        )
+    report_bytes = canonical_json_bytes(report)
+    if len(report_bytes) > MAX_REPORT_BYTES:
+        raise NodeKitReplayContractError(
+            "artifact_too_large",
+            f"report output exceeds {MAX_REPORT_BYTES} bytes",
+        )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(report_bytes)
+    return 0 if report["verdict"] == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/activegraph/src/nodebench_activegraph_canary/runtime.py
+++ b/evals/activegraph/src/nodebench_activegraph_canary/runtime.py
@@ -1,0 +1,1267 @@
+"""Offline ActiveGraph graph-hop fork/diff canary.
+
+This module deliberately uses only ActiveGraph's instance-level ``Behavior``
+surface. It does not touch the process-global decorator registry.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+import re
+from typing import Any
+
+import activegraph
+from activegraph import Behavior, FrozenClock, Graph, IDGen, Runtime
+
+from .canonical import canonical_sha256
+
+
+INPUT_SCHEMA_VERSION = "nodebench.activegraph.graph-hop-input.v1"
+OUTPUT_SCHEMA_VERSION = "nodebench.activegraph.graph-hop-output.v1"
+ACTIVEGRAPH_VERSION = "1.10.0"
+ACTIVEGRAPH_INSPECTED_REF = "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+
+_SCORE_FIELDS = (
+    "semantic_score_bp",
+    "graph_score_bp",
+    "source_quality_bp",
+)
+_DOMAIN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:#/-]*$")
+_CASE_ID_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+_RUN_ID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+_RFC3339_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$"
+)
+
+_LIMITATIONS = [
+    (
+        "ActiveGraph strict replay checks behavior execution boundaries but "
+        "does not prove arbitrary nested payload equality."
+    ),
+    (
+        "This canary is offline, SQLite-backed, and single-writer; it does "
+        "not validate a production NodeBench integration."
+    ),
+    (
+        "Upstream ActiveGraph issue #67 blocks system-of-record use until "
+        "accepted nested payloads are protected from caller mutation."
+    ),
+    (
+        "This synthetic golden case characterizes fork/diff mechanics only; "
+        "canonical NodeKit export replay is evaluated by the separate offline "
+        "replay lane."
+    ),
+]
+
+
+class DeterministicRunIDGen(IDGen):
+    """Use one configured run ID for the single fork created by this canary."""
+
+    def __init__(self, fork_run_id: str) -> None:
+        super().__init__()
+        self._fork_run_id = fork_run_id
+        self._issued = False
+
+    def run(self) -> str:
+        if self._issued:
+            raise RuntimeError(
+                "DeterministicRunIDGen is configured for exactly one fork run"
+            )
+        self._issued = True
+        return self._fork_run_id
+
+
+def run_canary(input_doc: dict[str, Any], db_path: Path) -> dict[str, Any]:
+    """Run one deterministic baseline/fork graph-hop comparison.
+
+    ``input_doc`` is deep-copied before validation and never mutated. ``db_path``
+    must not already exist because a canary database is immutable evidence for
+    one invocation.
+    """
+
+    if type(input_doc) is not dict:
+        raise ValueError("input must be a JSON object")
+    if not isinstance(db_path, Path):
+        raise TypeError("db_path must be a pathlib.Path")
+    if activegraph.__version__ != ACTIVEGRAPH_VERSION:
+        raise RuntimeError(
+            "ActiveGraph version mismatch: "
+            f"expected {ACTIVEGRAPH_VERSION}, got {activegraph.__version__}"
+        )
+
+    document = deepcopy(input_doc)
+    _validate_input(document)
+    input_sha256 = canonical_sha256(document)
+
+    if db_path.exists():
+        raise ValueError(f"db_path already exists: {db_path}")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    determinism = document["determinism"]
+    timestamp_iso = _normalize_rfc3339_for_clock(
+        determinism["timestamp_iso"]
+    )
+    baseline_policy = document["policies"]["baseline"]
+    variant_policy = document["policies"]["variant"]
+
+    parent_runtime: Runtime | None = None
+    fork_runtime: Runtime | None = None
+    reloaded_parent_runtime: Runtime | None = None
+    reloaded_fork_runtime: Runtime | None = None
+    try:
+        ids = DeterministicRunIDGen(determinism["fork_run_id"])
+        parent_graph = Graph(
+            ids=ids,
+            clock=FrozenClock(timestamp_iso),
+            run_id=determinism["parent_run_id"],
+        )
+        parent_runtime = Runtime(
+            parent_graph,
+            behaviors=[_selection_behavior(baseline_policy)],
+            persist_to=str(db_path),
+            seed=0,
+            trace_context_reads=True,
+        )
+
+        evaluation_request = _materialize_topology(parent_graph, document)
+        fork_event = parent_graph.events[-1]
+
+        fork_runtime = parent_runtime.fork(
+            at_event=fork_event.id,
+            label="graph-hop-policy-variant",
+            behaviors=[_selection_behavior(variant_policy)],
+        )
+        # Runtime.fork reconstructs a Graph with its default wall clock.
+        # Replace it before any queued behavior is allowed to run.
+        fork_runtime.graph.clock = FrozenClock(timestamp_iso)
+
+        parent_runtime.run_until_idle()
+        fork_runtime.run_until_idle()
+
+        activegraph_diff = parent_runtime.diff(fork_runtime)
+        normalized_diff = _normalize_diff(activegraph_diff)
+        baseline_run = _summarize_run(parent_runtime, baseline_policy)
+        variant_run = _summarize_run(fork_runtime, variant_policy)
+
+        assertions = _build_assertions(
+            document=document,
+            baseline_runtime=parent_runtime,
+            fork_runtime=fork_runtime,
+            baseline_run=baseline_run,
+            variant_run=variant_run,
+            normalized_diff=normalized_diff,
+        )
+
+        live_fingerprints = {
+            "baseline": _event_log_fingerprint(parent_runtime),
+            "variant": _event_log_fingerprint(fork_runtime),
+        }
+        # Prove the stored log can reconstruct both projections from fresh
+        # Runtime instances. Close the live writers first so this exercises
+        # the same handle boundary callers encounter on Windows.
+        _close_runtime_store(fork_runtime)
+        _close_runtime_store(parent_runtime)
+        reloaded_parent_runtime = Runtime.load(
+            str(db_path),
+            run_id=parent_runtime.run_id,
+            behaviors=[],
+            seed=0,
+            trace_context_reads=True,
+        )
+        reloaded_fork_runtime = Runtime.load(
+            str(db_path),
+            run_id=fork_runtime.run_id,
+            behaviors=[],
+            seed=0,
+            trace_context_reads=True,
+        )
+        reloaded_fingerprints = {
+            "baseline": _event_log_fingerprint(reloaded_parent_runtime),
+            "variant": _event_log_fingerprint(reloaded_fork_runtime),
+        }
+        assertions.append(
+            _assertion(
+                "persisted-reload-parity",
+                live_fingerprints,
+                reloaded_fingerprints,
+            )
+        )
+
+        return {
+            "schema_version": OUTPUT_SCHEMA_VERSION,
+            "activegraph": {
+                "version": ACTIVEGRAPH_VERSION,
+                "inspected_ref": ACTIVEGRAPH_INSPECTED_REF,
+            },
+            "case_id": document["case_id"],
+            "input_sha256": input_sha256,
+            "fork_point": {
+                "event_id": fork_event.id,
+                "event_type": fork_event.type,
+                "object_id": evaluation_request.id,
+            },
+            "runs": {
+                "baseline": baseline_run,
+                "variant": variant_run,
+            },
+            "diff": normalized_diff,
+            "assertions": assertions,
+            "verdict": (
+                "pass" if all(assertion["passed"] for assertion in assertions)
+                else "fail"
+            ),
+            "limitations": list(_LIMITATIONS),
+        }
+    finally:
+        # Each runtime owns a distinct SQLite connection to the same file.
+        # Close the fork first, then the parent, so Windows releases every
+        # handle before the caller moves or deletes the artifact.
+        for runtime in (
+            reloaded_fork_runtime,
+            reloaded_parent_runtime,
+            fork_runtime,
+            parent_runtime,
+        ):
+            if runtime is None:
+                continue
+            _close_runtime_store(runtime)
+
+
+def inspect_payload_isolation(
+    input_doc: dict[str, Any],
+    db_path: Path,
+) -> dict[str, Any]:
+    """Exercise the adapter's deepcopy boundary while the live graph is open.
+
+    The helper mutates an internal caller-side copy after emitting a separate
+    deepcopy, then returns the accepted live, persisted, and reloaded candidate
+    payloads. It makes the upstream issue #67 boundary observable without
+    exposing a live Runtime or mutating the caller's document.
+    """
+
+    if type(input_doc) is not dict:
+        raise ValueError("input must be a JSON object")
+    if not isinstance(db_path, Path):
+        raise TypeError("db_path must be a pathlib.Path")
+    if activegraph.__version__ != ACTIVEGRAPH_VERSION:
+        raise RuntimeError(
+            "ActiveGraph version mismatch: "
+            f"expected {ACTIVEGRAPH_VERSION}, got {activegraph.__version__}"
+        )
+    document = deepcopy(input_doc)
+    _validate_input(document)
+    if db_path.exists():
+        raise ValueError(f"db_path already exists: {db_path}")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    caller_side_candidate = deepcopy(
+        sorted(
+            document["candidates"],
+            key=lambda candidate: candidate["candidate_id"],
+        )[0]
+    )
+    expected_candidate = deepcopy(caller_side_candidate)
+    live_runtime: Runtime | None = None
+    reloaded_runtime: Runtime | None = None
+    persisted_store: Any = None
+    try:
+        graph = Graph(
+            clock=FrozenClock(
+                _normalize_rfc3339_for_clock(
+                    document["determinism"]["timestamp_iso"]
+                )
+            ),
+            run_id=document["determinism"]["parent_run_id"],
+        )
+        live_runtime = Runtime(
+            graph,
+            behaviors=[],
+            persist_to=str(db_path),
+            seed=0,
+        )
+        candidate_object = graph.add_object(
+            "candidate",
+            deepcopy(caller_side_candidate),
+        )
+
+        # This is the caller-accessible object. Mutating it while the graph is
+        # live must not alter the separate payload passed across our boundary.
+        caller_side_candidate["label"] = "mutated after emit"
+        caller_side_candidate["hop_path"][0][
+            "evidence_id"
+        ] = "mutation:must-not-cross-boundary"
+
+        live_event = next(
+            event
+            for event in graph.events
+            if event.type == "object.created"
+            and event.payload["object"]["id"] == candidate_object.id
+        )
+        live_event_candidate = deepcopy(
+            live_event.payload["object"]["data"]
+        )
+        projected = graph.get_object(candidate_object.id)
+        if projected is None:
+            raise RuntimeError("live candidate projection is missing")
+        live_projection_candidate = deepcopy(projected.data)
+
+        from activegraph import SQLiteEventStore
+
+        persisted_store = SQLiteEventStore(
+            str(db_path),
+            run_id=live_runtime.run_id,
+        )
+        persisted_event = next(
+            event
+            for event in persisted_store.iter_events()
+            if event.type == "object.created"
+            and event.payload["object"]["id"] == candidate_object.id
+        )
+        persisted_event_candidate = deepcopy(
+            persisted_event.payload["object"]["data"]
+        )
+        persisted_store.close()
+        persisted_store = None
+
+        _close_runtime_store(live_runtime)
+        reloaded_runtime = Runtime.load(
+            str(db_path),
+            run_id=live_runtime.run_id,
+            behaviors=[],
+            seed=0,
+        )
+        reloaded = reloaded_runtime.graph.get_object(candidate_object.id)
+        if reloaded is None:
+            raise RuntimeError("reloaded candidate projection is missing")
+
+        return {
+            "expected_candidate": expected_candidate,
+            "live_event_candidate": live_event_candidate,
+            "live_projection_candidate": live_projection_candidate,
+            "persisted_event_candidate": persisted_event_candidate,
+            "reloaded_projection_candidate": deepcopy(reloaded.data),
+        }
+    finally:
+        if reloaded_runtime is not None:
+            _close_runtime_store(reloaded_runtime)
+        if persisted_store is not None:
+            persisted_store.close()
+        if live_runtime is not None:
+            _close_runtime_store(live_runtime)
+
+
+def _selection_behavior(policy_input: dict[str, Any]) -> Behavior:
+    policy = deepcopy(policy_input)
+
+    def select_candidate(event: Any, graph: Any, ctx: Any) -> None:
+        query_id = event.payload["object"]["data"]["query_id"]
+        query_objects = sorted(
+            ctx.view.objects(type="query"),
+            key=lambda query: query.data["query_id"],
+        )
+        matching_queries = [
+            query for query in query_objects if query.data["query_id"] == query_id
+        ]
+        if len(matching_queries) != 1:
+            raise RuntimeError(
+                f"expected one query object for {query_id!r}, "
+                f"found {len(matching_queries)}"
+            )
+        query_object = matching_queries[0]
+        candidate_objects = sorted(
+            ctx.view.objects(type="candidate"),
+            key=lambda candidate: candidate.data["candidate_id"],
+        )
+        hop_objects = sorted(
+            ctx.view.objects(type="hop_evidence"),
+            key=lambda hop: hop.data["hop_id"],
+        )
+        topology_objects = {
+            item.id: item
+            for item in [query_object, *candidate_objects, *hop_objects]
+        }
+        hop_relations = ctx.view.relations(type="graph_hop")
+        weights = policy["weights_bp"]
+        candidates_by_id = {
+            candidate.data["candidate_id"]: candidate
+            for candidate in candidate_objects
+        }
+        graph_evidence = [
+            _traverse_graph_evidence(
+                query_object=query_object,
+                candidate_object=candidate,
+                hop_relations=hop_relations,
+                topology_objects=topology_objects,
+            )
+            for candidate in candidate_objects
+        ]
+        evidence_by_candidate = {
+            item["candidate_id"]: item for item in graph_evidence
+        }
+        ranking = []
+        for candidate in candidate_objects:
+            candidate_id = candidate.data["candidate_id"]
+            score_values = {
+                "semantic_score_bp": candidate.data["semantic_score_bp"],
+                "graph_score_bp": evidence_by_candidate[candidate_id][
+                    "graph_score_bp"
+                ],
+                "source_quality_bp": candidate.data["source_quality_bp"],
+            }
+            ranking.append(
+                {
+                    "candidate_id": candidate_id,
+                    "score_bp": (
+                        sum(
+                            score_values[field] * weights[field]
+                            for field in _SCORE_FIELDS
+                        )
+                        // 10_000
+                    ),
+                }
+            )
+        ranking.sort(
+            key=lambda entry: (-entry["score_bp"], entry["candidate_id"])
+        )
+        winner_candidate_id = ranking[0]["candidate_id"]
+        decision = graph.add_object(
+            "decision",
+            {
+                "policy_id": policy["policy_id"],
+                "winner_candidate_id": winner_candidate_id,
+                "ranked": deepcopy(ranking),
+                "weights_bp": deepcopy(weights),
+                "graph_evidence": deepcopy(graph_evidence),
+            },
+        )
+        graph.add_relation(
+            decision.id,
+            candidates_by_id[winner_candidate_id].id,
+            "selects",
+            {"candidate_id": winner_candidate_id},
+        )
+        graph.emit(
+            "graph_hop.completed",
+            {
+                "policy_id": policy["policy_id"],
+                "decision_id": decision.id,
+                "winner_candidate_id": winner_candidate_id,
+                "graph_score_bp": evidence_by_candidate[winner_candidate_id][
+                    "graph_score_bp"
+                ],
+                "relation_ids": deepcopy(
+                    evidence_by_candidate[winner_candidate_id]["relation_ids"]
+                ),
+            },
+        )
+
+    return Behavior(
+        name="graph_hop_selector",
+        fn=select_candidate,
+        on=["object.created"],
+        where={"object.type": "evaluation_request"},
+        view_spec={
+            "include_types": [
+                "query",
+                "candidate",
+                "hop_evidence",
+                "evaluation_request",
+            ],
+            "recent_events": 50,
+        },
+        creates=["decision"],
+    )
+
+
+def _materialize_topology(graph: Graph, document: dict[str, Any]) -> Any:
+    """Project explicit hop edges into graph objects and relations."""
+
+    query = graph.add_object("query", deepcopy(document["query"]))
+    candidates = sorted(
+        document["candidates"],
+        key=lambda candidate: candidate["candidate_id"],
+    )
+    candidate_objects: dict[str, Any] = {}
+    for candidate in candidates:
+        candidate_objects[candidate["candidate_id"]] = graph.add_object(
+            "candidate",
+            {
+                "candidate_id": candidate["candidate_id"],
+                "label": candidate["label"],
+                "semantic_score_bp": candidate["semantic_score_bp"],
+                "source_quality_bp": candidate["source_quality_bp"],
+            },
+        )
+
+    endpoint_objects = {
+        f"query:{document['query']['query_id']}": query,
+        **{
+            f"candidate:{candidate_id}": candidate_object
+            for candidate_id, candidate_object in candidate_objects.items()
+        },
+    }
+    intermediate_ids = sorted(
+        {
+            endpoint_id
+            for candidate in candidates
+            for edge in candidate["hop_path"]
+            for endpoint_id in (edge["source_id"], edge["target_id"])
+            if endpoint_id not in endpoint_objects
+        }
+    )
+    for hop_id in intermediate_ids:
+        endpoint_objects[hop_id] = graph.add_object(
+            "hop_evidence",
+            {"hop_id": hop_id},
+        )
+
+    for candidate in candidates:
+        for ordinal, edge in enumerate(candidate["hop_path"]):
+            graph.add_relation(
+                endpoint_objects[edge["source_id"]].id,
+                endpoint_objects[edge["target_id"]].id,
+                "graph_hop",
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "ordinal": ordinal,
+                    "evidence_id": edge["evidence_id"],
+                    "graph_score_bp": edge["graph_score_bp"],
+                },
+            )
+
+    return graph.add_object(
+        "evaluation_request",
+        {"query_id": document["query"]["query_id"]},
+    )
+
+
+def _traverse_graph_evidence(
+    *,
+    query_object: Any,
+    candidate_object: Any,
+    hop_relations: list[Any],
+    topology_objects: dict[str, Any],
+) -> dict[str, Any]:
+    """Walk one candidate's ordered path and derive its graph score."""
+
+    candidate_id = candidate_object.data["candidate_id"]
+    relations = sorted(
+        [
+            relation
+            for relation in hop_relations
+            if relation.data.get("candidate_id") == candidate_id
+        ],
+        key=lambda relation: relation.data.get("ordinal", -1),
+    )
+    if not relations:
+        raise RuntimeError(f"candidate {candidate_id!r} has no graph_hop path")
+
+    current_object_id = query_object.id
+    node_ids = [current_object_id]
+    relation_ids: list[str] = []
+    evidence_ids: list[str] = []
+    graph_scores: list[int] = []
+    for expected_ordinal, relation in enumerate(relations):
+        if relation.data.get("ordinal") != expected_ordinal:
+            raise RuntimeError(
+                f"candidate {candidate_id!r} has a non-contiguous hop ordinal"
+            )
+        if relation.source != current_object_id:
+            raise RuntimeError(
+                f"candidate {candidate_id!r} has a disconnected graph_hop path"
+            )
+        if relation.target not in topology_objects:
+            raise RuntimeError(
+                f"candidate {candidate_id!r} targets an unknown hop object"
+            )
+        current_object_id = relation.target
+        node_ids.append(current_object_id)
+        relation_ids.append(relation.id)
+        evidence_ids.append(relation.data["evidence_id"])
+        graph_scores.append(relation.data["graph_score_bp"])
+
+    if current_object_id != candidate_object.id:
+        raise RuntimeError(
+            f"candidate {candidate_id!r} graph_hop path does not terminate "
+            "at its candidate object"
+        )
+    unique_scores = set(graph_scores)
+    if len(unique_scores) != 1:
+        raise RuntimeError(
+            f"candidate {candidate_id!r} graph_hop edges disagree on score"
+        )
+
+    return {
+        "candidate_id": candidate_id,
+        "graph_score_bp": graph_scores[0],
+        "node_ids": node_ids,
+        "relation_ids": relation_ids,
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _summarize_run(
+    runtime: Runtime,
+    policy: dict[str, Any],
+) -> dict[str, Any]:
+    decisions = [
+        obj for obj in runtime.graph.all_objects() if obj.type == "decision"
+    ]
+    if len(decisions) != 1:
+        raise RuntimeError(
+            f"expected exactly one decision object, found {len(decisions)}"
+        )
+    decision_data = decisions[0].data
+    event_envelopes = [deepcopy(event.to_dict()) for event in runtime.graph.events]
+    return {
+        "run_id": runtime.run_id,
+        "policy_id": policy["policy_id"],
+        "winner_candidate_id": decision_data["winner_candidate_id"],
+        "ranking": deepcopy(decision_data["ranked"]),
+        "weights_bp": deepcopy(decision_data["weights_bp"]),
+        "event_count": len(event_envelopes),
+        "event_log_sha256": canonical_sha256(event_envelopes),
+    }
+
+
+def _normalize_diff(diff: Any) -> dict[str, Any]:
+    def event_summary(event: Any) -> dict[str, str]:
+        return {"id": event.id, "type": event.type}
+
+    divergent_objects = [
+        {
+            "id": item.id,
+            "in_parent": deepcopy(item.in_parent),
+            "in_fork": deepcopy(item.in_fork),
+        }
+        for item in sorted(diff.divergent_objects, key=lambda item: item.id)
+    ]
+    divergent_relations = [
+        {
+            "id": item.id,
+            "in_parent": deepcopy(item.in_parent),
+            "in_fork": deepcopy(item.in_fork),
+        }
+        for item in sorted(diff.divergent_relations, key=lambda item: item.id)
+    ]
+    decision_entries = [
+        item
+        for item in divergent_objects
+        if (item["in_parent"] or item["in_fork"] or {}).get("type") == "decision"
+    ]
+    if len(decision_entries) != 1:
+        raise RuntimeError(
+            "expected exactly one divergent decision for decision_delta"
+        )
+    decision_entry = decision_entries[0]
+
+    return {
+        "is_identical": bool(diff.is_identical),
+        "shared_events": [event_summary(event) for event in diff.shared_events],
+        "parent_only_events": [
+            event_summary(event) for event in diff.parent_only_events
+        ],
+        "fork_only_events": [
+            event_summary(event) for event in diff.fork_only_events
+        ],
+        "divergent_objects": divergent_objects,
+        "divergent_relations": divergent_relations,
+        "decision_delta": {
+            "baseline": _decision_result_from_snapshot(
+                decision_entry["in_parent"]
+            ),
+            "variant": _decision_result_from_snapshot(
+                decision_entry["in_fork"]
+            ),
+        },
+    }
+
+
+def _decision_result_from_snapshot(
+    decision_snapshot: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if decision_snapshot is None:
+        return None
+    data = decision_snapshot["data"]
+    return {
+        "policy_id": data["policy_id"],
+        "winner_candidate_id": data["winner_candidate_id"],
+        "ranking": deepcopy(data["ranked"]),
+        "weights_bp": deepcopy(data["weights_bp"]),
+        "graph_evidence": deepcopy(data["graph_evidence"]),
+    }
+
+
+def _build_assertions(
+    *,
+    document: dict[str, Any],
+    baseline_runtime: Runtime,
+    fork_runtime: Runtime,
+    baseline_run: dict[str, Any],
+    variant_run: dict[str, Any],
+    normalized_diff: dict[str, Any],
+) -> list[dict[str, Any]]:
+    candidate_count = len(document["candidates"])
+    intermediate_ids = _intermediate_hop_ids(document)
+    intermediate_count = len(intermediate_ids)
+    hop_relation_count = sum(
+        len(candidate["hop_path"]) for candidate in document["candidates"]
+    )
+    seed_object_count = candidate_count + intermediate_count + 2
+    seed_event_count = seed_object_count + hop_relation_count
+    expected_event_count = seed_event_count + 7
+    decision_object_id = f"decision#{seed_object_count + 1}"
+    selection_relation_id = f"rel_{hop_relation_count + 1:03d}"
+
+    expected_winners = {
+        "baseline": document["expected"]["baseline_winner_id"],
+        "variant": document["expected"]["variant_winner_id"],
+    }
+    actual_winners = {
+        "baseline": baseline_run["winner_candidate_id"],
+        "variant": variant_run["winner_candidate_id"],
+    }
+
+    expected_counts = {
+        "baseline": expected_event_count,
+        "variant": expected_event_count,
+    }
+    actual_counts = {
+        "baseline": baseline_run["event_count"],
+        "variant": variant_run["event_count"],
+    }
+
+    expected_tail = [
+        {"id": _event_id(seed_event_count + 2), "type": "object.created"},
+        {"id": _event_id(seed_event_count + 3), "type": "relation.created"},
+        {
+            "id": _event_id(seed_event_count + 4),
+            "type": "graph_hop.completed",
+        },
+        {"id": _event_id(seed_event_count + 6), "type": "context.read"},
+    ]
+    seed_topology_object_events = candidate_count + intermediate_count + 1
+    expected_shared_events = [
+        {"id": _event_id(index), "type": "object.created"}
+        for index in range(1, seed_topology_object_events + 1)
+    ]
+    expected_shared_events.extend(
+        {
+            "id": _event_id(index),
+            "type": "relation.created",
+        }
+        for index in range(
+            seed_topology_object_events + 1,
+            seed_topology_object_events + hop_relation_count + 1,
+        )
+    )
+    expected_shared_events.append(
+        {"id": _event_id(seed_event_count), "type": "object.created"}
+    )
+    expected_diff_summary = {
+        "is_identical": False,
+        "shared_events": expected_shared_events,
+        "parent_only_events": expected_tail,
+        "fork_only_events": expected_tail,
+        "divergent_object_ids": [decision_object_id],
+        "divergent_relation_ids": [selection_relation_id],
+    }
+    actual_diff_summary = {
+        "is_identical": normalized_diff["is_identical"],
+        "shared_events": normalized_diff["shared_events"],
+        "parent_only_events": normalized_diff["parent_only_events"],
+        "fork_only_events": normalized_diff["fork_only_events"],
+        "divergent_object_ids": [
+            item["id"] for item in normalized_diff["divergent_objects"]
+        ],
+        "divergent_relation_ids": [
+            item["id"] for item in normalized_diff["divergent_relations"]
+        ],
+    }
+
+    topology_read_ids = [
+        "query#1",
+        *[
+            f"candidate#{index}"
+            for index in range(2, candidate_count + 2)
+        ],
+        *[
+            f"hop_evidence#{index}"
+            for index in range(
+                candidate_count + 2,
+                candidate_count + intermediate_count + 2,
+            )
+        ],
+    ]
+    expected_read_sets = {
+        "baseline": topology_read_ids,
+        "variant": topology_read_ids,
+    }
+    actual_read_sets = {
+        "baseline": _context_read_object_ids(baseline_runtime),
+        "variant": _context_read_object_ids(fork_runtime),
+    }
+
+    runtime_errors = {
+        "baseline": _runtime_errors(baseline_runtime),
+        "variant": _runtime_errors(fork_runtime),
+    }
+    expected_graph_evidence = _expected_graph_evidence(document)
+    actual_graph_evidence = {
+        lane: normalized_diff["decision_delta"][lane]["graph_evidence"]
+        for lane in ("baseline", "variant")
+    }
+
+    return [
+        _assertion(
+            "expected-winners",
+            expected_winners,
+            actual_winners,
+        ),
+        _assertion("event-counts", expected_counts, actual_counts),
+        _assertion(
+            "fork-diff",
+            expected_diff_summary,
+            actual_diff_summary,
+        ),
+        _assertion(
+            "graph-topology-traversal",
+            {
+                "baseline": expected_graph_evidence,
+                "variant": expected_graph_evidence,
+            },
+            actual_graph_evidence,
+        ),
+        _assertion(
+            "context-read-set",
+            expected_read_sets,
+            actual_read_sets,
+        ),
+        _assertion(
+            "no-runtime-errors",
+            {"baseline": [], "variant": []},
+            runtime_errors,
+        ),
+    ]
+
+
+def _intermediate_hop_ids(document: dict[str, Any]) -> list[str]:
+    endpoint_ids = {
+        f"query:{document['query']['query_id']}",
+        *{
+            f"candidate:{candidate['candidate_id']}"
+            for candidate in document["candidates"]
+        },
+    }
+    return sorted(
+        {
+            endpoint_id
+            for candidate in document["candidates"]
+            for edge in candidate["hop_path"]
+            for endpoint_id in (edge["source_id"], edge["target_id"])
+            if endpoint_id not in endpoint_ids
+        }
+    )
+
+
+def _expected_graph_evidence(
+    document: dict[str, Any],
+) -> list[dict[str, Any]]:
+    candidates = sorted(
+        document["candidates"],
+        key=lambda candidate: candidate["candidate_id"],
+    )
+    candidate_count = len(candidates)
+    intermediate_ids = _intermediate_hop_ids(document)
+    endpoint_object_ids = {
+        f"query:{document['query']['query_id']}": "query#1",
+        **{
+            f"candidate:{candidate['candidate_id']}": f"candidate#{index}"
+            for index, candidate in enumerate(candidates, start=2)
+        },
+        **{
+            hop_id: f"hop_evidence#{index}"
+            for index, hop_id in enumerate(
+                intermediate_ids,
+                start=candidate_count + 2,
+            )
+        },
+    }
+    relation_number = 1
+    expected: list[dict[str, Any]] = []
+    for candidate in candidates:
+        path = candidate["hop_path"]
+        relation_ids = []
+        for _edge in path:
+            relation_ids.append(f"rel_{relation_number:03d}")
+            relation_number += 1
+        expected.append(
+            {
+                "candidate_id": candidate["candidate_id"],
+                "graph_score_bp": path[0]["graph_score_bp"],
+                "node_ids": [
+                    endpoint_object_ids[path[0]["source_id"]],
+                    *[
+                        endpoint_object_ids[edge["target_id"]]
+                        for edge in path
+                    ],
+                ],
+                "relation_ids": relation_ids,
+                "evidence_ids": [
+                    edge["evidence_id"] for edge in path
+                ],
+            }
+        )
+    return expected
+
+
+def _assertion(name: str, expected: Any, actual: Any) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": actual == expected,
+        "expected": expected,
+        "actual": actual,
+    }
+
+
+def _context_read_object_ids(runtime: Runtime) -> list[str]:
+    events = [
+        event for event in runtime.graph.events if event.type == "context.read"
+    ]
+    if len(events) != 1:
+        return []
+    return list(events[0].payload.get("object_ids", []))
+
+
+def _runtime_errors(runtime: Runtime) -> list[dict[str, str]]:
+    return [
+        {
+            "behavior": failure.behavior,
+            "event_id": failure.event_id,
+            "exception_type": failure.exception_type,
+            "message": failure.message,
+        }
+        for failure in runtime.errors
+    ]
+
+
+def _event_log_fingerprint(runtime: Runtime) -> dict[str, Any]:
+    envelopes = [deepcopy(event.to_dict()) for event in runtime.graph.events]
+    projection = _projection_snapshot(runtime)
+    decisions = projection["decisions"]
+    if len(decisions) != 1:
+        raise RuntimeError(
+            f"expected one projected decision, found {len(decisions)}"
+        )
+    return {
+        "event_count": len(envelopes),
+        "event_log_sha256": canonical_sha256(envelopes),
+        "projection": projection,
+        "result": _decision_result_from_snapshot(decisions[0]),
+    }
+
+
+def _projection_snapshot(runtime: Runtime) -> dict[str, Any]:
+    decisions = sorted(
+        (
+            _normalize_object_snapshot(obj)
+            for obj in runtime.graph.all_objects()
+            if obj.type == "decision"
+        ),
+        key=lambda item: item["id"],
+    )
+    selects_relations = sorted(
+        (
+            _normalize_relation_snapshot(relation)
+            for relation in runtime.graph.all_relations()
+            if relation.type == "selects"
+        ),
+        key=lambda item: item["id"],
+    )
+    return {
+        "decisions": decisions,
+        "selects_relations": selects_relations,
+    }
+
+
+def _normalize_object_snapshot(obj: Any) -> dict[str, Any]:
+    snapshot = deepcopy(obj.to_dict())
+    snapshot.pop("provenance", None)
+    return snapshot
+
+
+def _normalize_relation_snapshot(relation: Any) -> dict[str, Any]:
+    snapshot = deepcopy(relation.to_dict())
+    snapshot.pop("provenance", None)
+    return snapshot
+
+
+def _close_runtime_store(runtime: Runtime) -> None:
+    store = runtime.graph.store
+    if store is not None:
+        store.close()
+
+
+def _event_id(number: int) -> str:
+    return f"evt_{number:03d}"
+
+
+def _validate_input(document: dict[str, Any]) -> None:
+    _expect_keys(
+        document,
+        "$",
+        {
+            "schema_version",
+            "case_id",
+            "determinism",
+            "query",
+            "candidates",
+            "policies",
+            "expected",
+        },
+    )
+    if document["schema_version"] != INPUT_SCHEMA_VERSION:
+        raise ValueError(
+            f"$.schema_version must equal {INPUT_SCHEMA_VERSION!r}"
+        )
+    _expect_string(document["case_id"], "$.case_id", pattern=_CASE_ID_RE)
+
+    determinism = _expect_mapping(document["determinism"], "$.determinism")
+    _expect_keys(
+        determinism,
+        "$.determinism",
+        {"timestamp_iso", "parent_run_id", "fork_run_id"},
+    )
+    _expect_timestamp(determinism["timestamp_iso"], "$.determinism.timestamp_iso")
+    parent_run_id = _expect_string(
+        determinism["parent_run_id"],
+        "$.determinism.parent_run_id",
+        pattern=_RUN_ID_RE,
+    )
+    fork_run_id = _expect_string(
+        determinism["fork_run_id"],
+        "$.determinism.fork_run_id",
+        pattern=_RUN_ID_RE,
+    )
+    if parent_run_id == fork_run_id:
+        raise ValueError("parent_run_id and fork_run_id must be different")
+
+    query = _expect_mapping(document["query"], "$.query")
+    _expect_keys(query, "$.query", {"query_id", "text"})
+    _expect_domain_id(query["query_id"], "$.query.query_id")
+    _expect_string(query["text"], "$.query.text")
+
+    candidates = document["candidates"]
+    if type(candidates) is not list or len(candidates) < 2:
+        raise ValueError("$.candidates must be an array with at least 2 items")
+    candidate_ids: list[str] = []
+    evidence_ids: list[str] = []
+    for index, candidate_value in enumerate(candidates):
+        path = f"$.candidates[{index}]"
+        candidate = _expect_mapping(candidate_value, path)
+        _expect_keys(
+            candidate,
+            path,
+            {
+                "candidate_id",
+                "label",
+                "semantic_score_bp",
+                "source_quality_bp",
+                "hop_path",
+            },
+        )
+        candidate_ids.append(
+            _expect_domain_id(candidate["candidate_id"], f"{path}.candidate_id")
+        )
+        _expect_string(candidate["label"], f"{path}.label")
+        for field in ("semantic_score_bp", "source_quality_bp"):
+            _expect_basis_points(candidate[field], f"{path}.{field}")
+        hop_path = candidate["hop_path"]
+        if type(hop_path) is not list or not hop_path:
+            raise ValueError(f"{path}.hop_path must contain at least 1 edge")
+        expected_source_id = f"query:{query['query_id']}"
+        path_node_ids = [expected_source_id]
+        edge_scores: list[int] = []
+        for edge_index, edge_value in enumerate(hop_path):
+            edge_path = f"{path}.hop_path[{edge_index}]"
+            edge = _expect_mapping(edge_value, edge_path)
+            _expect_keys(
+                edge,
+                edge_path,
+                {
+                    "source_id",
+                    "target_id",
+                    "evidence_id",
+                    "graph_score_bp",
+                },
+            )
+            source_id = _expect_domain_id(
+                edge["source_id"],
+                f"{edge_path}.source_id",
+            )
+            target_id = _expect_domain_id(
+                edge["target_id"],
+                f"{edge_path}.target_id",
+            )
+            evidence_ids.append(
+                _expect_domain_id(
+                    edge["evidence_id"],
+                    f"{edge_path}.evidence_id",
+                )
+            )
+            edge_scores.append(
+                _expect_basis_points(
+                    edge["graph_score_bp"],
+                    f"{edge_path}.graph_score_bp",
+                )
+            )
+            if source_id != expected_source_id:
+                raise ValueError(
+                    f"{edge_path}.source_id must continue the contiguous "
+                    f"hop path from {expected_source_id!r}"
+                )
+            if source_id == target_id:
+                raise ValueError(
+                    f"{edge_path} source_id and target_id must be different"
+                )
+            expected_source_id = target_id
+            path_node_ids.append(target_id)
+        expected_target_id = f"candidate:{candidate['candidate_id']}"
+        if expected_source_id != expected_target_id:
+            raise ValueError(
+                f"{path}.hop_path must terminate at {expected_target_id!r}"
+            )
+        if len(set(edge_scores)) != 1:
+            raise ValueError(
+                f"{path}.hop_path graph_score_bp values must agree"
+            )
+        if len(set(path_node_ids)) != len(path_node_ids):
+            raise ValueError(
+                f"{path}.hop_path must not contain cycles or repeated nodes"
+            )
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("candidate_id values must be unique")
+    if len(set(evidence_ids)) != len(evidence_ids):
+        raise ValueError("evidence_id values must be globally unique")
+    reserved_endpoint_ids = {
+        f"query:{query['query_id']}",
+        *{f"candidate:{candidate_id}" for candidate_id in candidate_ids},
+    }
+    for index, candidate in enumerate(candidates):
+        internal_node_ids = [
+            edge["target_id"] for edge in candidate["hop_path"][:-1]
+        ]
+        reserved_internal_ids = sorted(
+            set(internal_node_ids) & reserved_endpoint_ids
+        )
+        if reserved_internal_ids:
+            raise ValueError(
+                f"$.candidates[{index}].hop_path internal evidence nodes "
+                "must not reuse query or candidate endpoints: "
+                f"{', '.join(reserved_internal_ids)}"
+            )
+
+    policies = _expect_mapping(document["policies"], "$.policies")
+    _expect_keys(policies, "$.policies", {"baseline", "variant"})
+    for lane in ("baseline", "variant"):
+        policy_path = f"$.policies.{lane}"
+        policy = _expect_mapping(policies[lane], policy_path)
+        _expect_keys(policy, policy_path, {"policy_id", "weights_bp"})
+        _expect_domain_id(policy["policy_id"], f"{policy_path}.policy_id")
+        weights_path = f"{policy_path}.weights_bp"
+        weights = _expect_mapping(policy["weights_bp"], weights_path)
+        _expect_keys(weights, weights_path, set(_SCORE_FIELDS))
+        for field in _SCORE_FIELDS:
+            _expect_basis_points(weights[field], f"{weights_path}.{field}")
+        if sum(weights[field] for field in _SCORE_FIELDS) != 10_000:
+            raise ValueError(f"{weights_path} values must total exactly 10000")
+    baseline_policy = policies["baseline"]
+    variant_policy = policies["variant"]
+    if baseline_policy["policy_id"] == variant_policy["policy_id"]:
+        raise ValueError("baseline and variant policy_id values must differ")
+    if baseline_policy["weights_bp"] == variant_policy["weights_bp"]:
+        raise ValueError(
+            "baseline and variant policy weights_bp must differ"
+        )
+
+    expected = _expect_mapping(document["expected"], "$.expected")
+    _expect_keys(
+        expected,
+        "$.expected",
+        {"baseline_winner_id", "variant_winner_id"},
+    )
+    for field in ("baseline_winner_id", "variant_winner_id"):
+        winner_id = _expect_domain_id(expected[field], f"$.expected.{field}")
+        if winner_id not in candidate_ids:
+            raise ValueError(
+                f"$.expected.{field} must reference an existing candidate_id"
+            )
+
+
+def _expect_mapping(value: Any, path: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{path} must be an object")
+    return value
+
+
+def _expect_keys(
+    value: dict[str, Any],
+    path: str,
+    required: set[str],
+) -> None:
+    actual = set(value)
+    missing = sorted(required - actual)
+    extra = sorted(actual - required)
+    if missing:
+        raise ValueError(f"{path} is missing required keys: {', '.join(missing)}")
+    if extra:
+        raise ValueError(f"{path} has unsupported keys: {', '.join(extra)}")
+
+
+def _expect_string(
+    value: Any,
+    path: str,
+    *,
+    pattern: re.Pattern[str] | None = None,
+) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{path} must be a non-empty string")
+    if pattern is not None and pattern.fullmatch(value) is None:
+        raise ValueError(f"{path} has an invalid format")
+    return value
+
+
+def _expect_domain_id(value: Any, path: str) -> str:
+    return _expect_string(value, path, pattern=_DOMAIN_ID_RE)
+
+
+def _expect_basis_points(value: Any, path: str) -> int:
+    if type(value) is not int or not 0 <= value <= 10_000:
+        raise ValueError(f"{path} must be an integer from 0 through 10000")
+    return value
+
+
+def _expect_timestamp(value: Any, path: str) -> str:
+    timestamp = _expect_string(value, path)
+    if _RFC3339_RE.fullmatch(timestamp) is None:
+        raise ValueError(f"{path} must be an RFC 3339 date-time")
+    normalized = timestamp
+    if timestamp.endswith(("Z", "z")):
+        normalized = f"{timestamp[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{path} must be an RFC 3339 date-time") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{path} must include a UTC offset")
+    return timestamp
+
+
+def _normalize_rfc3339_for_clock(timestamp: str) -> str:
+    normalized = f"{timestamp[:10]}T{timestamp[11:]}"
+    if normalized.endswith("z"):
+        normalized = f"{normalized[:-1]}Z"
+    return normalized

--- a/evals/activegraph/tests/conftest.py
+++ b/evals/activegraph/tests/conftest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+EVAL_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = EVAL_DIR / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    assert isinstance(value, dict)
+    return value
+
+
+@pytest.fixture
+def eval_dir() -> Path:
+    return EVAL_DIR
+
+
+@pytest.fixture
+def input_schema(eval_dir: Path) -> dict[str, Any]:
+    return load_json(eval_dir / "schemas" / "graph-hop-input.v1.schema.json")
+
+
+@pytest.fixture
+def output_schema(eval_dir: Path) -> dict[str, Any]:
+    return load_json(eval_dir / "schemas" / "graph-hop-output.v1.schema.json")
+
+
+@pytest.fixture
+def nodekit_export_schema(eval_dir: Path) -> dict[str, Any]:
+    return load_json(eval_dir / "schemas" / "nodekit-run-export.v1.schema.json")
+
+
+@pytest.fixture
+def nodekit_replay_output_schema(eval_dir: Path) -> dict[str, Any]:
+    return load_json(
+        eval_dir / "schemas" / "nodekit-replay-output.v1.schema.json"
+    )
+
+
+@pytest.fixture
+def image_attestation_schema(eval_dir: Path) -> dict[str, Any]:
+    return load_json(
+        eval_dir / "schemas" / "image-attestation.v1.schema.json"
+    )
+
+
+@pytest.fixture
+def upstream_record(eval_dir: Path) -> dict[str, Any]:
+    return load_json(eval_dir / "UPSTREAM.json")
+
+
+@pytest.fixture
+def golden_input(eval_dir: Path) -> dict[str, Any]:
+    return load_json(
+        eval_dir / "fixtures" / "golden-selection-flip.input.v1.json"
+    )

--- a/evals/activegraph/tests/test_canary.py
+++ b/evals/activegraph/tests/test_canary.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from nodebench_activegraph_canary import (
+    canonical_json_bytes,
+    canonical_sha256,
+    inspect_payload_isolation,
+    run_canary,
+)
+
+
+EXPECTED_INPUT_SHA256 = (
+    "41c7bd138518e7235fb5a18594eb5051852ecdc6696bbd0a421da569064ab309"
+)
+BASELINE_WEIGHTS = {
+    "semantic_score_bp": 8000,
+    "graph_score_bp": 1000,
+    "source_quality_bp": 1000,
+}
+VARIANT_WEIGHTS = {
+    "semantic_score_bp": 3000,
+    "graph_score_bp": 6000,
+    "source_quality_bp": 1000,
+}
+GRAPH_EVIDENCE = [
+    {
+        "candidate_id": "cand_a",
+        "graph_score_bp": 3000,
+        "node_ids": ["query#1", "hop_evidence#5", "candidate#2"],
+        "relation_ids": ["rel_001", "rel_002"],
+        "evidence_ids": [
+            "ev_a_query_signal",
+            "ev_a_signal_candidate",
+        ],
+    },
+    {
+        "candidate_id": "cand_b",
+        "graph_score_bp": 9500,
+        "node_ids": ["query#1", "hop_evidence#4", "candidate#3"],
+        "relation_ids": ["rel_003", "rel_004"],
+        "evidence_ids": [
+            "ev_b_query_signal",
+            "ev_b_signal_candidate",
+        ],
+    },
+]
+
+
+def validate_output(
+    output: dict[str, Any],
+    output_schema: dict[str, Any],
+) -> None:
+    Draft202012Validator(
+        output_schema,
+        format_checker=FormatChecker(),
+    ).validate(output)
+
+
+def event_pairs(events: list[dict[str, str]]) -> list[tuple[str, str]]:
+    return [(event["id"], event["type"]) for event in events]
+
+
+def test_canonical_helpers_are_stable(golden_input: dict[str, Any]) -> None:
+    canonical = canonical_json_bytes(golden_input)
+
+    assert canonical.endswith(b"\n")
+    assert b"\r" not in canonical
+    assert canonical_sha256(golden_input) == EXPECTED_INPUT_SHA256
+    assert canonical_sha256(deepcopy(golden_input)) == EXPECTED_INPUT_SHA256
+
+
+def test_golden_selection_flip(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+    output_schema: dict[str, Any],
+) -> None:
+    output = run_canary(golden_input, tmp_path / "golden.sqlite3")
+    validate_output(output, output_schema)
+
+    assert output["schema_version"] == "nodebench.activegraph.graph-hop-output.v1"
+    assert output["case_id"] == "golden-selection-flip"
+    assert output["input_sha256"] == EXPECTED_INPUT_SHA256
+    assert output["activegraph"] == {
+        "version": "1.10.0",
+        "inspected_ref": "8aedb1866cf5dce056af97529152ffd6f468a1ed",
+    }
+    assert output["fork_point"] == {
+        "event_id": "evt_010",
+        "event_type": "object.created",
+        "object_id": "evaluation_request#6",
+    }
+
+    baseline = output["runs"]["baseline"]
+    variant = output["runs"]["variant"]
+    assert baseline["run_id"] == "01J00000000000000000000001"
+    assert baseline["policy_id"] == "semantic_v1"
+    assert baseline["winner_candidate_id"] == "cand_a"
+    assert baseline["ranking"] == [
+        {"candidate_id": "cand_a", "score_bp": 8700},
+        {"candidate_id": "cand_b", "score_bp": 7450},
+    ]
+    assert baseline["weights_bp"] == BASELINE_WEIGHTS
+    assert baseline["event_count"] == 17
+
+    assert variant["run_id"] == "01J00000000000000000000002"
+    assert variant["policy_id"] == "graph_v1"
+    assert variant["winner_candidate_id"] == "cand_b"
+    assert variant["ranking"] == [
+        {"candidate_id": "cand_b", "score_bp": 8700},
+        {"candidate_id": "cand_a", "score_bp": 5450},
+    ]
+    assert variant["weights_bp"] == VARIANT_WEIGHTS
+    assert variant["event_count"] == 17
+    assert baseline["event_log_sha256"] != variant["event_log_sha256"]
+
+    diff = output["diff"]
+    assert diff["is_identical"] is False
+    assert event_pairs(diff["shared_events"]) == [
+        ("evt_001", "object.created"),
+        ("evt_002", "object.created"),
+        ("evt_003", "object.created"),
+        ("evt_004", "object.created"),
+        ("evt_005", "object.created"),
+        ("evt_006", "relation.created"),
+        ("evt_007", "relation.created"),
+        ("evt_008", "relation.created"),
+        ("evt_009", "relation.created"),
+        ("evt_010", "object.created"),
+    ]
+    expected_tail = [
+        ("evt_012", "object.created"),
+        ("evt_013", "relation.created"),
+        ("evt_014", "graph_hop.completed"),
+        ("evt_016", "context.read"),
+    ]
+    assert event_pairs(diff["parent_only_events"]) == expected_tail
+    assert event_pairs(diff["fork_only_events"]) == expected_tail
+    baseline_result = {
+        "policy_id": "semantic_v1",
+        "winner_candidate_id": "cand_a",
+        "ranking": baseline["ranking"],
+        "weights_bp": BASELINE_WEIGHTS,
+        "graph_evidence": GRAPH_EVIDENCE,
+    }
+    variant_result = {
+        "policy_id": "graph_v1",
+        "winner_candidate_id": "cand_b",
+        "ranking": variant["ranking"],
+        "weights_bp": VARIANT_WEIGHTS,
+        "graph_evidence": GRAPH_EVIDENCE,
+    }
+    assert diff["decision_delta"] == {
+        "baseline": baseline_result,
+        "variant": variant_result,
+    }
+    baseline_decision = {
+        "id": "decision#7",
+        "type": "decision",
+        "data": {
+            "policy_id": "semantic_v1",
+            "winner_candidate_id": "cand_a",
+            "ranked": baseline["ranking"],
+            "weights_bp": BASELINE_WEIGHTS,
+            "graph_evidence": GRAPH_EVIDENCE,
+        },
+        "version": 1,
+    }
+    variant_decision = {
+        "id": "decision#7",
+        "type": "decision",
+        "data": {
+            "policy_id": "graph_v1",
+            "winner_candidate_id": "cand_b",
+            "ranked": variant["ranking"],
+            "weights_bp": VARIANT_WEIGHTS,
+            "graph_evidence": GRAPH_EVIDENCE,
+        },
+        "version": 1,
+    }
+    assert diff["divergent_objects"] == [
+        {
+            "id": "decision#7",
+            "in_parent": baseline_decision,
+            "in_fork": variant_decision,
+        }
+    ]
+    baseline_relation = {
+        "id": "rel_005",
+        "source": "decision#7",
+        "target": "candidate#2",
+        "type": "selects",
+        "data": {"candidate_id": "cand_a"},
+    }
+    variant_relation = {
+        "id": "rel_005",
+        "source": "decision#7",
+        "target": "candidate#3",
+        "type": "selects",
+        "data": {"candidate_id": "cand_b"},
+    }
+    assert diff["divergent_relations"] == [
+        {
+            "id": "rel_005",
+            "in_parent": baseline_relation,
+            "in_fork": variant_relation,
+        }
+    ]
+
+    assert output["verdict"] == "pass"
+    assert output["assertions"]
+    assert all(assertion["passed"] for assertion in output["assertions"])
+    assertions_by_name = {
+        assertion["name"]: assertion for assertion in output["assertions"]
+    }
+    traversal = assertions_by_name["graph-topology-traversal"]
+    assert traversal["passed"] is True
+    assert traversal["actual"] == {
+        "baseline": GRAPH_EVIDENCE,
+        "variant": GRAPH_EVIDENCE,
+    }
+    reload_parity = assertions_by_name["persisted-reload-parity"]
+    assert reload_parity["passed"] is True
+    assert reload_parity["actual"] == reload_parity["expected"]
+    for lane, result, decision, relation in (
+        ("baseline", baseline_result, baseline_decision, baseline_relation),
+        ("variant", variant_result, variant_decision, variant_relation),
+    ):
+        fingerprint = reload_parity["actual"][lane]
+        assert fingerprint["event_count"] == 17
+        assert fingerprint["event_log_sha256"] == output["runs"][lane][
+            "event_log_sha256"
+        ]
+        assert fingerprint["projection"] == {
+            "decisions": [decision],
+            "selects_relations": [relation],
+        }
+        assert fingerprint["result"] == result
+    assert output["limitations"]
+    assert (
+        "This synthetic golden case characterizes fork/diff mechanics only; "
+        "canonical NodeKit export replay is evaluated by the separate offline "
+        "replay lane."
+    ) in output["limitations"]
+
+
+def test_repeatability_across_reconstructed_stores(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    first = run_canary(deepcopy(golden_input), tmp_path / "first.sqlite3")
+    second = run_canary(deepcopy(golden_input), tmp_path / "second.sqlite3")
+
+    assert first == second
+    assert (tmp_path / "first.sqlite3").is_file()
+    assert (tmp_path / "second.sqlite3").is_file()
+
+
+def test_runner_does_not_mutate_caller_input(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    caller_input = deepcopy(golden_input)
+    before = deepcopy(caller_input)
+
+    run_canary(caller_input, tmp_path / "no-mutation.sqlite3")
+
+    assert caller_input == before
+
+
+def test_issue_67_containment_covers_live_persisted_and_reloaded_payloads(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    db_path = tmp_path / "payload-isolation.sqlite3"
+    caller_input = deepcopy(golden_input)
+    before = deepcopy(caller_input)
+
+    observed = inspect_payload_isolation(caller_input, db_path)
+
+    assert caller_input == before
+    expected = observed["expected_candidate"]
+    assert expected == before["candidates"][0]
+    assert observed == {
+        "expected_candidate": expected,
+        "live_event_candidate": expected,
+        "live_projection_candidate": expected,
+        "persisted_event_candidate": expected,
+        "reloaded_projection_candidate": expected,
+    }
+    assert db_path.is_file()
+
+
+def test_runner_rejects_weight_sum_other_than_10000(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    malformed = deepcopy(golden_input)
+    malformed["policies"]["variant"]["weights_bp"]["graph_score_bp"] = 5999
+
+    with pytest.raises(ValueError, match="10000"):
+        run_canary(malformed, tmp_path / "bad-weight.sqlite3")
+
+
+def test_runner_rejects_identical_baseline_and_variant_policies(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    malformed = deepcopy(golden_input)
+    malformed["policies"]["variant"] = deepcopy(
+        malformed["policies"]["baseline"]
+    )
+    db_path = tmp_path / "identical-policies.sqlite3"
+
+    with pytest.raises(ValueError, match="baseline|variant|policy"):
+        run_canary(malformed, db_path)
+
+    assert not db_path.exists()
+
+
+def test_runner_rejects_duplicate_candidate_ids(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    malformed = deepcopy(golden_input)
+    malformed["candidates"][1]["candidate_id"] = "cand_a"
+
+    with pytest.raises(ValueError, match="candidate"):
+        run_canary(malformed, tmp_path / "duplicate-id.sqlite3")
+
+
+def test_runner_rejects_schema_invalid_input(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+) -> None:
+    malformed = deepcopy(golden_input)
+    del malformed["query"]["text"]
+
+    with pytest.raises(ValueError, match="query|text|schema"):
+        run_canary(malformed, tmp_path / "invalid-input.sqlite3")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda value: value["candidates"][0].update({"hop_path": []}),
+            "hop_path",
+        ),
+        (
+            lambda value: value["candidates"][0]["hop_path"][1].update(
+                {"source_id": "evidence:disconnected"}
+            ),
+            "contiguous|source",
+        ),
+        (
+            lambda value: value["candidates"][0]["hop_path"][0].update(
+                {"source_id": "query:wrong"}
+            ),
+            "query|source",
+        ),
+        (
+            lambda value: value["candidates"][0]["hop_path"][-1].update(
+                {"target_id": "candidate:wrong"}
+            ),
+            "candidate|target",
+        ),
+        (
+            lambda value: value["candidates"][1]["hop_path"][0].update(
+                {
+                    "evidence_id": value["candidates"][0]["hop_path"][0][
+                        "evidence_id"
+                    ]
+                }
+            ),
+            "evidence",
+        ),
+        (
+            lambda value: value["candidates"][0]["hop_path"][1].update(
+                {"graph_score_bp": 3001}
+            ),
+            "graph_score|agree|common",
+        ),
+    ],
+)
+def test_runner_rejects_invalid_graph_topology(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+    mutation: Any,
+    message: str,
+) -> None:
+    malformed = deepcopy(golden_input)
+    mutation(malformed)
+    db_path = tmp_path / "invalid-topology.sqlite3"
+
+    with pytest.raises(ValueError, match=message):
+        run_canary(malformed, db_path)
+
+    assert not db_path.exists()
+
+
+def test_cli_writes_valid_failed_report_and_exits_nonzero(
+    tmp_path: Path,
+    golden_input: dict[str, Any],
+    output_schema: dict[str, Any],
+    eval_dir: Path,
+) -> None:
+    failing_input = deepcopy(golden_input)
+    failing_input["expected"]["baseline_winner_id"] = "cand_b"
+    input_path = tmp_path / "failing-input.json"
+    output_path = tmp_path / "failed-report.json"
+    db_path = tmp_path / "failed.sqlite3"
+    input_path.write_text(
+        json.dumps(failing_input, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    environment = os.environ.copy()
+    prior_pythonpath = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(eval_dir / "src"),
+            *([prior_pythonpath] if prior_pythonpath else []),
+        ]
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nodebench_activegraph_canary",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--db",
+            str(db_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert completed.returncode == 2
+    assert output_path.is_file()
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    validate_output(report, output_schema)
+    assert report["verdict"] == "fail"
+    winners = next(
+        item for item in report["assertions"] if item["name"] == "expected-winners"
+    )
+    assert winners["passed"] is False

--- a/evals/activegraph/tests/test_contracts.py
+++ b/evals/activegraph/tests/test_contracts.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError
+
+
+def validator(schema: dict[str, Any]) -> Draft202012Validator:
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def test_schemas_are_valid_draft_2020_12(
+    input_schema: dict[str, Any],
+    output_schema: dict[str, Any],
+    image_attestation_schema: dict[str, Any],
+) -> None:
+    Draft202012Validator.check_schema(input_schema)
+    Draft202012Validator.check_schema(output_schema)
+    Draft202012Validator.check_schema(image_attestation_schema)
+
+
+def test_golden_input_matches_schema(
+    input_schema: dict[str, Any],
+    golden_input: dict[str, Any],
+) -> None:
+    validator(input_schema).validate(golden_input)
+    assert golden_input["determinism"]["timestamp_iso"].endswith("z")
+    assert "t" in golden_input["determinism"]["timestamp_iso"]
+    for candidate in golden_input["candidates"]:
+        assert "graph_score_bp" not in candidate
+        assert candidate["hop_path"]
+        assert all(
+            set(edge)
+            == {
+                "source_id",
+                "target_id",
+                "evidence_id",
+                "graph_score_bp",
+            }
+            for edge in candidate["hop_path"]
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_path_fragment"),
+    [
+        (
+            lambda value: value["candidates"].pop(),
+            "candidates",
+        ),
+        (
+            lambda value: value["candidates"][0].update(
+                {"semantic_score_bp": 10001}
+            ),
+            "semantic_score_bp",
+        ),
+        (
+            lambda value: value["determinism"].update(
+                {"parent_run_id": "not-a-run-id"}
+            ),
+            "parent_run_id",
+        ),
+        (
+            lambda value: value.update({"unexpected": True}),
+            "",
+        ),
+        (
+            lambda value: value["candidates"][0].update({"hop_path": []}),
+            "hop_path",
+        ),
+        (
+            lambda value: value["candidates"][0].update(
+                {"graph_score_bp": 3000}
+            ),
+            "candidates.0",
+        ),
+    ],
+)
+def test_input_schema_rejects_malformed_documents(
+    input_schema: dict[str, Any],
+    golden_input: dict[str, Any],
+    mutate: Any,
+    expected_path_fragment: str,
+) -> None:
+    malformed = deepcopy(golden_input)
+    mutate(malformed)
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator(input_schema).validate(malformed)
+
+    rendered_path = ".".join(str(part) for part in exc_info.value.absolute_path)
+    assert expected_path_fragment in rendered_path
+
+
+def test_input_schema_documents_cross_field_runner_invariants(
+    input_schema: dict[str, Any],
+) -> None:
+    description = input_schema["description"]
+    weights_description = input_schema["$defs"]["policy"]["properties"][
+        "weights_bp"
+    ]["description"]
+
+    assert "Candidate and evidence ID uniqueness" in description
+    assert "Graph scores are derived" in description
+    assert "path connectivity and endpoints" in description
+    assert "sum" in description.lower()
+    assert "total exactly 10000" in weights_description
+
+
+def test_output_schema_pins_activegraph_release(
+    output_schema: dict[str, Any],
+) -> None:
+    activegraph = output_schema["properties"]["activegraph"]["properties"]
+
+    assert activegraph["version"]["const"] == "1.10.0"
+    assert (
+        activegraph["inspected_ref"]["const"]
+        == "8aedb1866cf5dce056af97529152ffd6f468a1ed"
+    )
+    required_limitation = output_schema["properties"]["limitations"]["contains"][
+        "const"
+    ]
+    assert "synthetic golden case" in required_limitation
+    assert "separate offline replay lane" in required_limitation
+
+
+def test_upstream_provenance_matches_runtime_contract(
+    upstream_record: dict[str, Any],
+    output_schema: dict[str, Any],
+) -> None:
+    activegraph = output_schema["properties"]["activegraph"]["properties"]
+
+    assert upstream_record["repository"] == (
+        "https://github.com/yoheinakajima/activegraph"
+    )
+    assert upstream_record["pinned_version"] == activegraph["version"]["const"]
+    assert upstream_record["release_tag"] == "v1.10.0"
+    assert (
+        upstream_record["release_commit"]
+        == "148e12c2969f18fa12a1a3c2e75f3affd9aa0616"
+    )
+    assert (
+        upstream_record["annotated_tag_object"]
+        == "3fbcd8fc56a45ae68622d4e2b18a6d5844180527"
+    )
+    assert (
+        upstream_record["inspected_ref"]
+        == activegraph["inspected_ref"]["const"]
+    )
+    assert upstream_record["test_dependencies"] == {
+        "jsonschema": "4.26.0",
+        "pytest": "9.1.1",
+    }
+
+
+def test_requirements_pin_activegraph_release(eval_dir: Path) -> None:
+    requirements = (eval_dir / "requirements.in").read_text(
+        encoding="utf-8"
+    ).splitlines()
+
+    assert requirements == [
+        "activegraph==1.10.0",
+        "jsonschema==4.26.0",
+        "pytest==9.1.1",
+        "rfc8785==0.1.4",
+    ]

--- a/evals/activegraph/tests/test_nodekit_replay.py
+++ b/evals/activegraph/tests/test_nodekit_replay.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from nodebench_activegraph_canary.nodekit_replay import (
+    ACTIVEGRAPH_VERSION,
+    EVENT_SCHEMA_VERSION,
+    EXPORT_SCHEMA_VERSION,
+    GENESIS_HASH,
+    OUTPUT_SCHEMA_VERSION,
+    SAFE_FIELDS_BY_EVENT,
+    SAFE_PAYLOAD_SCHEMA_VERSION,
+    NodeKitReplayContractError,
+    canonical_hash,
+    canonical_json_text,
+    run_nodekit_replay_canary,
+    validate_nodekit_export,
+)
+
+SANDBOX_IMAGE = f"sha256:{'a' * 64}"
+BUILD_INPUTS_HASH = f"sha256:{'b' * 64}"
+UPSTREAM_HASH = f"sha256:{'c' * 64}"
+IMAGE_ATTESTATION_HASH = f"sha256:{'d' * 64}"
+NODEBENCH_CANDIDATE_COMMIT = "e" * 40
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_build_attestation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256",
+        BUILD_INPUTS_HASH,
+    )
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256",
+        UPSTREAM_HASH,
+    )
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_IMAGE_ATTESTATION_SHA256",
+        IMAGE_ATTESTATION_HASH,
+    )
+    monkeypatch.setenv(
+        "NODEBENCH_CANDIDATE_COMMIT",
+        NODEBENCH_CANDIDATE_COMMIT,
+    )
+
+def _safe_payload(event_type: str, source: dict[str, Any]) -> dict[str, Any]:
+    fields = {
+        key: source[key]
+        for key in SAFE_FIELDS_BY_EVENT[event_type]
+        if key in source and type(source[key]) in {str, int, float, bool}
+    }
+    return {
+        "projectionVersion": SAFE_PAYLOAD_SCHEMA_VERSION,
+        "sourceDigest": canonical_hash(source),
+        "sourceBytes": len(canonical_json_text(source).encode("utf-8")),
+        "fields": fields,
+    }
+
+
+def _event(
+    *,
+    run_id: str,
+    sequence: int,
+    event_type: str,
+    recorded_at: int,
+    payload: dict[str, Any],
+    previous_hash: str,
+) -> dict[str, Any]:
+    body = {
+        "contractVersion": EVENT_SCHEMA_VERSION,
+        "runId": run_id,
+        "sequence": sequence,
+        "eventType": event_type,
+        "recordedAt": recorded_at,
+        "payload": _safe_payload(event_type, payload),
+        "previousHash": previous_hash,
+    }
+    return {**body, "contentHash": canonical_hash(body)}
+
+
+def _export() -> dict[str, Any]:
+    run_id = "trace_python_cross_language_contract"
+    started = _event(
+        run_id=run_id,
+        sequence=0,
+        event_type="run.started",
+        recorded_at=1_725_000_000_000,
+        payload={
+            "workflowName": "NodeKit replay",
+            "sessionType": "agent",
+            "sessionStartedAt": 1_724_999_999_000,
+            "nested": {"z": 2, "a": 1},
+        },
+        previous_hash=GENESIS_HASH,
+    )
+    evidence = _event(
+        run_id=run_id,
+        sequence=1,
+        event_type="evidence.attached",
+        recorded_at=1_725_000_000_010,
+        payload={"sourceRefs": [{"label": "source-a"}]},
+        previous_hash=started["contentHash"],
+    )
+    completed = _event(
+        run_id=run_id,
+        sequence=2,
+        event_type="run.completed",
+        recorded_at=1_725_000_000_020,
+        payload={"status": "completed"},
+        previous_hash=evidence["contentHash"],
+    )
+    events = [started, evidence, completed]
+    base = {
+        "schemaVersion": EXPORT_SCHEMA_VERSION,
+        "runId": run_id,
+        "session": {
+            "id": "session-python-contract",
+            "typeAtRunStart": "agent",
+            "startedAt": 1_724_999_999_000,
+        },
+        "trace": {
+            "id": "trace-row-python-contract",
+            "runId": run_id,
+            "workflowName": "NodeKit replay",
+            "status": "completed",
+            "startedAt": 1_725_000_000_000,
+            "endedAt": 1_725_000_000_020,
+        },
+        "events": events,
+        "completeness": {
+            "eventChainComplete": True,
+            "spanLifecycleComplete": True,
+            "contractVersion": EVENT_SCHEMA_VERSION,
+            "eventCount": 3,
+            "firstSequence": 0,
+            "lastSequence": 2,
+            "terminalEventType": "run.completed",
+        },
+        "hashes": {
+            "algorithm": "sha256",
+            "chainHead": completed["contentHash"],
+        },
+    }
+    return {
+        **base,
+        "hashes": {
+            **base["hashes"],
+            "exportHash": canonical_hash(base),
+        },
+    }
+
+
+def _rehash_export(document: dict[str, Any]) -> None:
+    previous_hash = GENESIS_HASH
+    for event in document["events"]:
+        event["previousHash"] = previous_hash
+        event["contentHash"] = canonical_hash(
+            {
+                "contractVersion": event["contractVersion"],
+                "runId": event["runId"],
+                "sequence": event["sequence"],
+                "eventType": event["eventType"],
+                "recordedAt": event["recordedAt"],
+                "payload": event["payload"],
+                "previousHash": event["previousHash"],
+            }
+        )
+        previous_hash = event["contentHash"]
+    document["hashes"]["chainHead"] = previous_hash
+    document["hashes"]["exportHash"] = canonical_hash(
+        {
+            **document,
+            "hashes": {
+                "algorithm": "sha256",
+                "chainHead": previous_hash,
+            },
+        }
+    )
+
+
+def test_nodekit_export_and_report_schemas_are_valid(
+    nodekit_export_schema: dict[str, Any],
+    nodekit_replay_output_schema: dict[str, Any],
+) -> None:
+    Draft202012Validator.check_schema(nodekit_export_schema)
+    Draft202012Validator.check_schema(nodekit_replay_output_schema)
+    Draft202012Validator(nodekit_export_schema).validate(_export())
+
+
+def test_nodekit_export_schema_rejects_terminal_status_contradiction(
+    nodekit_export_schema: dict[str, Any],
+) -> None:
+    document = _export()
+    document["events"][-1]["payload"]["fields"]["status"] = "error"
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(nodekit_export_schema).validate(document)
+
+
+def test_canonical_hash_matches_typescript_for_numeric_and_unicode_edges() -> None:
+    fixture = {
+        "z": -0.0,
+        "tiny": 1e-7,
+        "threshold": 1e-6,
+        "huge": 1e21,
+        "fraction": 0.8,
+        "nested": {"😀": 2, "\ue000": 1},
+    }
+
+    assert canonical_hash(fixture) == (
+        "sha256:d4f50ebd3e2d78d0975c68bafdbdf327"
+        "b64a13c9acddd09cc95a747a1eaa1812"
+    )
+
+
+def test_replay_persists_and_reloads_the_exact_exported_sequence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    nodekit_replay_output_schema: dict[str, Any],
+) -> None:
+    monkeypatch.setenv("NODEBENCH_ACTIVEGRAPH_MODE", "offline-observer")
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE",
+        SANDBOX_IMAGE,
+    )
+    document = _export()
+    original = deepcopy(document)
+    report = run_nodekit_replay_canary(
+        document,
+        tmp_path / "nodekit.sqlite3",
+        _test_only_allow_host_runtime=True,
+    )
+
+    Draft202012Validator(nodekit_replay_output_schema).validate(report)
+    assert document == original
+    assert report["schema_version"] == OUTPUT_SCHEMA_VERSION
+    assert report["activegraph"]["version"] == ACTIVEGRAPH_VERSION
+    assert report["isolation"] == {
+        "runtime": "docker",
+        "image": SANDBOX_IMAGE,
+        "network": "none",
+        "rootFilesystem": "read-only",
+        "writableMount": "/evidence",
+        "buildInputsHash": BUILD_INPUTS_HASH,
+        "nodebenchCandidateCommit": NODEBENCH_CANDIDATE_COMMIT,
+        "upstreamHash": UPSTREAM_HASH,
+        "imageAttestationHash": IMAGE_ATTESTATION_HASH,
+    }
+    assert report["run_id"] == document["runId"]
+    assert report["event_count"] == len(document["events"])
+    assert report["nodekit_chain_head"] == document["hashes"]["chainHead"]
+    assert report["replayed_events_sha256"] == canonical_hash(document["events"])
+    assert report["input_export_sha256"] == document["hashes"]["exportHash"]
+    assert report["persisted_reload_parity"] is True
+    assert report["verdict"] == "pass"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        (
+            lambda value: value["events"][1].update({"sequence": 4}),
+            "sequence_not_contiguous",
+        ),
+        (
+            lambda value: value["events"][1]["payload"].update(
+                {"sourceDigest": f"sha256:{'f' * 64}"}
+            ),
+            "content_hash_mismatch",
+        ),
+        (
+            lambda value: value["events"].pop(),
+            "terminal_event_missing",
+        ),
+        (
+            lambda value: value["trace"].update({"id": "tampered"}),
+            "export_hash_mismatch",
+        ),
+        (
+            lambda value: value["trace"].update(
+                {"reconstructedSummary": "not canonical"}
+            ),
+            "shape_invalid",
+        ),
+        (
+            lambda value: value["trace"].update({"status": "running"}),
+            "run_not_terminal",
+        ),
+    ],
+)
+def test_validation_fails_closed_before_creating_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Any,
+    code: str,
+) -> None:
+    monkeypatch.setenv("NODEBENCH_ACTIVEGRAPH_MODE", "offline-observer")
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE",
+        SANDBOX_IMAGE,
+    )
+    document = _export()
+    mutate(document)
+    db_path = tmp_path / "must-not-exist.sqlite3"
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        run_nodekit_replay_canary(
+            document,
+            db_path,
+            _test_only_allow_host_runtime=True,
+        )
+
+    assert exc_info.value.code == code
+    assert not db_path.exists()
+
+
+def test_replay_requires_explicit_offline_mode_before_any_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NODEBENCH_ACTIVEGRAPH_MODE", raising=False)
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE",
+        SANDBOX_IMAGE,
+    )
+    db_path = tmp_path / "must-not-exist.sqlite3"
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        run_nodekit_replay_canary(
+            _export(),
+            db_path,
+            _test_only_allow_host_runtime=True,
+        )
+
+    assert exc_info.value.code == "offline_mode_required"
+    assert not db_path.exists()
+
+
+def test_replay_requires_immutable_sandbox_image_before_any_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NODEBENCH_ACTIVEGRAPH_MODE", "offline-observer")
+    monkeypatch.delenv(
+        "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE",
+        raising=False,
+    )
+    db_path = tmp_path / "must-not-exist.sqlite3"
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        run_nodekit_replay_canary(
+            _export(),
+            db_path,
+            _test_only_allow_host_runtime=True,
+        )
+
+    assert exc_info.value.code == "sandbox_image_required"
+    assert not db_path.exists()
+
+
+def test_replay_requires_exact_build_attestation_before_any_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NODEBENCH_ACTIVEGRAPH_MODE", "offline-observer")
+    monkeypatch.setenv(
+        "NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE",
+        SANDBOX_IMAGE,
+    )
+    monkeypatch.delenv(
+        "NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256",
+        raising=False,
+    )
+    db_path = tmp_path / "must-not-exist.sqlite3"
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        run_nodekit_replay_canary(
+            _export(),
+            db_path,
+            _test_only_allow_host_runtime=True,
+        )
+
+    assert exc_info.value.code == "image_attestation_required"
+    assert not db_path.exists()
+
+
+def test_validation_rejects_terminal_run_with_open_span() -> None:
+    document = _export()
+    started = document["events"][0]
+    span_started = _event(
+        run_id=document["runId"],
+        sequence=1,
+        event_type="span.started",
+        recorded_at=started["recordedAt"] + 1,
+        payload={"spanId": "span-open"},
+        previous_hash=started["contentHash"],
+    )
+    completed = _event(
+        run_id=document["runId"],
+        sequence=2,
+        event_type="run.completed",
+        recorded_at=started["recordedAt"] + 2,
+        payload={"status": "completed"},
+        previous_hash=span_started["contentHash"],
+    )
+    document["events"] = [started, span_started, completed]
+    document["trace"]["endedAt"] = completed["recordedAt"]
+    document["hashes"]["chainHead"] = completed["contentHash"]
+    document["hashes"]["exportHash"] = canonical_hash(
+        {
+            **document,
+            "hashes": {
+                "algorithm": "sha256",
+                "chainHead": completed["contentHash"],
+            },
+        }
+    )
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        validate_nodekit_export(document)
+
+    assert exc_info.value.code == "span_lifecycle_incomplete"
+
+
+@pytest.mark.parametrize(
+    ("terminal_type", "trace_status", "payload_status"),
+    [
+        ("run.completed", "completed", "error"),
+        ("run.failed", "error", "completed"),
+    ],
+)
+def test_validation_rejects_semantically_contradictory_terminal_payload(
+    terminal_type: str,
+    trace_status: str,
+    payload_status: str,
+) -> None:
+    document = _export()
+    terminal = document["events"][-1]
+    terminal["eventType"] = terminal_type
+    terminal["payload"]["fields"]["status"] = payload_status
+    document["trace"]["status"] = trace_status
+    document["completeness"]["terminalEventType"] = terminal_type
+    _rehash_export(document)
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        validate_nodekit_export(document)
+
+    assert exc_info.value.code == "terminal_status_mismatch"
+
+
+def test_validation_rejects_hash_valid_backward_event_time() -> None:
+    document = _export()
+    document["events"][1]["recordedAt"] = (
+        document["events"][0]["recordedAt"] - 1
+    )
+    _rehash_export(document)
+
+    with pytest.raises(NodeKitReplayContractError) as exc_info:
+        validate_nodekit_export(document)
+
+    assert exc_info.value.code == "recorded_at_not_monotonic"
+
+
+def test_cli_refuses_host_execution_before_writing_outputs(
+    tmp_path: Path,
+    eval_dir: Path,
+) -> None:
+    source_path = tmp_path / "disposable-export.json"
+    output_path = tmp_path / "report.json"
+    db_path = tmp_path / "activegraph.sqlite3"
+    source_path.write_text(
+        json.dumps(_export(), ensure_ascii=False),
+        encoding="utf-8",
+    )
+    before = source_path.read_bytes()
+    environment = os.environ.copy()
+    environment["NODEBENCH_ACTIVEGRAPH_MODE"] = "offline-observer"
+    environment["NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE"] = SANDBOX_IMAGE
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(eval_dir / "src")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nodebench_activegraph_canary.nodekit_replay_cli",
+            "--input",
+            str(source_path),
+            "--output",
+            str(output_path),
+            "--db",
+            str(db_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert completed.returncode != 0
+    assert "sandbox_runtime_required" in completed.stderr
+    assert source_path.read_bytes() == before
+    assert not output_path.exists()
+    assert not db_path.exists()
+
+
+def test_cli_rejects_oversized_input_before_reading_or_writing(
+    tmp_path: Path,
+    eval_dir: Path,
+) -> None:
+    source_path = tmp_path / "oversized-export.json"
+    output_path = tmp_path / "report.json"
+    db_path = tmp_path / "activegraph.sqlite3"
+    source_path.write_bytes(b"{}")
+    with source_path.open("r+b") as handle:
+        handle.truncate(1024 * 1024 + 1)
+    environment = os.environ.copy()
+    environment["NODEBENCH_ACTIVEGRAPH_MODE"] = "offline-observer"
+    environment["NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE"] = SANDBOX_IMAGE
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(eval_dir / "src")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nodebench_activegraph_canary.nodekit_replay_cli",
+            "--input",
+            str(source_path),
+            "--output",
+            str(output_path),
+            "--db",
+            str(db_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert completed.returncode != 0
+    assert "export_too_large" in completed.stderr
+    assert not output_path.exists()
+    assert not db_path.exists()
+
+
+def test_validate_nodekit_export_returns_an_isolated_copy() -> None:
+    source = _export()
+    validated = validate_nodekit_export(source)
+    validated["trace"]["workflowName"] = "caller mutation"
+
+    assert source["trace"]["workflowName"] == "NodeKit replay"

--- a/evals/nodebench-activegraph-canary.json
+++ b/evals/nodebench-activegraph-canary.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "nodeagent.evaluation-binding/v1",
+  "id": "nodebench-activegraph-canary",
+  "status": "offline-shadow",
+  "command": "python -m pytest evals/activegraph/tests -q",
+  "sources": [
+    "backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts",
+    "backend/convex/domains/operations/taskManager/nodeKitRunExport.ts",
+    "backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts",
+    "backend/convex/schema.ts",
+    "scripts/nodekit/runActiveGraphCanary.mjs",
+    "evals/activegraph"
+  ]
+}

--- a/evals/nodebench-conformance.json
+++ b/evals/nodebench-conformance.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "nodeagent.evaluation-binding/v1",
+  "id": "nodebench-conformance",
+  "status": "legacy-mapped",
+  "command": "npx playwright test evals/e2e/ui-contract-runner.spec.ts --project=chromium --workers=1",
+  "sources": [
+    "evals/e2e/ui-contract-runner.spec.ts",
+    "proof/ui-contract/surfaces"
+  ]
+}

--- a/evals/nodebench-entity-intelligence.json
+++ b/evals/nodebench-entity-intelligence.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "nodeagent.evaluation-binding/v1",
+  "id": "nodebench-entity-intelligence",
+  "status": "legacy-mapped",
+  "command": "npx tsx packages/mcp-local/src/benchmarks/searchQualityEval.ts",
+  "sources": ["packages/mcp-local/src/benchmarks/searchQualityEval.ts"]
+}

--- a/evals/nodebench-production.json
+++ b/evals/nodebench-production.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "nodeagent.evaluation-binding/v1",
+  "id": "nodebench-production",
+  "status": "legacy-mapped",
+  "command": "npm run verify-live",
+  "sources": ["scripts/verify-live.ts", "evals/e2e/live-smoke.spec.ts"]
+}

--- a/evals/nodebench-smoke.json
+++ b/evals/nodebench-smoke.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "nodeagent.evaluation-binding/v1",
+  "id": "nodebench-smoke",
+  "status": "legacy-mapped",
+  "command": "npm run dogfood:verify:smoke",
+  "sources": ["scripts/ui/runSegmentedDogfoodVerify.mjs"]
+}

--- a/evidence/activegraph-production-slice/after.txt
+++ b/evidence/activegraph-production-slice/after.txt
@@ -1,0 +1,11 @@
+CHANGE   add canonical NodeKit run export and fail-closed ActiveGraph offline canary
+COMMAND  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts --reporter=dot
+EXIT     0
+
+RUN  v2.1.9 C:/Users/hshum/.codex/worktrees/7899/nodebench-ai
+
+PASS  backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts (15 tests)
+PASS  scripts/__tests__/nodekitActiveGraphCanary.test.ts (8 tests)
+
+Test Files  2 passed (2)
+Tests       23 passed (23)

--- a/evidence/activegraph-production-slice/before.txt
+++ b/evidence/activegraph-production-slice/before.txt
@@ -1,0 +1,11 @@
+CHANGE   add canonical NodeKit run export and fail-closed ActiveGraph offline canary
+COMMAND  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts --reporter=dot
+EXIT     1
+
+RUN  v2.1.9 C:/Users/hshum/.codex/worktrees/7899/nodebench-ai
+
+filter:  backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts, scripts/__tests__/nodekitActiveGraphCanary.test.ts
+include: **/*.{test,spec}.?(c|m)[jt]s?(x)
+exclude: **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*, evals/**, .tmp/**, .nodebench-ref/**, .overstory/**, .claude/worktrees/**, .worktrees/**
+
+No test files found, exiting with code 1

--- a/evidence/activegraph-production-slice/verification.txt
+++ b/evidence/activegraph-production-slice/verification.txt
@@ -1,0 +1,63 @@
+SLICE
+  Canonical owner-scoped NodeKit run export plus fail-closed ActiveGraph
+  offline observer, with selective NodeKit v1 reconciliation from PR #592.
+
+BEFORE / AFTER
+  evidence/activegraph-production-slice/before.txt
+    exact focused command exited 1 because both contract suites were absent.
+  evidence/activegraph-production-slice/after.txt
+    the identical command exited 0 with 23/23 tests passing.
+
+VERIFICATION
+  PASS  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts backend/convex/domains/operations/taskManager/taskManagerOwnership.auth.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts scripts/__tests__/releaseWorkflowContracts.test.ts --reporter=dot
+        4 files passed; 39 tests passed; 3 tests skipped.
+  PASS  .tmp/venvs/activegraph-canary/Scripts/python.exe -m pytest evals/activegraph/tests -q
+        42 tests passed, including real ActiveGraph SQLite persist/reload parity.
+  PASS  npx tsc -p backend/convex --noEmit --pretty false
+  PASS  npx tsc --noEmit --pretty false
+  PASS  npm run build
+        Vite transformed 7,354 modules and generated the PWA. Existing
+        caniuse-lite age and PostCSS from-option warnings were non-blocking.
+  PASS  NodeKit inspect
+        application=nodebench-entity-intelligence
+        backend.functionsDirectory=./backend/convex
+        configHash=79befad12a6fbcc7af51987c337083eba7ff74a352d86255ea90eeac26108063
+        evals=126 packs=1 skills=1
+  PASS  NodeKit doctor
+        node version, nodekit.repo/v1 manifest, catalog, production lifecycle,
+        active support, contract declaration 1/1, and source rules 0/0.
+  PASS  git diff --check
+
+FAIL-CLOSED ENVIRONMENT NOTE
+  docker info --format '{{.ServerVersion}}'
+    exited 1 because the Docker Desktop Linux daemon was not running.
+  No container result is claimed. The production-derived wrapper now requires
+  an immutable Docker image ID/digest and constructs a network-none,
+  read-only-root, capability-dropped, resource-bounded invocation with only the
+  evidence directory writable. Missing Docker fails closed. Python refuses its
+  replay CLI outside Docker. Real ActiveGraph persistence/reload remains proven
+  by the explicit private host unit-test seam.
+
+PR-READY DOCKER FOLLOW-UP (2026-07-28)
+  Docker Desktop was started without installing or changing Docker
+  configuration. The exact committed build metadata for 309c71d8 produced image
+  sha256:56d547ad379e88ed71632ec34692cc79e8908a26f9bac10a58aefabd770f64b3
+  and attestation
+  sha256:c9f736fd412e14ecdf0b60fe3a8e00f27866aa1417e5f8928beaeb1024fb1982.
+  A real 9-event canonical NodeKit export replay passed inside that image with
+  network none, a read-only root, only /evidence writable, and exact SQLite
+  persist/reload parity. The original fail-closed result above remains the
+  truthful result of the earlier capture; it is not rewritten as a pass.
+
+KNOWN TEST-HARNESS LIMITATION
+  The three skipped task-manager integration cases pre-existed this slice's
+  proof path. This checkout has convex-test 0.0.53, whose peer contract requires
+  Convex ^1.32.0, while the repo currently resolves Convex 1.31.5. Import fails
+  because convex/values does not export getConvexSize. The two source guards in
+  that file pass, and the new owner/error/retention boundaries have focused
+  contract and source-guard coverage. Dependencies were not upgraded as part
+  of this isolated integration slice.
+
+SAFETY
+  No Convex deploy, production write, ActiveGraph dual-write, commit, push,
+  merge, or PR creation was performed.

--- a/evidence/activegraph-release-hardening/after.txt
+++ b/evidence/activegraph-release-hardening/after.txt
@@ -1,0 +1,117 @@
+CHANGE
+  Harden the NodeKit run-event/export retention and offline ActiveGraph boundary.
+
+SOURCE STATE
+  Docker anchor commit: 309c71d82e481ac2a2465efbd87644a4a109693f
+  Branch: codex/activegraph-canary
+  No push, merge, Convex deploy, or production mutation was performed during
+  this capture.
+
+ROOT-CAUSE FIXES
+  - Terminal event type and payload status must agree.
+  - Event recordedAt values must be nondecreasing.
+  - Admission reserves enough event capacity to close every open span and append
+    one terminal event, preventing a valid run from becoming unclosable.
+  - Retention starts only at terminal events; expired terminal lookup cannot be
+    starved by legacy nonterminal rows.
+  - Stale running traces close or purge in bounded batches; 300 legacy open spans
+    drain over continuations instead of accumulating forever.
+  - Retention deletes whole owner-verified chains only and stops when a corrupt
+    full batch makes no progress.
+  - Export without canonical history returns run_history_unavailable rather than
+    inferring a legacy trace.
+  - Child execution, source, report, SQLite, and attestation reads are bounded.
+  - Replay is bound to an immutable image digest, canonical build-input hash,
+    candidate commit, pinned ActiveGraph release/tag object, and exact image
+    labels. The local attestation is explicitly not a signed supply-chain proof.
+
+SCENARIO TESTS
+COMMAND
+  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts backend/convex/domains/operations/taskManager/taskManagerOwnership.auth.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts scripts/__tests__/releaseWorkflowContracts.test.ts --reporter=dot --pool=threads --maxWorkers=1 --minWorkers=1
+EXIT
+  0
+RESULT
+  5 files passed; 61 tests passed; 3 integration cases skipped because the
+  checkout's convex-test 0.0.53 peer requires Convex >=1.32 while the repository
+  resolves Convex 1.31.5. The two source guards in that suite pass.
+  Coverage includes owner isolation, whole-chain deletion, corrupt-chain
+  fail-closed behavior, stale closure/purge, multi-continuation span draining,
+  terminal-backlog draining, no-progress termination, terminal/timestamp
+  semantics, input/output/storage bounds, timeout behavior, and image
+  attestation rejection.
+
+PYTHON SCENARIO TESTS
+COMMAND
+  .tmp/venvs/activegraph-canary/Scripts/python.exe -m pytest evals/activegraph/tests -q
+EXIT
+  0
+RESULT
+  48 passed in 1.97s.
+
+TYPECHECK
+COMMANDS
+  npx tsc -p backend/convex --noEmit --pretty false
+  npx tsc --noEmit --pretty false
+EXIT
+  0
+
+PRODUCTION BUILD
+COMMAND
+  npm run build
+EXIT
+  0
+RESULT
+  Vite transformed 7,354 modules and built successfully; PWA artifacts generated.
+  Existing non-blocking warnings: stale caniuse-lite data and a PostCSS plugin
+  without the from option.
+
+DEPENDENCY AND FORMAT HYGIENE
+COMMANDS
+  .tmp/venvs/activegraph-canary/Scripts/python.exe -m pip check
+  npx prettier --check <claimed ActiveGraph TypeScript/JavaScript/JSON files>
+  git diff --check
+RESULT
+  No broken Python requirements; all targeted files match Prettier; diff check
+  passed. The only diff-check output was a pre-existing CRLF warning for
+  .serena/project.yml, which this task did not modify.
+
+REAL DOCKER
+COMMAND
+  docker build --file evals/activegraph/Dockerfile <exact emitted build args>
+  node scripts/nodekit/runActiveGraphCanary.mjs --attestation-output <path>
+    --sandbox-image <immutable image ID>
+  node scripts/nodekit/runActiveGraphCanary.mjs --input .tmp/nodekit-export.json
+    --evidence-root <exclusive root> --sandbox-image <immutable image ID>
+    --image-attestation <path>
+EXIT
+  0
+RESULT
+  PASS. Docker Desktop 4.78.0 / Engine 29.5.3.
+  Image:
+    sha256:56d547ad379e88ed71632ec34692cc79e8908a26f9bac10a58aefabd770f64b3
+  Build inputs:
+    sha256:d2b144ab0bceeb3eee05ba998a23a782227d909c6427f223385be519e6bbc105
+  Upstream record:
+    sha256:37482a57c2a6417fa756977e0dc05e39320470dc613e4c6af93397b3db519e75
+  Image attestation:
+    sha256:c9f736fd412e14ecdf0b60fe3a8e00f27866aa1417e5f8928beaeb1024fb1982
+  Canonical 9-event NodeKit export:
+    sha256:cd7f691ed8c459354e51db73a8f455f8cf16548db992132740c404b4c6fb485b
+  Replay verdict: pass.
+  Persisted/reload parity: true.
+  Isolation report: Docker runtime, network none, read-only root, only
+  /evidence writable. The exclusive run directory contained exactly the export,
+  report, and 69,632-byte SQLite database.
+
+INDEPENDENT REVIEW
+  A read-only Codex review attempt timed out after 300 seconds and returned no
+  verdict. It is not counted as approval. Manual liveness review found and fixed
+  the lifecycle-capacity wedge and corrupt-full-batch continuation loop before
+  the final green test run.
+
+REMAINING RELEASE GATES
+  1. Amend the documentation/evidence-only delta and repeat metadata,
+     attestation, and network-none replay against the final PR head.
+  2. Push and review through CI.
+  3. Any production deployment requires separate live DOM/API verification;
+     none occurred in this task.

--- a/evidence/activegraph-release-hardening/before.txt
+++ b/evidence/activegraph-release-hardening/before.txt
@@ -1,0 +1,50 @@
+CHANGE
+  Harden the NodeKit run-event/export retention and offline ActiveGraph boundary.
+
+SOURCE STATE
+  Git HEAD: 2d3217eed619c36851c793ca79f5904b41c96c2c
+  Existing ActiveGraph candidate files were already uncommitted in this worktree.
+
+OBSERVABLE 1 — contradictory terminal receipt accepted
+COMMAND
+  npx tsx -e "<build run.started; build run.completed with status:error; verify chain>"
+EXIT
+  0
+OUTPUT
+  {"terminalType":"run.completed","payloadStatus":"error"}
+
+OBSERVABLE 2 — non-monotonic event time accepted
+COMMAND
+  npx tsx -e "<build events at 100,1000,200; verify chain>"
+EXIT
+  0
+OUTPUT
+  {"accepted":"run.completed","times":[100,1000,200]}
+
+OBSERVABLE 3 — default concurrent Vitest worker instability
+COMMAND
+  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts scripts/__tests__/releaseWorkflowContracts.test.ts --reporter=dot
+EXIT
+  1
+OUTPUT
+  Error: Worker exited unexpectedly
+
+SERIALIZED BASELINE
+COMMAND
+  npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts scripts/__tests__/releaseWorkflowContracts.test.ts --reporter=dot --pool=threads --maxWorkers=1 --minWorkers=1
+EXIT
+  0
+RESULT
+  3 files passed; 37 tests passed.
+
+STATIC BOUNDARY FACTS
+  - Every event received retentionExpiresAt.
+  - The daily sweep took only the first 128 expired rows and skipped running traces.
+  - The sweep deleted at most 256 rows per daily invocation.
+  - The Docker child had no process timeout.
+  - Source export, report, and SQLite reads had no byte caps.
+  - The focused Docker wrapper test synthesized its report and SQLite header.
+
+REAL DOCKER
+  NOT_RUN — the existing verification record says the Docker Desktop Linux
+  daemon was unavailable. No container success is inferred from unit tests.

--- a/nodeagent.yaml
+++ b/nodeagent.yaml
@@ -1,47 +1,58 @@
-# NodeAgent application composition — phase 0 (declares the LIVE system).
-# The runtime engine is repo-local today; "engine: nodeagent-native" becomes
-# accurate only after the NodeRoom->NodeAgent runtime extraction lands and this
-# repo consumes @nodeagent/runtime. Until then this manifest documents reality.
-apiVersion: nodeagent.dev/v1
-kind: AgentApplication
+# NodeBenchAI application composition. NodeKit resolves and hashes this authored
+# projection; the existing NodeBench runtime remains authoritative in production.
+schemaVersion: nodeagent.application/v1
 
-metadata:
-  name: nodebench-entity-intelligence
-  version: 1.0.0
+application:
+  id: nodebench-entity-intelligence
+  name: NodeBench Entity Intelligence
+  purpose: >-
+    Produce source-grounded company, market, and research intelligence through
+    the durable NodeBench application and its entity-intelligence capability.
 
-spec:
-  authoring:
-    directory: ./agent
-    # Source of truth remains code until a manifest compiler exists:
-    #   backend/convex/domains/redesign/chatRuns.ts  (orchestrator prompts + response shapes)
-    #   backend/convex/domains/agents/**             (orchestrator-workers, trace types)
-    #   workers/node/pipeline/**                   (judge gates, projection writer)
+authoring:
+  directory: ./agent
 
-  runtime:
-    engine: repo-local # target: nodeagent-native
-    profile: production
+runtime:
+  engine: repo-local-nodebench
+  profile: production
 
-  backend:
-    adapter: convex
-    path: ./convex
+provider:
+  adapter: repo-local-google-gemini-rest
+  model:
+    provider: google
+    id: gemini-3.5-flash
+  secretRef: GEMINI_API_KEY
 
-  packs:
-    - ./packs/entity-intelligence/pack.yaml
+backend:
+  adapter: convex
+  config:
+    functionsDirectory: ./backend/convex
+    layoutStatus: standard-tree-phase-2
 
-  orchestration:
-    planner: orchestrator-workers # .claude/rules/orchestrator_workers.md
-    maxConcurrentSubagents: 10 # harness lane cap
+orchestration:
+  planner: orchestrator-workers
+  implementationSources:
+    - ./backend/convex/domains/redesign/chatRuns.ts
+    - ./backend/convex/domains/agents
+    - ./workers/node/pipeline
+  maxConcurrentSubagents: 10
+  migrationTarget: nodeagent-native
 
-  policies:
-    ref: ./agent/policies
+packs:
+  - ./packs/entity-intelligence/pack.yaml
 
-  evaluations:
-    required:
-      - id: conformance
-        command: npm run test:e2e:check # ui-contract runner (Tier B per PR)
-      - id: smoke
-        command: npm run dogfood:verify:smoke
-      - id: benchmark
-        command: npx tsx packages/mcp-local/src/benchmarks/searchQualityEval.ts
-      - id: production
-        command: npm run verify-live
+policies:
+  directory: ./agent/policies
+  enforcement: legacy-code-and-ci
+
+evaluations:
+  required:
+    - nodebench-conformance
+    - nodebench-smoke
+    - nodebench-entity-intelligence
+    - nodebench-production
+    - nodebench-activegraph-canary
+
+contracts:
+  event: nodeagent.event/v1
+  trace: nodeagent.trace/v1

--- a/nodekit.yaml
+++ b/nodekit.yaml
@@ -1,47 +1,54 @@
-# NodeKit repository contract — phase 0 (declarative adoption, no file moves).
-# Standard: NodeKit Agent Application Standard (node-platform).
-# Honest posture: this repo predates the standard; several concerns live at
-# legacy paths. Each is declared where it IS, not where the standard wants it.
-apiVersion: nodekit.dev/v1
-kind: Repository
+# NodeBenchAI brownfield registration. The standard tree is physically present,
+# while the production agent runtime remains the repo-local migration source.
+schemaVersion: nodekit.repo/v1
+repository: HomenShum/NodeBenchAI
+lifecycle: production
+support: active
+role: domain-application
+commandProfile: untracked
 
-metadata:
-  name: nodebench-ai
-  github: HomenShum/NodeBenchAI
-  role: domain-application # registry currently says legacy-product; this manifest is the correction proposal
-  status: production # live at https://www.nodebenchai.com, actively shipped
+# NodeBenchAI is not a canonical platform-contract owner. Runtime, trace,
+# memory, and proof ownership remain external targets.
+canonicalFor: []
+consumes:
+  - nodeagent.policy-context
 
-spec:
-  ownership:
-    runtime: NodeAgent # target owner; today the harness is repo-local (see conformance notes)
-    trace: NodeTrace
-    memory: NodeMem
-    proof: NodeProof
+commands:
+  dev:
+    script: dev
+    mode: service
+  check:
+    script: test:run
+    mode: finite
+  proof:
+    script: verify-live
+    mode: finite
 
-  lifecycle:
-    bootstrap: npm install
-    demo: npm run dev
-    check: npm run test:run
-    proof: npm run verify-live
+noKey:
+  status: missing
+  command: null
+  externalAccountsRequired: 2
+  disclosure: >-
+    The production-backed NodeBench application currently requires a configured
+    Convex deployment and Google model credentials. Local fixtures and tests are
+    not presented as a deterministic no-key application demo.
 
-  # Where standard-tree concerns actually live today (migration map).
-  layout:
-    agentAuthoring: ./agent # phase-0 authored surface; compiled truth remains in code
-    packs:
-      - ./packs/entity-intelligence/pack.yaml
-    backend: ./backend/convex # convex.json "functions" points here (standard-tree phase 2, 2026-07-19)
-    web: ./apps/web # Vite root (index.html + src); public/, env, dist stay at repo root
-    evals:
-      benchmark: packages/mcp-local/src/benchmarks
-      conformance: evals/e2e # ui-contract-runner + surface contracts
-      production: scripts/verify-live.ts
-    proof: proof/ui-contract # evidence folders + manifest.schema.json
-    adw: adw/improvement-loop # + adw/goals/ (goal cards, HARD_GATES.md)
-    mcpDistribution: packages/mcp-local # 304-tool MCP server (npx nodebench-mcp)
+environment:
+  contractVersion: nodeplatform.env/v1
+  status: legacy
 
-  conformance:
-    forbidVendoredRuntime: false # repo-local harness is the MIGRATION SOURCE, not a vendored copy;
-    # flips to true after @nodeagent/runtime extraction (phase 2 of
-    # the ecosystem migration) and this repo consumes the package.
-    requireCompiledManifest: false # no .nodeagent/ compiler exists yet; do not fake generated output
-    requireProductionProof: true # scripts/verify-live.ts (Tier A) + npm run live-smoke (Tier B)
+proof:
+  command: npm run verify-live
+  receiptSchema: null
+
+# This DeepTrace type is a domain specialization that happens to share the
+# canonical PolicyContext signature; it is not a second runtime policy owner.
+contractDeclarations:
+  - concept: nodeagent.policy-context
+    signature: policy-context
+    path: backend/convex/domains/deepTrace/dimensionModel.ts
+    mode: domain-specialization
+    origin: nodeagent.policy-context
+    reason: DeepTrace scoring context, not the NodeAgent runtime policy contract.
+
+architectureExceptions: []

--- a/packs/entity-intelligence/SKILL.md
+++ b/packs/entity-intelligence/SKILL.md
@@ -1,0 +1,34 @@
+# Entity Intelligence
+
+Use this capability for source-grounded questions about companies, markets,
+competitive position, diligence, and changes over time. The expected result is
+an evidence-backed answer or reusable run artifact, not an unsupported chat
+response.
+
+## Brownfield status
+
+This pack is logically registered but not physically extracted. Production
+execution remains in:
+
+- `backend/convex/domains/redesign/chatRuns.ts` for orchestration and response
+  policy;
+- `backend/convex/domains/agents/` for worker orchestration;
+- `packages/mcp-local/src/tools/` for the tool surface;
+- `workers/node/routes/search.ts` and `workers/node/pipeline/` for grounding and
+  judges;
+- `apps/web/src/features/redesign/components/ChatAssistantMessage.tsx` for
+  rendering.
+
+Do not duplicate or move those implementations during contract alignment. Use
+the evaluation bindings in `../../evals/` to verify the current paths, and treat
+`repo-local-nodebench` as authoritative until shadow parity supports promotion
+to `nodeagent-native`.
+
+## Output contract
+
+- Preserve source URLs and citation bindings for material claims.
+- Label unavailable evidence and failed fetches honestly.
+- Apply the deterministic response-shape policy from the live runtime.
+- Keep durable writes behind the existing policy and approval gates.
+- Preserve run, tool, verification, and deployment evidence needed for a future
+  canonical receipt.

--- a/packs/entity-intelligence/pack.yaml
+++ b/packs/entity-intelligence/pack.yaml
@@ -1,35 +1,51 @@
-# Entity-intelligence capability pack — phase 0 declaration.
-# Declares the capability where it LIVES; extraction into a portable pack
-# directory is a later phase (mirrors the NodeSlide layering decision).
-apiVersion: nodeagent.dev/v1
-kind: CapabilityPack
+# Logical ownership manifest for the existing NodeBench entity-intelligence
+# capability. Implementations remain at their current standard-tree paths.
+schemaVersion: nodeagent.pack/v1
+id: entity-intelligence
+version: 0.1.0
+name: Entity Intelligence
+description: >-
+  Source-grounded company and market intelligence, diligence, reusable run
+  artifacts, narrative workflows, forecasting, and change monitoring.
 
-metadata:
-  name: entity-intelligence
-  version: 0.1.0
-  description: >
-    Company/market/question intelligence: sourced synthesis, 8-section entity
-    workspace, diligence blocks, daily brief + narrative workflows, forecasting,
-    reusable run receipts, change watching.
+skill: ./SKILL.md
 
-spec:
-  locations: # current sources of truth (not yet extracted)
-    tools:
-      - packages/mcp-local/src/tools # enrichment, web, memory, deep-sim domains
-    orchestration:
-      - backend/convex/domains/redesign/chatRuns.ts # run pipeline + response policy
-      - backend/convex/workflows # dailyLinkedInPost, narrative
-    validators:
-      - workers/node/routes/search.ts # 4-layer grounding (confidence, isGrounded, citations)
-      - workers/node/pipeline # diligence judge, 10-gate catalog
-    artifacts:
-      - backend/convex/domains/redesign # chat runs as receipts (mintShowcaseRun)
-      - proof/ui-contract # UI evidence manifests
-    renderers:
-      - apps/web/src/features/redesign/components/ChatAssistantMessage.tsx # THE canonical answer
-  evals:
-    benchmark: packages/mcp-local/src/benchmarks/searchQualityEval.ts # 103 queries, 18 categories
-    conformance: evals/e2e/ui-contract-runner.spec.ts
-    production: scripts/verify-live.ts
-  fixtures:
-    deterministic: true # demo conversations + QA answer seed (?qaState=answer)
+prompts:
+  - ../../backend/convex/domains/redesign/chatRuns.ts
+
+artifacts:
+  - entity-intelligence-answer
+  - evidence-index
+  - redesign-chat-run-receipt
+
+tools:
+  - nodebench.mcp-tool-registry
+  - nodebench.entity-search
+  - nodebench.diligence
+
+jobs:
+  - nodebench.entity-intelligence-run
+
+validators:
+  - nodebench.grounding
+  - nodebench.citation-chain
+  - nodebench.response-policy
+
+policies:
+  - ../../agent/policies/approvals.yaml
+  - ../../agent/policies/budgets.yaml
+  - ../../agent/policies/egress.yaml
+
+renderers:
+  - nodebench.chat-assistant-message
+
+evals:
+  - ../../evals/nodebench-conformance.json
+  - ../../evals/nodebench-smoke.json
+  - ../../evals/nodebench-entity-intelligence.json
+  - ../../evals/nodebench-production.json
+
+permissions:
+  migrationStatus: logical-owner
+  runtimeAuthority: repo-local-nodebench
+  durableWrites: existing-policy-gated

--- a/scripts/__tests__/nodekitActiveGraphCanary.test.ts
+++ b/scripts/__tests__/nodekitActiveGraphCanary.test.ts
@@ -1,0 +1,834 @@
+import {
+  appendFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertCanonicalNodeKitRunExport,
+  buildOfflineCanaryEnvironment,
+  computeActiveGraphBuildInputsHash,
+  createActiveGraphImageAttestation,
+  imageLabelsForActiveGraphAttestation,
+  readNodeBenchCandidateCommit,
+  runActiveGraphCanaryFromExport,
+} from "../nodekit/runActiveGraphCanary.mjs";
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  buildNodeKitRunEvent,
+  canonicalNodeKitJson,
+} from "../../backend/convex/domains/operations/taskManager/nodeKitRunEvents";
+import { buildCanonicalNodeKitRunExport } from "../../backend/convex/domains/operations/taskManager/nodeKitRunExport";
+
+const hashBytes = (value: Buffer) =>
+  createHash("sha256").update(value).digest("hex");
+const canonicalHash = (value: unknown) =>
+  `sha256:${createHash("sha256")
+    .update(canonicalNodeKitJson(value), "utf8")
+    .digest("hex")}`;
+const repoRoot = resolve(import.meta.dirname, "../..");
+const SANDBOX_IMAGE = `sha256:${"a".repeat(64)}`;
+const NODEBENCH_CANDIDATE_COMMIT = readNodeBenchCandidateCommit();
+
+function writeImageAttestation(root: string, image = SANDBOX_IMAGE) {
+  const path = join(root, "activegraph-image-attestation.json");
+  const attestation = createActiveGraphImageAttestation({
+    sandboxImage: image,
+    nodebenchCandidateCommit: NODEBENCH_CANDIDATE_COMMIT,
+  });
+  writeFileSync(path, `${JSON.stringify(attestation)}\n`, "utf8");
+  return { path, attestation };
+}
+
+function withAttestedImage(
+  attestation: ReturnType<typeof createActiveGraphImageAttestation>,
+  runImpl: (...args: any[]) => any,
+) {
+  return vi.fn(
+    (executable: string, args: readonly string[], options: unknown) => {
+      if (args[0] === "image" && args[1] === "inspect") {
+        return {
+          status: 0,
+          stdout: `${JSON.stringify(
+            imageLabelsForActiveGraphAttestation(attestation),
+          )}\n`,
+          stderr: "",
+        };
+      }
+      return runImpl(executable, args, options);
+    },
+  );
+}
+
+function listTypeScriptSources(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return listTypeScriptSources(path);
+    return entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
+      ? [path]
+      : [];
+  });
+}
+
+async function writeValidExport(path: string) {
+  const runId = "trace_disposable_copy_test";
+  const started = await buildNodeKitRunEvent({
+    runId,
+    sequence: 0,
+    eventType: "run.started",
+    recordedAt: 10,
+    payload: {
+      workflowName: "offline-copy-test",
+      sessionType: "agent",
+      sessionStartedAt: 5,
+    },
+    previousHash: NODEKIT_RUN_GENESIS_HASH,
+  });
+  const completed = await buildNodeKitRunEvent({
+    runId,
+    sequence: 1,
+    eventType: "run.completed",
+    recordedAt: 20,
+    payload: { status: "completed" },
+    previousHash: started.contentHash,
+  });
+  const exportDoc = await buildCanonicalNodeKitRunExport({
+    sessionId: "session-copy-test",
+    traceId: "trace-record-copy-test",
+    events: [started, completed],
+  });
+  writeFileSync(path, `${JSON.stringify(exportDoc)}\n`, "utf8");
+  return exportDoc;
+}
+
+function rehashExport(document: any) {
+  let previousHash = NODEKIT_RUN_GENESIS_HASH;
+  for (const event of document.events) {
+    event.previousHash = previousHash;
+    event.contentHash = canonicalHash({
+      contractVersion: event.contractVersion,
+      runId: event.runId,
+      sequence: event.sequence,
+      eventType: event.eventType,
+      recordedAt: event.recordedAt,
+      payload: event.payload,
+      previousHash: event.previousHash,
+    });
+    previousHash = event.contentHash;
+  }
+  document.hashes.chainHead = previousHash;
+  document.hashes.exportHash = canonicalHash({
+    ...document,
+    hashes: {
+      algorithm: "sha256",
+      chainHead: previousHash,
+    },
+  });
+}
+
+describe("NodeKit -> ActiveGraph offline boundary", () => {
+  it("hashes the exact ActiveGraph build inputs deterministically", () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-build-hash-"));
+    mkdirSync(join(root, "src", "nodebench_activegraph_canary"), {
+      recursive: true,
+    });
+    writeFileSync(join(root, ".dockerignore"), "*\n!src/\n", "utf8");
+    writeFileSync(join(root, "Dockerfile"), "FROM scratch\n", "utf8");
+    writeFileSync(
+      join(root, "requirements.in"),
+      "activegraph==1.10.0\n",
+      "utf8",
+    );
+    writeFileSync(join(root, "UPSTREAM.json"), "{}\n", "utf8");
+    const source = join(
+      root,
+      "src",
+      "nodebench_activegraph_canary",
+      "runtime.py",
+    );
+    writeFileSync(source, "VALUE = 1\n", "utf8");
+
+    const first = computeActiveGraphBuildInputsHash(root);
+    expect(computeActiveGraphBuildInputsHash(root)).toBe(first);
+    writeFileSync(source, "VALUE = 2\n", "utf8");
+    expect(computeActiveGraphBuildInputsHash(root)).not.toBe(first);
+  });
+
+  it("keeps owned trace creators canonical and limits deletion to retention", () => {
+    const backendRoot = resolve(repoRoot, "backend", "convex");
+    const sources = listTypeScriptSources(backendRoot).map((path) => ({
+      path,
+      relativePath: relative(repoRoot, path).replaceAll("\\", "/"),
+      source: readFileSync(path, "utf8"),
+    }));
+    const directTraceCreators = sources
+      .filter(({ source }) => source.includes('insert("agentTaskTraces"'))
+      .map(({ relativePath }) => relativePath)
+      .sort();
+
+    expect(directTraceCreators).toEqual([
+      "backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts",
+      "backend/convex/domains/operations/taskManager/mutations.ts",
+      "backend/convex/workflows/endToEndQa.ts",
+    ]);
+    const ownedTraceCreators = [
+      "backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts",
+      "backend/convex/domains/operations/taskManager/mutations.ts",
+    ];
+    for (const creator of ownedTraceCreators) {
+      const source = sources.find(
+        ({ relativePath }) => relativePath === creator,
+      )?.source;
+      expect(source).toContain("appendNodeKitRunEvent");
+      expect(source).toContain('"run.started"');
+    }
+
+    const eventPatches = sources.flatMap(({ relativePath, source }) =>
+      /\bpatch\(\s*["']nodeKitRunEvents["']/.test(source) ? [relativePath] : [],
+    );
+    expect(eventPatches).toEqual([]);
+    const eventDeletes = sources.flatMap(({ relativePath, source }) =>
+      /ctx\.db\.delete\(event\._id\)/.test(source) &&
+      source.includes('"nodeKitRunEvents"')
+        ? [relativePath]
+        : [],
+    );
+    expect(eventDeletes).toEqual([
+      "backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts",
+    ]);
+
+    const exportSource = readFileSync(
+      resolve(
+        backendRoot,
+        "domains",
+        "operations",
+        "taskManager",
+        "nodeKitRunExport.ts",
+      ),
+      "utf8",
+    );
+    expect(exportSource).toContain(
+      "const ownerId = await requireOwnerId(ctx);",
+    );
+    expect(exportSource).toContain("session.userId !== ownerId");
+    expect(exportSource).toContain('"run_history_unavailable"');
+    expect(exportSource).toContain(".take(NODEKIT_RUN_MAX_EVENTS + 1)");
+    expect(exportSource).toContain("new ConvexError");
+    const retentionSource = readFileSync(
+      resolve(
+        backendRoot,
+        "domains",
+        "operations",
+        "taskManager",
+        "nodeKitRunRetention.ts",
+      ),
+      "utf8",
+    );
+    expect(retentionSource).toContain("session.userId !== ownerId");
+    expect(retentionSource).toContain('trace.status === "running"');
+    expect(retentionSource).toContain('"by_type_retention_expiration"');
+    expect(retentionSource).toContain("terminal.retentionExpiresAt > now");
+    expect(retentionSource).toContain("for (const event of traceEvents)");
+    expect(readFileSync(resolve(backendRoot, "crons.ts"), "utf8")).toContain(
+      '"nodekit run-event retention"',
+    );
+  });
+
+  it("stages a disposable copy, scrubs production credentials, and never mutates the source export", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-"));
+    const sourceDir = join(root, "source");
+    const evidenceRoot = join(root, "evidence");
+    mkdirSync(sourceDir);
+    const exportPath = join(sourceDir, "run-export.json");
+    const exportDoc = await writeValidExport(exportPath);
+    const beforeBytes = readFileSync(exportPath);
+    const { path: imageAttestationPath, attestation } =
+      writeImageAttestation(root);
+
+    const spawnSyncImpl = withAttestedImage(
+      attestation,
+      (
+        executable: string,
+        args: readonly string[],
+        options: {
+          env: NodeJS.ProcessEnv;
+          timeout?: number;
+          maxBuffer?: number;
+        },
+      ) => {
+        const outputPath = join(evidenceRoot, "fixed-run", "report.json");
+        const dbPath = join(evidenceRoot, "fixed-run", "activegraph.sqlite3");
+        writeFileSync(
+          outputPath,
+          `${JSON.stringify({
+            schema_version: "nodebench.activegraph.nodekit-replay-output.v1",
+            activegraph: {
+              version: "1.10.0",
+              release_commit: "148e12c2969f18fa12a1a3c2e75f3affd9aa0616",
+              annotated_tag_object: "3fbcd8fc56a45ae68622d4e2b18a6d5844180527",
+              inspected_ref: "8aedb1866cf5dce056af97529152ffd6f468a1ed",
+            },
+            isolation: {
+              runtime: "docker",
+              image: SANDBOX_IMAGE,
+              network: "none",
+              rootFilesystem: "read-only",
+              writableMount: "/evidence",
+              buildInputsHash: attestation.buildInputsHash,
+              nodebenchCandidateCommit: attestation.nodebenchCandidateCommit,
+              upstreamHash: attestation.upstreamHash,
+              imageAttestationHash: attestation.attestationHash,
+            },
+            mode: "offline-observer",
+            run_id: exportDoc.runId,
+            input_export_sha256: exportDoc.hashes.exportHash,
+            event_count: exportDoc.events.length,
+            nodekit_chain_head: exportDoc.hashes.chainHead,
+            replayed_events_sha256: `sha256:${createHash("sha256")
+              .update(canonicalNodeKitJson(exportDoc.events), "utf8")
+              .digest("hex")}`,
+            persisted_reload_parity: true,
+            verdict: "pass",
+            limitations: ["offline observer only"],
+          })}\n`,
+          "utf8",
+        );
+        writeFileSync(
+          dbPath,
+          Buffer.concat([
+            Buffer.from("SQLite format 3\u0000", "binary"),
+            Buffer.alloc(128),
+          ]),
+        );
+        expect(executable).toBe("docker");
+        expect(args).toEqual(
+          expect.arrayContaining([
+            "--network",
+            "none",
+            "--read-only",
+            "--cap-drop",
+            "ALL",
+            SANDBOX_IMAGE,
+          ]),
+        );
+        expect(options.env.CONVEX_URL).toBeUndefined();
+        expect(options.env.CONVEX_SITE_URL).toBeUndefined();
+        expect(options.env.MCP_SECRET).toBeUndefined();
+        expect(options.env.GEMINI_API_KEY).toBeUndefined();
+        expect(options.env.OPENAI_API_KEY).toBeUndefined();
+        expect(options.timeout).toBe(120_000);
+        expect(options.maxBuffer).toBe(1024 * 1024);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    const result = await runActiveGraphCanaryFromExport({
+      exportPath,
+      evidenceRoot,
+      runDirectoryName: "fixed-run",
+      sandboxImage: SANDBOX_IMAGE,
+      imageAttestationPath,
+      spawnSyncImpl,
+      _testOnlyAllowDirtyBuildInputs: true,
+      sourceEnvironment: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        CONVEX_URL: "https://prod.invalid",
+        CONVEX_SITE_URL: "https://prod.invalid",
+        MCP_SECRET: "must-not-cross",
+        GEMINI_API_KEY: "must-not-cross",
+        OPENAI_API_KEY: "must-not-cross",
+      },
+    });
+
+    expect(spawnSyncImpl).toHaveBeenCalledTimes(2);
+    expect(hashBytes(readFileSync(exportPath))).toBe(hashBytes(beforeBytes));
+    expect(readFileSync(exportPath)).toEqual(beforeBytes);
+    expect(
+      resolve(result.stagedExportPath).startsWith(resolve(evidenceRoot)),
+    ).toBe(true);
+    expect(result.stagedExportPath).not.toBe(resolve(exportPath));
+    expect(JSON.parse(readFileSync(result.stagedExportPath, "utf8"))).toEqual(
+      exportDoc,
+    );
+    expect(result.report.verdict).toBe("pass");
+    expect(result.report.input_export_sha256).toBe(exportDoc.hashes.exportHash);
+    expect(readdirSync(join(evidenceRoot, "fixed-run")).sort()).toEqual([
+      "activegraph.sqlite3",
+      "nodekit-run-export.json",
+      "report.json",
+    ]);
+  });
+
+  it("requires an immutable sandbox image before creating evidence", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-sandbox-"));
+    const exportPath = join(root, "run-export.json");
+    await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const spawnSyncImpl = vi.fn();
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        spawnSyncImpl,
+      }),
+    ).rejects.toThrow(/sandbox_image_required/);
+
+    expect(spawnSyncImpl).not.toHaveBeenCalled();
+    expect(() => readdirSync(evidenceRoot)).toThrow();
+  });
+
+  it("rejects an immutable digest without its exact build attestation and image labels", async () => {
+    const root = mkdtempSync(
+      join(tmpdir(), "nodekit-activegraph-attestation-"),
+    );
+    const exportPath = join(root, "run-export.json");
+    await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const noInspect = vi.fn();
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        sandboxImage: SANDBOX_IMAGE,
+        spawnSyncImpl: noInspect,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/image_attestation_required/);
+    expect(noInspect).not.toHaveBeenCalled();
+
+    const { path: imageAttestationPath } = writeImageAttestation(root);
+    const wrongLabels = vi.fn(() => ({
+      status: 0,
+      stdout: "{}",
+      stderr: "",
+    }));
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl: wrongLabels,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/image_label_mismatch/);
+    expect(wrongLabels).toHaveBeenCalledTimes(1);
+    expect(() => readdirSync(evidenceRoot)).toThrow();
+  });
+
+  it.each([
+    ["run.completed", "completed", "error"],
+    ["run.failed", "error", "completed"],
+  ] as const)(
+    "rejects %s with contradictory status %s/%s before replay",
+    async (terminalType, traceStatus, payloadStatus) => {
+      const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-terminal-"));
+      const exportPath = join(root, "run-export.json");
+      const source = await writeValidExport(exportPath);
+      const document: any = structuredClone(source);
+      document.events.at(-1).eventType = terminalType;
+      document.events.at(-1).payload.fields.status = payloadStatus;
+      document.trace.status = traceStatus;
+      document.completeness.terminalEventType = terminalType;
+      rehashExport(document);
+
+      expect(() => assertCanonicalNodeKitRunExport(document)).toThrow(
+        /terminal_status_mismatch/,
+      );
+    },
+  );
+
+  it("rejects a hash-valid backward event timestamp before replay", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-time-"));
+    const exportPath = join(root, "run-export.json");
+    const source = await writeValidExport(exportPath);
+    const document: any = structuredClone(source);
+    const evidence = await buildNodeKitRunEvent({
+      runId: document.runId,
+      sequence: 1,
+      eventType: "evidence.attached",
+      recordedAt: document.events[0].recordedAt - 1,
+      payload: {},
+      previousHash: document.events[0].contentHash,
+    });
+    const terminal = await buildNodeKitRunEvent({
+      runId: document.runId,
+      sequence: 2,
+      eventType: "run.completed",
+      recordedAt: document.trace.endedAt,
+      payload: { status: "completed" },
+      previousHash: evidence.contentHash,
+    });
+    document.events = [
+      document.events[0],
+      structuredClone(evidence),
+      structuredClone(terminal),
+    ];
+    document.completeness.eventCount = 3;
+    document.completeness.lastSequence = 2;
+    rehashExport(document);
+
+    expect(() => assertCanonicalNodeKitRunExport(document)).toThrow(
+      /recorded_at_not_monotonic/,
+    );
+  });
+
+  it("rejects an oversized source export before creating evidence or spawning", async () => {
+    const root = mkdtempSync(
+      join(tmpdir(), "nodekit-activegraph-source-bound-"),
+    );
+    const exportPath = join(root, "run-export.json");
+    await writeValidExport(exportPath);
+    appendFileSync(exportPath, " ".repeat(1024 * 1024), "utf8");
+    const evidenceRoot = join(root, "evidence");
+    const spawnSyncImpl = vi.fn(() => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        sandboxImage: SANDBOX_IMAGE,
+        spawnSyncImpl,
+      }),
+    ).rejects.toThrow(/export_too_large/);
+
+    expect(spawnSyncImpl).not.toHaveBeenCalled();
+    expect(() => readdirSync(evidenceRoot)).toThrow();
+  });
+
+  it("rejects extra sandbox artifacts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-artifacts-"));
+    const exportPath = join(root, "run-export.json");
+    const exportDoc = await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const runDirectory = join(evidenceRoot, "artifact-run");
+    const { path: imageAttestationPath, attestation } =
+      writeImageAttestation(root);
+    const spawnSyncImpl = withAttestedImage(attestation, () => {
+      writeFileSync(
+        join(runDirectory, "report.json"),
+        JSON.stringify({
+          schema_version: "nodebench.activegraph.nodekit-replay-output.v1",
+          activegraph: {
+            version: "1.10.0",
+            release_commit: "148e12c2969f18fa12a1a3c2e75f3affd9aa0616",
+            annotated_tag_object: "3fbcd8fc56a45ae68622d4e2b18a6d5844180527",
+            inspected_ref: "8aedb1866cf5dce056af97529152ffd6f468a1ed",
+          },
+          isolation: {
+            runtime: "docker",
+            image: SANDBOX_IMAGE,
+            network: "none",
+            rootFilesystem: "read-only",
+            writableMount: "/evidence",
+            buildInputsHash: attestation.buildInputsHash,
+            nodebenchCandidateCommit: attestation.nodebenchCandidateCommit,
+            upstreamHash: attestation.upstreamHash,
+            imageAttestationHash: attestation.attestationHash,
+          },
+          mode: "offline-observer",
+          run_id: exportDoc.runId,
+          input_export_sha256: exportDoc.hashes.exportHash,
+          event_count: exportDoc.events.length,
+          nodekit_chain_head: exportDoc.hashes.chainHead,
+          replayed_events_sha256: `sha256:${createHash("sha256")
+            .update(canonicalNodeKitJson(exportDoc.events), "utf8")
+            .digest("hex")}`,
+          persisted_reload_parity: true,
+          verdict: "pass",
+          limitations: ["offline observer only"],
+        }),
+        "utf8",
+      );
+      writeFileSync(
+        join(runDirectory, "activegraph.sqlite3"),
+        Buffer.concat([
+          Buffer.from("SQLite format 3\u0000", "binary"),
+          Buffer.alloc(128),
+        ]),
+      );
+      writeFileSync(join(runDirectory, "unexpected.txt"), "not allowed");
+      return { status: 0, stdout: "", stderr: "" };
+    });
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "artifact-run",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/artifact_set_invalid/);
+  });
+
+  it.each([
+    {
+      label: "report",
+      mutate: (runDirectory: string) => {
+        appendFileSync(
+          join(runDirectory, "report.json"),
+          " ".repeat(64 * 1024),
+          "utf8",
+        );
+      },
+    },
+    {
+      label: "SQLite database",
+      mutate: (runDirectory: string) => {
+        truncateSync(
+          join(runDirectory, "activegraph.sqlite3"),
+          64 * 1024 * 1024 + 1,
+        );
+      },
+    },
+  ])("rejects an oversized $label artifact", async ({ mutate }) => {
+    const root = mkdtempSync(
+      join(tmpdir(), "nodekit-activegraph-output-bound-"),
+    );
+    const exportPath = join(root, "run-export.json");
+    const exportDoc = await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const runDirectory = join(evidenceRoot, "oversized-run");
+    const { path: imageAttestationPath, attestation } =
+      writeImageAttestation(root);
+    const spawnSyncImpl = withAttestedImage(attestation, () => {
+      writeFileSync(
+        join(runDirectory, "report.json"),
+        JSON.stringify({
+          schema_version: "nodebench.activegraph.nodekit-replay-output.v1",
+          activegraph: {
+            version: "1.10.0",
+            release_commit: "148e12c2969f18fa12a1a3c2e75f3affd9aa0616",
+            annotated_tag_object: "3fbcd8fc56a45ae68622d4e2b18a6d5844180527",
+            inspected_ref: "8aedb1866cf5dce056af97529152ffd6f468a1ed",
+          },
+          isolation: {
+            runtime: "docker",
+            image: SANDBOX_IMAGE,
+            network: "none",
+            rootFilesystem: "read-only",
+            writableMount: "/evidence",
+            buildInputsHash: attestation.buildInputsHash,
+            nodebenchCandidateCommit: attestation.nodebenchCandidateCommit,
+            upstreamHash: attestation.upstreamHash,
+            imageAttestationHash: attestation.attestationHash,
+          },
+          mode: "offline-observer",
+          run_id: exportDoc.runId,
+          input_export_sha256: exportDoc.hashes.exportHash,
+          event_count: exportDoc.events.length,
+          nodekit_chain_head: exportDoc.hashes.chainHead,
+          replayed_events_sha256: `sha256:${createHash("sha256")
+            .update(canonicalNodeKitJson(exportDoc.events), "utf8")
+            .digest("hex")}`,
+          persisted_reload_parity: true,
+          verdict: "pass",
+          limitations: ["offline observer only"],
+        }),
+        "utf8",
+      );
+      writeFileSync(
+        join(runDirectory, "activegraph.sqlite3"),
+        Buffer.concat([
+          Buffer.from("SQLite format 3\u0000", "binary"),
+          Buffer.alloc(128),
+        ]),
+      );
+      mutate(runDirectory);
+      return { status: 0, stdout: "", stderr: "" };
+    });
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "oversized-run",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/artifact_too_large/);
+  });
+
+  it("fails before creating evidence or spawning when the source export is tampered", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-invalid-"));
+    const exportPath = join(root, "run-export.json");
+    const exportDoc = await writeValidExport(exportPath);
+    writeFileSync(
+      exportPath,
+      `${JSON.stringify({
+        ...exportDoc,
+        trace: { ...exportDoc.trace, id: "tampered" },
+      })}\n`,
+      "utf8",
+    );
+    const evidenceRoot = join(root, "evidence");
+    const spawnSyncImpl = vi.fn();
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        spawnSyncImpl,
+      }),
+    ).rejects.toThrow(/export_hash_mismatch/);
+
+    expect(spawnSyncImpl).not.toHaveBeenCalled();
+    expect(() => readdirSync(evidenceRoot)).toThrow();
+  });
+
+  it("rejects unexpected contract fields before creating evidence or spawning", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-shape-"));
+    const exportPath = join(root, "run-export.json");
+    const exportDoc = await writeValidExport(exportPath);
+    writeFileSync(
+      exportPath,
+      `${JSON.stringify({
+        ...exportDoc,
+        trace: { ...exportDoc.trace, reconstructedSummary: "not canonical" },
+      })}\n`,
+      "utf8",
+    );
+    const evidenceRoot = join(root, "evidence");
+    const spawnSyncImpl = vi.fn();
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "must-not-exist",
+        spawnSyncImpl,
+      }),
+    ).rejects.toThrow(/shape_invalid/);
+
+    expect(spawnSyncImpl).not.toHaveBeenCalled();
+    expect(() => readdirSync(evidenceRoot)).toThrow();
+  });
+
+  it("fails closed on a nonzero canary exit and never reuses an evidence directory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-fail-"));
+    const exportPath = join(root, "run-export.json");
+    await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const { path: imageAttestationPath, attestation } =
+      writeImageAttestation(root);
+    const spawnSyncImpl = withAttestedImage(attestation, () => ({
+      status: 2,
+      stdout: "",
+      stderr: "canary verdict failed",
+    }));
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "failed-run",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/ActiveGraph canary exited with code 2/);
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "failed-run",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it("reports a bounded child timeout as a typed failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-timeout-"));
+    const exportPath = join(root, "run-export.json");
+    await writeValidExport(exportPath);
+    const evidenceRoot = join(root, "evidence");
+    const { path: imageAttestationPath, attestation } =
+      writeImageAttestation(root);
+    const timeoutError = Object.assign(new Error("timed out"), {
+      code: "ETIMEDOUT",
+    });
+    const spawnSyncImpl = withAttestedImage(attestation, () => ({
+      status: null,
+      signal: "SIGTERM",
+      stdout: "",
+      stderr: "",
+      error: timeoutError,
+    }));
+
+    await expect(
+      runActiveGraphCanaryFromExport({
+        exportPath,
+        evidenceRoot,
+        runDirectoryName: "timeout-run",
+        sandboxImage: SANDBOX_IMAGE,
+        imageAttestationPath,
+        spawnSyncImpl,
+        _testOnlyAllowDirtyBuildInputs: true,
+      }),
+    ).rejects.toThrow(/canary_timeout/);
+  });
+
+  it("whitelists only process mechanics needed by the offline child", () => {
+    const env = buildOfflineCanaryEnvironment({
+      PATH: "path",
+      Path: "windows-path",
+      SystemRoot: "C:\\Windows",
+      TEMP: "temp",
+      TMP: "tmp",
+      PYTHONPATH: "caller-pythonpath",
+      CONVEX_DEPLOY_KEY: "secret",
+      VITE_CONVEX_URL: "secret",
+      MCP_HTTP_TOKEN: "secret",
+      ANTHROPIC_API_KEY: "secret",
+    });
+
+    expect(env).toMatchObject({
+      PATH: "path",
+      Path: "windows-path",
+      SystemRoot: "C:\\Windows",
+      TEMP: "temp",
+      TMP: "tmp",
+      NODEBENCH_ACTIVEGRAPH_MODE: "offline-observer",
+      PYTHONIOENCODING: "utf-8",
+    });
+    expect(Object.keys(env).sort()).not.toEqual(
+      expect.arrayContaining([
+        "CONVEX_DEPLOY_KEY",
+        "VITE_CONVEX_URL",
+        "MCP_HTTP_TOKEN",
+        "ANTHROPIC_API_KEY",
+      ]),
+    );
+    expect(env.PYTHONPATH).toBeUndefined();
+  });
+});

--- a/scripts/__tests__/releaseWorkflowContracts.test.ts
+++ b/scripts/__tests__/releaseWorkflowContracts.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { getDistributionSurfaces } from "../../packages/mcp-local/src/tools/deltaTools.js";
+import { resolveConvexTypecheckProject } from "../lib/convexProject.mjs";
 import {
   describeFetchError,
   fetchWithRetry,
@@ -32,6 +33,33 @@ const listProductionWorkerSources = (directory: string): string[] =>
   });
 
 describe("release workflow contracts", () => {
+  it("follows the configured Convex functions directory after a standard-tree migration", () => {
+    const migratedRepo = mkdtempSync(join(tmpdir(), "nodebench-convex-project-"));
+    expect(migratedRepo.startsWith(tmpdir())).toBe(true);
+
+    try {
+      mkdirSync(join(migratedRepo, "backend", "convex"), { recursive: true });
+      writeFileSync(
+        join(migratedRepo, "convex.json"),
+        JSON.stringify({ functions: "backend/convex/" }),
+      );
+
+      expect(resolveConvexTypecheckProject(migratedRepo)).toBe(
+        "backend/convex",
+      );
+
+      writeFileSync(
+        join(migratedRepo, "convex.json"),
+        JSON.stringify({ functions: "../shared-convex" }),
+      );
+      expect(() => resolveConvexTypecheckProject(migratedRepo)).toThrow(
+        "must stay inside the repository root",
+      );
+    } finally {
+      rmSync(migratedRepo, { recursive: true, force: true });
+    }
+  });
+
   it("keeps exact-head previews buildable across multi-commit PRs", () => {
     const ignoreBuild = readRepoFile("scripts/vercel-ignore-build.sh");
 

--- a/scripts/lib/convexProject.mjs
+++ b/scripts/lib/convexProject.mjs
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+const DEFAULT_CONVEX_PROJECT = "convex";
+
+/**
+ * Resolve the TypeScript project that owns Convex functions from convex.json.
+ *
+ * Keeping preflight tied to Convex's own configuration prevents standard-tree
+ * migrations from leaving a stale hard-coded functions path in release gates.
+ */
+export function resolveConvexTypecheckProject(root) {
+  const configPath = join(root, "convex.json");
+  if (!existsSync(configPath)) return DEFAULT_CONVEX_PROJECT;
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "invalid JSON";
+    throw new Error(`Cannot read ${configPath}: ${detail}`);
+  }
+
+  if (config.functions === undefined) return DEFAULT_CONVEX_PROJECT;
+  if (typeof config.functions !== "string" || !config.functions.trim()) {
+    throw new Error("convex.json functions must be a non-empty relative path");
+  }
+
+  const absoluteProject = resolve(root, config.functions);
+  const relativeProject = relative(root, absoluteProject);
+  if (
+    !relativeProject ||
+    isAbsolute(relativeProject) ||
+    relativeProject === ".." ||
+    relativeProject.startsWith(`..${sep}`)
+  ) {
+    throw new Error(
+      "convex.json functions must stay inside the repository root",
+    );
+  }
+
+  return relativeProject.split(sep).join("/");
+}

--- a/scripts/nodekit/runActiveGraphCanary.mjs
+++ b/scripts/nodekit/runActiveGraphCanary.mjs
@@ -1,0 +1,1566 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const EXPORT_SCHEMA = "nodekit.run-export/v1";
+const EVENT_SCHEMA = "nodekit.run-event/v1";
+const SAFE_PAYLOAD_SCHEMA = "nodekit.safe-event-payload/v1";
+const OUTPUT_SCHEMA = "nodebench.activegraph.nodekit-replay-output.v1";
+const ACTIVEGRAPH_VERSION = "1.10.0";
+const ACTIVEGRAPH_RELEASE_TAG = "v1.10.0";
+const ACTIVEGRAPH_RELEASE_COMMIT = "148e12c2969f18fa12a1a3c2e75f3affd9aa0616";
+const ACTIVEGRAPH_ANNOTATED_TAG_OBJECT =
+  "3fbcd8fc56a45ae68622d4e2b18a6d5844180527";
+const ACTIVEGRAPH_INSPECTED_REF = "8aedb1866cf5dce056af97529152ffd6f468a1ed";
+const IMAGE_ATTESTATION_SCHEMA = "nodebench.activegraph-image-attestation/v1";
+const BUILD_INPUTS_MANIFEST_SCHEMA = "nodebench.activegraph-build-inputs/v1";
+const IMAGE_LABELS = Object.freeze({
+  buildInputsHash: "ai.nodebench.activegraph.build-inputs-sha256",
+  nodebenchCandidateCommit: "ai.nodebench.candidate-commit",
+  upstreamHash: "ai.nodebench.activegraph.upstream-sha256",
+});
+const GENESIS_HASH = `sha256:${"0".repeat(64)}`;
+const MAX_EVENTS = 256;
+const MAX_REDACTED_SOURCE_BYTES = 32 * 1024;
+const MAX_STORED_PAYLOAD_BYTES = 2 * 1024;
+const MAX_EXPORT_BYTES = 1024 * 1024;
+const MAX_REPORT_BYTES = 64 * 1024;
+const MAX_SQLITE_BYTES = 64 * 1024 * 1024;
+const CHILD_TIMEOUT_MS = 120_000;
+const CHILD_MAX_BUFFER_BYTES = 1024 * 1024;
+const MAX_BUILD_INPUT_FILE_BYTES = 1024 * 1024;
+const MAX_BUILD_INPUT_TOTAL_BYTES = 8 * 1024 * 1024;
+const MAX_IMAGE_ATTESTATION_BYTES = 32 * 1024;
+const INSPECT_TIMEOUT_MS = 15_000;
+const INSPECT_MAX_BUFFER_BYTES = 64 * 1024;
+const EVENT_TYPES = new Set([
+  "run.started",
+  "span.started",
+  "span.completed",
+  "step.recorded",
+  "decision.recorded",
+  "verification.recorded",
+  "evidence.attached",
+  "approval.requested",
+  "run.completed",
+  "run.failed",
+]);
+const TERMINAL_TYPES = new Set(["run.completed", "run.failed"]);
+const SAFE_FIELDS_BY_EVENT = {
+  "run.started": new Set([
+    "workflowName",
+    "origin",
+    "groupId",
+    "model",
+    "goalId",
+    "sessionType",
+    "sessionStartedAt",
+  ]),
+  "span.started": new Set([
+    "spanId",
+    "parentSpanId",
+    "spanSequence",
+    "depth",
+    "spanType",
+  ]),
+  "span.completed": new Set(["spanId", "spanSequence", "status", "durationMs"]),
+  "step.recorded": new Set([
+    "spanId",
+    "parentSpanId",
+    "spanSequence",
+    "stage",
+    "type",
+    "tool",
+    "durationMs",
+  ]),
+  "decision.recorded": new Set(["decisionType", "confidence"]),
+  "verification.recorded": new Set(["status"]),
+  "evidence.attached": new Set(),
+  "approval.requested": new Set(["approvalId", "toolName", "riskLevel"]),
+  "run.completed": new Set([
+    "status",
+    "totalDurationMs",
+    "crossCheckStatus",
+    "dogfoodRunId",
+  ]),
+  "run.failed": new Set([
+    "status",
+    "totalDurationMs",
+    "crossCheckStatus",
+    "dogfoodRunId",
+  ]),
+};
+const REQUIRED_FIELDS_BY_EVENT = {
+  "run.started": ["workflowName", "sessionType", "sessionStartedAt"],
+  "span.started": ["spanId"],
+  "span.completed": ["spanId"],
+  "run.completed": ["status"],
+  "run.failed": ["status"],
+};
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(MODULE_DIR, "..", "..");
+
+class NodeKitExportBoundaryError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    this.name = "NodeKitExportBoundaryError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new NodeKitExportBoundaryError(code, message);
+}
+
+function readBoundedRegularFile(
+  path,
+  { label, maxBytes, missingCode, invalidCode, tooLargeCode },
+) {
+  let descriptor;
+  try {
+    const linkStats = lstatSync(path);
+    if (!linkStats.isFile() || linkStats.isSymbolicLink()) {
+      fail(invalidCode, `${label} must be a regular file, not a symlink.`);
+    }
+    descriptor = openSync(path, "r");
+    const stats = fstatSync(descriptor);
+    if (!stats.isFile() || stats.size < 1) {
+      fail(invalidCode, `${label} must be a non-empty regular file.`);
+    }
+    if (stats.size > maxBytes) {
+      fail(tooLargeCode, `${label} exceeds the ${maxBytes}-byte bound.`);
+    }
+    const buffer = Buffer.alloc(maxBytes + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const count = readSync(
+        descriptor,
+        buffer,
+        bytesRead,
+        buffer.length - bytesRead,
+        bytesRead,
+      );
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    if (bytesRead > maxBytes) {
+      fail(tooLargeCode, `${label} exceeds the ${maxBytes}-byte bound.`);
+    }
+    if (bytesRead < 1) {
+      fail(invalidCode, `${label} must be a non-empty regular file.`);
+    }
+    return Buffer.from(buffer.subarray(0, bytesRead));
+  } catch (error) {
+    if (error instanceof NodeKitExportBoundaryError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(missingCode, `Unable to read ${label}: ${detail}`);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function normalizeCanonicalValue(input, seen = new WeakSet()) {
+  if (
+    input === null ||
+    typeof input === "string" ||
+    typeof input === "boolean"
+  ) {
+    return input;
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) {
+      fail("non_finite_number", "Canonical JSON numbers must be finite.");
+    }
+    return input;
+  }
+  if (typeof input !== "object") {
+    fail(
+      "non_json_value",
+      `Canonical JSON cannot encode values of type ${typeof input}.`,
+    );
+  }
+  if (seen.has(input)) {
+    fail("cyclic_value", "Canonical JSON values must be acyclic.");
+  }
+  seen.add(input);
+  if (Array.isArray(input)) {
+    const result = input.map((value) => normalizeCanonicalValue(value, seen));
+    seen.delete(input);
+    return result;
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail("non_plain_object", "Canonical JSON objects must be plain objects.");
+  }
+  const result = {};
+  for (const key of Object.keys(input).sort()) {
+    result[key] = normalizeCanonicalValue(input[key], seen);
+  }
+  seen.delete(input);
+  return result;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(normalizeCanonicalValue(value));
+}
+
+function canonicalHash(value) {
+  return `sha256:${createHash("sha256")
+    .update(canonicalJson(value), "utf8")
+    .digest("hex")}`;
+}
+
+function listActiveGraphSourceFiles(sourceRoot, directory = sourceRoot) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === "__pycache__" || entry.name.endsWith(".pyc")) continue;
+    const path = join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      fail(
+        "build_input_invalid",
+        `ActiveGraph build input cannot be a symbolic link: ${path}`,
+      );
+    }
+    if (entry.isDirectory()) {
+      files.push(...listActiveGraphSourceFiles(sourceRoot, path));
+    } else if (entry.isFile()) {
+      files.push(path);
+    } else {
+      fail(
+        "build_input_invalid",
+        `ActiveGraph build input must be a regular file: ${path}`,
+      );
+    }
+  }
+  return files;
+}
+
+function activeGraphBuildInputPaths(activeGraphRoot) {
+  const fixed = [
+    ".dockerignore",
+    "Dockerfile",
+    "requirements.in",
+    "UPSTREAM.json",
+  ].map((name) => resolve(activeGraphRoot, name));
+  return [
+    ...fixed,
+    ...listActiveGraphSourceFiles(resolve(activeGraphRoot, "src")),
+  ].sort((left, right) =>
+    relative(activeGraphRoot, left).localeCompare(
+      relative(activeGraphRoot, right),
+    ),
+  );
+}
+
+export function computeActiveGraphBuildInputsHash(
+  activeGraphRoot = resolve(REPO_ROOT, "evals", "activegraph"),
+) {
+  let totalBytes = 0;
+  const files = activeGraphBuildInputPaths(activeGraphRoot).map((path) => {
+    const bytes = readBoundedRegularFile(path, {
+      label: `ActiveGraph build input ${path}`,
+      maxBytes: MAX_BUILD_INPUT_FILE_BYTES,
+      missingCode: "build_input_missing",
+      invalidCode: "build_input_invalid",
+      tooLargeCode: "build_input_too_large",
+    });
+    totalBytes += bytes.length;
+    if (totalBytes > MAX_BUILD_INPUT_TOTAL_BYTES) {
+      fail(
+        "build_inputs_too_large",
+        `ActiveGraph build inputs exceed ${MAX_BUILD_INPUT_TOTAL_BYTES} bytes.`,
+      );
+    }
+    return {
+      path: relative(activeGraphRoot, path).replaceAll("\\", "/"),
+      bytes: bytes.length,
+      sha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+    };
+  });
+  return canonicalHash({
+    schemaVersion: BUILD_INPUTS_MANIFEST_SCHEMA,
+    files,
+  });
+}
+
+function readActiveGraphUpstream(
+  activeGraphRoot = resolve(REPO_ROOT, "evals", "activegraph"),
+) {
+  const path = resolve(activeGraphRoot, "UPSTREAM.json");
+  let value;
+  try {
+    value = JSON.parse(
+      readBoundedRegularFile(path, {
+        label: "UPSTREAM.json",
+        maxBytes: MAX_BUILD_INPUT_FILE_BYTES,
+        missingCode: "upstream_record_invalid",
+        invalidCode: "upstream_record_invalid",
+        tooLargeCode: "upstream_record_invalid",
+      }).toString("utf8"),
+    );
+  } catch (error) {
+    if (error instanceof NodeKitExportBoundaryError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    fail("upstream_record_invalid", `Unable to read UPSTREAM.json: ${detail}`);
+  }
+  assertObject(value, "UPSTREAM.json");
+  const upstream = {
+    package: value.package,
+    version: value.pinned_version,
+    releaseTag: value.release_tag,
+    releaseCommit: value.release_commit,
+    annotatedTagObject: value.annotated_tag_object,
+    inspectedRef: value.inspected_ref,
+  };
+  const expected = {
+    package: "activegraph",
+    version: ACTIVEGRAPH_VERSION,
+    releaseTag: ACTIVEGRAPH_RELEASE_TAG,
+    releaseCommit: ACTIVEGRAPH_RELEASE_COMMIT,
+    annotatedTagObject: ACTIVEGRAPH_ANNOTATED_TAG_OBJECT,
+    inspectedRef: ACTIVEGRAPH_INSPECTED_REF,
+  };
+  if (canonicalJson(upstream) !== canonicalJson(expected)) {
+    fail(
+      "upstream_record_mismatch",
+      "UPSTREAM.json does not match the audited ActiveGraph release and refs.",
+    );
+  }
+  return Object.freeze(upstream);
+}
+
+export function readNodeBenchCandidateCommit({
+  repoRoot = REPO_ROOT,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const child = spawnSyncImpl("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+    timeout: INSPECT_TIMEOUT_MS,
+    maxBuffer: INSPECT_MAX_BUFFER_BYTES,
+  });
+  if (child.error || child.status !== 0) {
+    fail(
+      "candidate_commit_unavailable",
+      String(child.error?.message || child.stderr || "git rev-parse failed"),
+    );
+  }
+  const commit = String(child.stdout || "").trim();
+  if (!/^[a-f0-9]{40}$/.test(commit)) {
+    fail(
+      "candidate_commit_invalid",
+      "NodeBench candidate commit must be a full Git SHA-1.",
+    );
+  }
+  return commit;
+}
+
+export function createActiveGraphBuildMetadata({
+  nodebenchCandidateCommit,
+  activeGraphRoot = resolve(REPO_ROOT, "evals", "activegraph"),
+}) {
+  if (!/^[a-f0-9]{40}$/.test(nodebenchCandidateCommit)) {
+    fail(
+      "candidate_commit_invalid",
+      "NodeBench candidate commit must be a full Git SHA-1.",
+    );
+  }
+  const upstream = readActiveGraphUpstream(activeGraphRoot);
+  return Object.freeze({
+    buildInputsHash: computeActiveGraphBuildInputsHash(activeGraphRoot),
+    nodebenchCandidateCommit,
+    upstream,
+    upstreamHash: canonicalHash(upstream),
+  });
+}
+
+export function createActiveGraphImageAttestation({
+  sandboxImage,
+  nodebenchCandidateCommit,
+  activeGraphRoot = resolve(REPO_ROOT, "evals", "activegraph"),
+}) {
+  assertImmutableSandboxImage(sandboxImage);
+  const metadata = createActiveGraphBuildMetadata({
+    nodebenchCandidateCommit,
+    activeGraphRoot,
+  });
+  const body = {
+    schemaVersion: IMAGE_ATTESTATION_SCHEMA,
+    image: sandboxImage,
+    ...metadata,
+  };
+  return Object.freeze({
+    ...body,
+    attestationHash: canonicalHash(body),
+  });
+}
+
+export function imageLabelsForActiveGraphAttestation(attestation) {
+  return Object.freeze({
+    [IMAGE_LABELS.buildInputsHash]: attestation.buildInputsHash,
+    [IMAGE_LABELS.nodebenchCandidateCommit]:
+      attestation.nodebenchCandidateCommit,
+    [IMAGE_LABELS.upstreamHash]: attestation.upstreamHash,
+  });
+}
+
+function exactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  if (
+    actual.length !== sortedExpected.length ||
+    actual.some((key, index) => key !== sortedExpected[index])
+  ) {
+    fail("shape_invalid", `${label} has unexpected or missing keys.`);
+  }
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("shape_invalid", `${label} must be an object.`);
+  }
+}
+
+function assertHash(value, label) {
+  if (typeof value !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    fail("hash_invalid", `${label} must be a lowercase sha256: digest.`);
+  }
+}
+
+function assertString(value, label, { nonEmpty = false, maxLength } = {}) {
+  if (
+    typeof value !== "string" ||
+    (nonEmpty && value.trim().length === 0) ||
+    (maxLength !== undefined && value.length > maxLength)
+  ) {
+    fail("shape_invalid", `${label} must be a valid string.`);
+  }
+}
+
+function assertTimestamp(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    fail("shape_invalid", `${label} must be a non-negative safe integer.`);
+  }
+}
+
+function assertSafeEventPayload(payload, eventType, label) {
+  assertObject(payload, label);
+  exactKeys(
+    payload,
+    ["projectionVersion", "sourceDigest", "sourceBytes", "fields"],
+    label,
+  );
+  if (payload.projectionVersion !== SAFE_PAYLOAD_SCHEMA) {
+    fail("payload_version_mismatch", `${label} version is unsupported.`);
+  }
+  assertHash(payload.sourceDigest, `${label}.sourceDigest`);
+  if (
+    !Number.isSafeInteger(payload.sourceBytes) ||
+    payload.sourceBytes < 0 ||
+    payload.sourceBytes > MAX_REDACTED_SOURCE_BYTES
+  ) {
+    fail("payload_size_invalid", `${label}.sourceBytes exceeds its bound.`);
+  }
+  assertObject(payload.fields, `${label}.fields`);
+  const allowed = SAFE_FIELDS_BY_EVENT[eventType];
+  for (const [field, value] of Object.entries(payload.fields)) {
+    if (!allowed.has(field)) {
+      fail("payload_field_invalid", `${label}.${field} is not allowed.`);
+    }
+    if (
+      value !== null &&
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      fail("payload_field_invalid", `${label}.${field} must be scalar.`);
+    }
+    if (
+      (typeof value === "string" && value.length > 256) ||
+      (typeof value === "number" && !Number.isFinite(value))
+    ) {
+      fail("payload_field_invalid", `${label}.${field} exceeds its bound.`);
+    }
+  }
+  for (const required of REQUIRED_FIELDS_BY_EVENT[eventType] ?? []) {
+    if (!(required in payload.fields)) {
+      fail(
+        "payload_field_missing",
+        `${label} requires safe field ${required}.`,
+      );
+    }
+  }
+  const expectedTerminalStatus =
+    eventType === "run.completed"
+      ? "completed"
+      : eventType === "run.failed"
+        ? "error"
+        : undefined;
+  if (
+    expectedTerminalStatus !== undefined &&
+    payload.fields.status !== expectedTerminalStatus
+  ) {
+    fail(
+      "terminal_status_mismatch",
+      `${label} requires status ${expectedTerminalStatus}.`,
+    );
+  }
+  if (
+    Buffer.byteLength(canonicalJson(payload), "utf8") > MAX_STORED_PAYLOAD_BYTES
+  ) {
+    fail("projected_payload_too_large", `${label} exceeds its stored bound.`);
+  }
+}
+
+function eventHashBody(event) {
+  return {
+    contractVersion: event.contractVersion,
+    runId: event.runId,
+    sequence: event.sequence,
+    eventType: event.eventType,
+    recordedAt: event.recordedAt,
+    payload: event.payload,
+    previousHash: event.previousHash,
+  };
+}
+
+export function assertCanonicalNodeKitRunExport(value) {
+  assertObject(value, "NodeKit export");
+  exactKeys(
+    value,
+    [
+      "schemaVersion",
+      "runId",
+      "session",
+      "trace",
+      "events",
+      "completeness",
+      "hashes",
+    ],
+    "NodeKit export",
+  );
+  if (value.schemaVersion !== EXPORT_SCHEMA) {
+    fail("export_schema_mismatch", "Unsupported NodeKit export schema.");
+  }
+  if (
+    typeof value.runId !== "string" ||
+    value.runId.trim().length === 0 ||
+    value.runId.length > 256
+  ) {
+    fail("run_id_invalid", "runId is required.");
+  }
+  assertObject(value.session, "session");
+  assertObject(value.trace, "trace");
+  assertObject(value.completeness, "completeness");
+  assertObject(value.hashes, "hashes");
+  exactKeys(value.session, ["id", "typeAtRunStart", "startedAt"], "session");
+  exactKeys(
+    value.trace,
+    ["id", "runId", "workflowName", "status", "startedAt", "endedAt"],
+    "trace",
+  );
+  exactKeys(
+    value.completeness,
+    [
+      "eventChainComplete",
+      "spanLifecycleComplete",
+      "contractVersion",
+      "eventCount",
+      "firstSequence",
+      "lastSequence",
+      "terminalEventType",
+    ],
+    "completeness",
+  );
+  exactKeys(value.hashes, ["algorithm", "chainHead", "exportHash"], "hashes");
+  assertString(value.session.id, "session.id", { nonEmpty: true });
+  assertString(value.session.typeAtRunStart, "session.typeAtRunStart", {
+    nonEmpty: true,
+    maxLength: 256,
+  });
+  assertTimestamp(value.session.startedAt, "session.startedAt");
+  assertString(value.trace.id, "trace.id", { nonEmpty: true });
+  assertString(value.trace.runId, "trace.runId", {
+    nonEmpty: true,
+    maxLength: 256,
+  });
+  assertString(value.trace.workflowName, "trace.workflowName", {
+    nonEmpty: true,
+  });
+  if (value.trace.status !== "completed" && value.trace.status !== "error") {
+    fail("run_not_terminal", "trace.status must be completed or error.");
+  }
+  assertTimestamp(value.trace.startedAt, "trace.startedAt");
+  assertTimestamp(value.trace.endedAt, "trace.endedAt");
+  if (value.trace.endedAt < value.trace.startedAt) {
+    fail("shape_invalid", "trace.endedAt cannot precede startedAt.");
+  }
+  if (!Array.isArray(value.events) || value.events.length < 2) {
+    fail("terminal_event_missing", "Export has no complete event chain.");
+  }
+  if (value.events.length > MAX_EVENTS) {
+    fail(
+      "event_limit_exceeded",
+      `Export exceeds the ${MAX_EVENTS}-event bound.`,
+    );
+  }
+  if (value.trace.runId !== value.runId) {
+    fail("run_id_mismatch", "Trace and export run IDs differ.");
+  }
+
+  let previousHash = GENESIS_HASH;
+  let terminalIndex = -1;
+  const openSpans = new Set();
+  const completedSpans = new Set();
+  for (let index = 0; index < value.events.length; index += 1) {
+    const event = value.events[index];
+    assertObject(event, `events[${index}]`);
+    exactKeys(
+      event,
+      [
+        "contractVersion",
+        "runId",
+        "sequence",
+        "eventType",
+        "recordedAt",
+        "payload",
+        "previousHash",
+        "contentHash",
+      ],
+      `events[${index}]`,
+    );
+    if (event.contractVersion !== EVENT_SCHEMA) {
+      fail("contract_version_mismatch", `events[${index}] contract mismatch.`);
+    }
+    if (event.runId !== value.runId) {
+      fail("run_id_mismatch", `events[${index}] run ID mismatch.`);
+    }
+    if (event.sequence !== index) {
+      fail(
+        "sequence_not_contiguous",
+        `Expected sequence ${index}, received ${event.sequence}.`,
+      );
+    }
+    if (!EVENT_TYPES.has(event.eventType)) {
+      fail("event_type_invalid", `events[${index}] type is unsupported.`);
+    }
+    assertSafeEventPayload(
+      event.payload,
+      event.eventType,
+      `events[${index}].payload`,
+    );
+    if (!Number.isSafeInteger(event.recordedAt) || event.recordedAt < 0) {
+      fail("recorded_at_invalid", `events[${index}] timestamp is invalid.`);
+    }
+    if (index > 0 && event.recordedAt < value.events[index - 1].recordedAt) {
+      fail(
+        "recorded_at_not_monotonic",
+        `events[${index}] was recorded before its predecessor.`,
+      );
+    }
+    assertHash(event.previousHash, `events[${index}].previousHash`);
+    assertHash(event.contentHash, `events[${index}].contentHash`);
+    if (event.previousHash !== previousHash) {
+      fail(
+        "previous_hash_mismatch",
+        `events[${index}] does not point to the preceding event.`,
+      );
+    }
+    const expectedHash = canonicalHash(eventHashBody(event));
+    if (event.contentHash !== expectedHash) {
+      fail(
+        "content_hash_mismatch",
+        `events[${index}] content does not match its hash.`,
+      );
+    }
+    if (TERMINAL_TYPES.has(event.eventType)) {
+      if (terminalIndex !== -1) {
+        fail("terminal_event_not_last", "Export has multiple terminal events.");
+      }
+      terminalIndex = index;
+    }
+    if (event.eventType === "span.started") {
+      const spanId = event.payload.fields.spanId;
+      if (
+        typeof spanId !== "string" ||
+        !spanId ||
+        openSpans.has(spanId) ||
+        completedSpans.has(spanId)
+      ) {
+        fail("span_duplicate_start", `Invalid start for span ${spanId}.`);
+      }
+      openSpans.add(spanId);
+    }
+    if (event.eventType === "span.completed") {
+      const spanId = event.payload.fields.spanId;
+      if (typeof spanId !== "string" || !openSpans.has(spanId)) {
+        fail(
+          "span_completion_without_start",
+          `Invalid completion for span ${spanId}.`,
+        );
+      }
+      openSpans.delete(spanId);
+      completedSpans.add(spanId);
+    }
+    previousHash = event.contentHash;
+  }
+  if (value.events[0].eventType !== "run.started") {
+    fail("start_event_missing", "Sequence 0 must be run.started.");
+  }
+  if (value.events[0].previousHash !== GENESIS_HASH) {
+    fail(
+      "previous_hash_mismatch",
+      "run.started must point to the genesis hash.",
+    );
+  }
+  if (terminalIndex === -1) {
+    fail("terminal_event_missing", "Export has no terminal event.");
+  }
+  if (terminalIndex !== value.events.length - 1) {
+    fail("terminal_event_not_last", "The terminal event must be last.");
+  }
+  if (openSpans.size > 0) {
+    fail(
+      "span_lifecycle_incomplete",
+      `Terminal run retains ${openSpans.size} open span(s).`,
+    );
+  }
+
+  const terminalEventType = value.events[terminalIndex].eventType;
+  const expectedTraceStatus =
+    terminalEventType === "run.completed" ? "completed" : "error";
+  if (value.trace.status !== expectedTraceStatus) {
+    fail(
+      "terminal_status_mismatch",
+      `Trace status ${value.trace.status} does not match ${terminalEventType}.`,
+    );
+  }
+  const startFields = value.events[0].payload.fields;
+  if (
+    value.trace.workflowName !== startFields.workflowName ||
+    value.trace.startedAt !== value.events[0].recordedAt ||
+    value.trace.endedAt !== value.events[terminalIndex].recordedAt ||
+    value.session.typeAtRunStart !== startFields.sessionType ||
+    value.session.startedAt !== startFields.sessionStartedAt ||
+    value.session.startedAt > value.trace.startedAt
+  ) {
+    fail(
+      "event_snapshot_mismatch",
+      "Session or trace metadata differs from immutable event snapshots.",
+    );
+  }
+  if (
+    value.completeness.eventChainComplete !== true ||
+    value.completeness.spanLifecycleComplete !== true ||
+    value.completeness.contractVersion !== EVENT_SCHEMA ||
+    value.completeness.eventCount !== value.events.length ||
+    value.completeness.firstSequence !== 0 ||
+    value.completeness.lastSequence !== value.events.length - 1 ||
+    value.completeness.terminalEventType !== terminalEventType
+  ) {
+    fail(
+      "completeness_mismatch",
+      "Completeness receipt does not match the event chain.",
+    );
+  }
+  if (
+    value.hashes.algorithm !== "sha256" ||
+    value.hashes.chainHead !== previousHash
+  ) {
+    fail("chain_head_mismatch", "Export chain head does not match its events.");
+  }
+  assertHash(value.hashes.exportHash, "hashes.exportHash");
+  const expectedExportHash = canonicalHash({
+    schemaVersion: value.schemaVersion,
+    runId: value.runId,
+    session: value.session,
+    trace: value.trace,
+    events: value.events,
+    completeness: value.completeness,
+    hashes: {
+      algorithm: value.hashes.algorithm,
+      chainHead: value.hashes.chainHead,
+    },
+  });
+  if (value.hashes.exportHash !== expectedExportHash) {
+    fail("export_hash_mismatch", "Export content does not match exportHash.");
+  }
+  return value;
+}
+
+export function buildOfflineCanaryEnvironment(sourceEnvironment = process.env) {
+  const allowed = [
+    "PATH",
+    "Path",
+    "PATHEXT",
+    "COMSPEC",
+    "SystemRoot",
+    "WINDIR",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+  ];
+  const environment = {};
+  for (const key of allowed) {
+    if (sourceEnvironment[key] !== undefined) {
+      environment[key] = sourceEnvironment[key];
+    }
+  }
+  return {
+    ...environment,
+    PYTHONIOENCODING: "utf-8",
+    PYTHONDONTWRITEBYTECODE: "1",
+    NODEBENCH_ACTIVEGRAPH_MODE: "offline-observer",
+  };
+}
+
+function assertChildReport(report, exportDoc, imageAttestation) {
+  assertObject(report, "ActiveGraph report");
+  exactKeys(
+    report,
+    [
+      "schema_version",
+      "activegraph",
+      "isolation",
+      "mode",
+      "run_id",
+      "input_export_sha256",
+      "event_count",
+      "nodekit_chain_head",
+      "replayed_events_sha256",
+      "persisted_reload_parity",
+      "verdict",
+      "limitations",
+    ],
+    "ActiveGraph report",
+  );
+  assertObject(report.activegraph, "ActiveGraph report.activegraph");
+  assertObject(report.isolation, "ActiveGraph report.isolation");
+  exactKeys(
+    report.activegraph,
+    ["version", "release_commit", "annotated_tag_object", "inspected_ref"],
+    "ActiveGraph report.activegraph",
+  );
+  exactKeys(
+    report.isolation,
+    [
+      "runtime",
+      "image",
+      "network",
+      "rootFilesystem",
+      "writableMount",
+      "buildInputsHash",
+      "nodebenchCandidateCommit",
+      "upstreamHash",
+      "imageAttestationHash",
+    ],
+    "ActiveGraph report.isolation",
+  );
+  if (report.schema_version !== OUTPUT_SCHEMA) {
+    fail("report_schema_mismatch", "ActiveGraph report schema mismatch.");
+  }
+  if (
+    report.activegraph.version !== ACTIVEGRAPH_VERSION ||
+    report.activegraph.release_commit !== ACTIVEGRAPH_RELEASE_COMMIT ||
+    report.activegraph.annotated_tag_object !==
+      ACTIVEGRAPH_ANNOTATED_TAG_OBJECT ||
+    report.activegraph.inspected_ref !== ACTIVEGRAPH_INSPECTED_REF ||
+    report.isolation.runtime !== "docker" ||
+    report.isolation.image !== imageAttestation.image ||
+    report.isolation.network !== "none" ||
+    report.isolation.rootFilesystem !== "read-only" ||
+    report.isolation.writableMount !== "/evidence" ||
+    report.isolation.buildInputsHash !== imageAttestation.buildInputsHash ||
+    report.isolation.nodebenchCandidateCommit !==
+      imageAttestation.nodebenchCandidateCommit ||
+    report.isolation.upstreamHash !== imageAttestation.upstreamHash ||
+    report.isolation.imageAttestationHash !==
+      imageAttestation.attestationHash ||
+    report.mode !== "offline-observer" ||
+    !Array.isArray(report.limitations) ||
+    report.limitations.length < 1 ||
+    report.limitations.some(
+      (limitation) => typeof limitation !== "string" || !limitation,
+    ) ||
+    report.verdict !== "pass" ||
+    report.run_id !== exportDoc.runId ||
+    report.input_export_sha256 !== exportDoc.hashes.exportHash ||
+    report.event_count !== exportDoc.events.length ||
+    report.nodekit_chain_head !== exportDoc.hashes.chainHead ||
+    report.replayed_events_sha256 !== canonicalHash(exportDoc.events) ||
+    report.persisted_reload_parity !== true
+  ) {
+    fail(
+      "canary_report_failed",
+      "ActiveGraph report did not prove exact persisted reload parity.",
+    );
+  }
+}
+
+function assertImmutableSandboxImage(image) {
+  if (
+    typeof image !== "string" ||
+    !/^(?:[a-z0-9._/-]+@)?sha256:[a-f0-9]{64}$/.test(image)
+  ) {
+    fail(
+      "sandbox_image_required",
+      "sandboxImage must be an immutable Docker image ID or digest.",
+    );
+  }
+}
+
+function assertCommittedActiveGraphBuildInputs({
+  repoRoot = REPO_ROOT,
+  spawnSyncImpl = spawnSync,
+}) {
+  const child = spawnSyncImpl(
+    "git",
+    [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "--",
+      "evals/activegraph/.dockerignore",
+      "evals/activegraph/Dockerfile",
+      "evals/activegraph/requirements.in",
+      "evals/activegraph/UPSTREAM.json",
+      "evals/activegraph/src",
+      "evals/activegraph/schemas/nodekit-run-export.v1.schema.json",
+      "evals/activegraph/schemas/nodekit-replay-output.v1.schema.json",
+      "evals/activegraph/schemas/image-attestation.v1.schema.json",
+      "scripts/nodekit/runActiveGraphCanary.mjs",
+      "backend/convex/schema.ts",
+      "backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts",
+      "backend/convex/domains/operations/taskManager/nodeKitRunExport.ts",
+      "backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      shell: false,
+      timeout: INSPECT_TIMEOUT_MS,
+      maxBuffer: INSPECT_MAX_BUFFER_BYTES,
+    },
+  );
+  if (child.error || child.status !== 0) {
+    fail(
+      "build_input_status_failed",
+      String(child.error?.message || child.stderr || "git status failed"),
+    );
+  }
+  if (String(child.stdout || "").trim()) {
+    fail(
+      "build_inputs_not_committed",
+      "The ActiveGraph image and NodeKit boundary inputs must be committed before attestation or replay.",
+    );
+  }
+}
+
+function readImageAttestation(path) {
+  if (typeof path !== "string" || !path.trim()) {
+    fail(
+      "image_attestation_required",
+      "An ActiveGraph image attestation file is required.",
+    );
+  }
+  const resolvedPath = resolve(path);
+  let value;
+  try {
+    value = JSON.parse(
+      readBoundedRegularFile(resolvedPath, {
+        label: "image attestation",
+        maxBytes: MAX_IMAGE_ATTESTATION_BYTES,
+        missingCode: "image_attestation_invalid",
+        invalidCode: "image_attestation_invalid",
+        tooLargeCode: "image_attestation_invalid",
+      }).toString("utf8"),
+    );
+  } catch (error) {
+    if (error instanceof NodeKitExportBoundaryError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(
+      "image_attestation_invalid",
+      `Unable to read image attestation: ${detail}`,
+    );
+  }
+  return { resolvedPath, value };
+}
+
+function assertImageAttestationShape(value) {
+  assertObject(value, "Image attestation");
+  exactKeys(
+    value,
+    [
+      "schemaVersion",
+      "image",
+      "buildInputsHash",
+      "nodebenchCandidateCommit",
+      "upstream",
+      "upstreamHash",
+      "attestationHash",
+    ],
+    "Image attestation",
+  );
+  if (value.schemaVersion !== IMAGE_ATTESTATION_SCHEMA) {
+    fail(
+      "image_attestation_schema_mismatch",
+      "Unsupported ActiveGraph image attestation schema.",
+    );
+  }
+  assertImmutableSandboxImage(value.image);
+  assertHash(value.buildInputsHash, "Image attestation.buildInputsHash");
+  assertHash(value.upstreamHash, "Image attestation.upstreamHash");
+  assertHash(value.attestationHash, "Image attestation.attestationHash");
+  if (!/^[a-f0-9]{40}$/.test(value.nodebenchCandidateCommit)) {
+    fail(
+      "candidate_commit_invalid",
+      "Image attestation candidate commit must be a full Git SHA-1.",
+    );
+  }
+  assertObject(value.upstream, "Image attestation.upstream");
+  exactKeys(
+    value.upstream,
+    [
+      "package",
+      "version",
+      "releaseTag",
+      "releaseCommit",
+      "annotatedTagObject",
+      "inspectedRef",
+    ],
+    "Image attestation.upstream",
+  );
+}
+
+function assertActiveGraphImageAttestation({
+  imageAttestationPath,
+  sandboxExecutable,
+  sandboxImage,
+  spawnSyncImpl,
+  sourceEnvironment,
+  activeGraphRoot = resolve(REPO_ROOT, "evals", "activegraph"),
+  nodebenchCandidateCommit,
+}) {
+  const { resolvedPath, value } = readImageAttestation(imageAttestationPath);
+  assertImageAttestationShape(value);
+  if (value.image !== sandboxImage) {
+    fail(
+      "image_attestation_mismatch",
+      "Attested image digest does not match sandboxImage.",
+    );
+  }
+  const expected = createActiveGraphImageAttestation({
+    sandboxImage,
+    nodebenchCandidateCommit,
+    activeGraphRoot,
+  });
+  if (value.buildInputsHash !== expected.buildInputsHash) {
+    fail(
+      "image_source_mismatch",
+      "Attested image was not built from the current canonical inputs.",
+    );
+  }
+  if (value.nodebenchCandidateCommit !== expected.nodebenchCandidateCommit) {
+    fail(
+      "candidate_commit_mismatch",
+      "Attested image belongs to another NodeBench candidate commit.",
+    );
+  }
+  if (
+    value.upstreamHash !== expected.upstreamHash ||
+    canonicalJson(value.upstream) !== canonicalJson(expected.upstream)
+  ) {
+    fail(
+      "upstream_attestation_mismatch",
+      "Attested ActiveGraph upstream refs do not match the audited record.",
+    );
+  }
+  if (value.attestationHash !== expected.attestationHash) {
+    fail(
+      "image_attestation_hash_mismatch",
+      "Image attestation content does not match attestationHash.",
+    );
+  }
+
+  const inspected = spawnSyncImpl(
+    sandboxExecutable,
+    ["image", "inspect", "--format", "{{json .Config.Labels}}", sandboxImage],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      shell: false,
+      env: buildOfflineCanaryEnvironment(sourceEnvironment),
+      timeout: INSPECT_TIMEOUT_MS,
+      maxBuffer: INSPECT_MAX_BUFFER_BYTES,
+    },
+  );
+  if (inspected.error || inspected.status !== 0) {
+    fail(
+      "image_attestation_inspect_failed",
+      String(
+        inspected.error?.message ||
+          inspected.stderr ||
+          "Docker image inspect failed",
+      ),
+    );
+  }
+  let labels;
+  try {
+    labels = JSON.parse(String(inspected.stdout || ""));
+  } catch {
+    fail(
+      "image_attestation_inspect_failed",
+      "Docker image labels were not valid JSON.",
+    );
+  }
+  assertObject(labels, "Docker image labels");
+  const expectedLabels = imageLabelsForActiveGraphAttestation(expected);
+  for (const [label, expectedValue] of Object.entries(expectedLabels)) {
+    if (labels[label] !== expectedValue) {
+      fail(
+        "image_label_mismatch",
+        `Docker image label ${label} does not match its attestation.`,
+      );
+    }
+  }
+  return Object.freeze({ ...expected, path: resolvedPath });
+}
+
+function assertRegularNonemptyFile(path, label, maxBytes) {
+  let stats;
+  try {
+    stats = lstatSync(path);
+  } catch {
+    fail("artifact_missing", `${label} was not produced.`);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size < 1) {
+    fail("artifact_invalid", `${label} must be a non-empty regular file.`);
+  }
+  if (stats.size > maxBytes) {
+    fail(
+      "artifact_too_large",
+      `${label} exceeds the ${maxBytes}-byte artifact bound.`,
+    );
+  }
+}
+
+function readSqliteHeader(path) {
+  const header = Buffer.alloc(16);
+  let descriptor;
+  try {
+    descriptor = openSync(path, "r");
+    const bytesRead = readSync(descriptor, header, 0, header.length, 0);
+    if (bytesRead !== header.length) {
+      fail(
+        "sqlite_artifact_invalid",
+        "ActiveGraph SQLite header is truncated.",
+      );
+    }
+    return header.toString("binary");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function assertExactCanaryArtifacts({
+  runDirectory,
+  sourcePath,
+  sourceBytes,
+  stagedExportPath,
+  stagedBytes,
+  reportPath,
+  dbPath,
+}) {
+  const expectedNames = [
+    "activegraph.sqlite3",
+    "nodekit-run-export.json",
+    "report.json",
+  ];
+  const actualNames = readdirSync(runDirectory).sort();
+  if (
+    actualNames.length !== expectedNames.length ||
+    actualNames.some((name, index) => name !== expectedNames[index])
+  ) {
+    fail(
+      "artifact_set_invalid",
+      "Canary output must contain exactly the export copy, SQLite DB, and report.",
+    );
+  }
+  assertRegularNonemptyFile(
+    stagedExportPath,
+    "Staged export",
+    MAX_EXPORT_BYTES,
+  );
+  assertRegularNonemptyFile(reportPath, "Replay report", MAX_REPORT_BYTES);
+  assertRegularNonemptyFile(
+    dbPath,
+    "ActiveGraph SQLite database",
+    MAX_SQLITE_BYTES,
+  );
+  const currentSourceBytes = readBoundedRegularFile(sourcePath, {
+    label: "source export",
+    maxBytes: MAX_EXPORT_BYTES,
+    missingCode: "source_mutated",
+    invalidCode: "source_mutated",
+    tooLargeCode: "source_mutated",
+  });
+  if (!currentSourceBytes.equals(sourceBytes)) {
+    fail(
+      "source_mutated",
+      "The source export changed during canary execution.",
+    );
+  }
+  const currentStagedBytes = readBoundedRegularFile(stagedExportPath, {
+    label: "staged export",
+    maxBytes: MAX_EXPORT_BYTES,
+    missingCode: "staged_export_mutated",
+    invalidCode: "staged_export_mutated",
+    tooLargeCode: "staged_export_mutated",
+  });
+  if (!currentStagedBytes.equals(stagedBytes)) {
+    fail(
+      "staged_export_mutated",
+      "The disposable export changed during canary execution.",
+    );
+  }
+  const sqliteHeader = readSqliteHeader(dbPath);
+  if (sqliteHeader !== "SQLite format 3\u0000") {
+    fail(
+      "sqlite_artifact_invalid",
+      "ActiveGraph output is not a SQLite 3 database.",
+    );
+  }
+}
+
+export async function runActiveGraphCanaryFromExport({
+  exportPath,
+  evidenceRoot = resolve(REPO_ROOT, ".tmp", "activegraph-canary", "nodekit"),
+  runDirectoryName = randomUUID(),
+  sandboxExecutable = "docker",
+  sandboxImage,
+  imageAttestationPath,
+  spawnSyncImpl = spawnSync,
+  sourceEnvironment = process.env,
+  _testOnlyAllowDirtyBuildInputs = false,
+}) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runDirectoryName)) {
+    fail("run_directory_invalid", "runDirectoryName is not a safe leaf name.");
+  }
+  const resolvedExportPath = resolve(exportPath);
+  let sourceBytes;
+  let exportDoc;
+  try {
+    sourceBytes = readBoundedRegularFile(resolvedExportPath, {
+      label: "source export",
+      maxBytes: MAX_EXPORT_BYTES,
+      missingCode: "export_read_failed",
+      invalidCode: "export_read_failed",
+      tooLargeCode: "export_too_large",
+    });
+    exportDoc = JSON.parse(sourceBytes.toString("utf8"));
+  } catch (error) {
+    if (error instanceof NodeKitExportBoundaryError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    fail("export_read_failed", `Unable to read export: ${detail}`);
+  }
+  assertCanonicalNodeKitRunExport(exportDoc);
+  assertImmutableSandboxImage(sandboxImage);
+  const nodebenchCandidateCommit = readNodeBenchCandidateCommit();
+  if (!_testOnlyAllowDirtyBuildInputs) {
+    assertCommittedActiveGraphBuildInputs({});
+  }
+  const imageAttestation = assertActiveGraphImageAttestation({
+    imageAttestationPath,
+    sandboxExecutable,
+    sandboxImage,
+    spawnSyncImpl,
+    sourceEnvironment,
+    nodebenchCandidateCommit,
+  });
+
+  const resolvedEvidenceRoot = resolve(evidenceRoot);
+  const runDirectory = resolve(resolvedEvidenceRoot, runDirectoryName);
+  const relativeRun = relative(resolvedEvidenceRoot, runDirectory);
+  if (
+    !relativeRun ||
+    isAbsolute(relativeRun) ||
+    relativeRun === ".." ||
+    relativeRun.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)
+  ) {
+    fail("run_directory_invalid", "Evidence directory escaped its root.");
+  }
+  if (runDirectory.includes(",")) {
+    fail(
+      "evidence_path_invalid",
+      "Docker bind-mount paths cannot contain commas.",
+    );
+  }
+  const stagedExportPath = resolve(runDirectory, "nodekit-run-export.json");
+  if (stagedExportPath === resolvedExportPath) {
+    fail("source_copy_required", "The canary must consume a disposable copy.");
+  }
+  const stagedBytes = Buffer.from(`${canonicalJson(exportDoc)}\n`, "utf8");
+  if (stagedBytes.length > MAX_EXPORT_BYTES) {
+    fail(
+      "export_too_large",
+      `Canonical export exceeds the ${MAX_EXPORT_BYTES}-byte input bound.`,
+    );
+  }
+
+  mkdirSync(resolvedEvidenceRoot, { recursive: true });
+  try {
+    mkdirSync(runDirectory, { recursive: false });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(
+      "evidence_directory_exists",
+      `Evidence directory already exists: ${detail}`,
+    );
+  }
+  writeFileSync(stagedExportPath, stagedBytes, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  const reportPath = resolve(runDirectory, "report.json");
+  const dbPath = resolve(runDirectory, "activegraph.sqlite3");
+  const userArgs =
+    typeof process.getuid === "function" && typeof process.getgid === "function"
+      ? ["--user", `${process.getuid()}:${process.getgid()}`]
+      : [];
+  const args = [
+    "run",
+    "--rm",
+    "--network",
+    "none",
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges:true",
+    "--pids-limit",
+    "64",
+    "--memory",
+    "512m",
+    "--cpus",
+    "1",
+    ...userArgs,
+    "--tmpfs",
+    "/tmp:rw,noexec,nosuid,size=64m",
+    "--mount",
+    `type=bind,src=${runDirectory},dst=/evidence`,
+    "--env",
+    "NODEBENCH_ACTIVEGRAPH_MODE=offline-observer",
+    "--env",
+    "PYTHONDONTWRITEBYTECODE=1",
+    "--env",
+    `NODEBENCH_ACTIVEGRAPH_SANDBOX_IMAGE=${sandboxImage}`,
+    "--env",
+    `NODEBENCH_ACTIVEGRAPH_BUILD_INPUTS_SHA256=${imageAttestation.buildInputsHash}`,
+    "--env",
+    `NODEBENCH_CANDIDATE_COMMIT=${imageAttestation.nodebenchCandidateCommit}`,
+    "--env",
+    `NODEBENCH_ACTIVEGRAPH_UPSTREAM_SHA256=${imageAttestation.upstreamHash}`,
+    "--env",
+    `NODEBENCH_ACTIVEGRAPH_IMAGE_ATTESTATION_SHA256=${imageAttestation.attestationHash}`,
+    sandboxImage,
+    "python",
+    "-I",
+    "-m",
+    "nodebench_activegraph_canary.nodekit_replay_cli",
+    "--input",
+    "/evidence/nodekit-run-export.json",
+    "--output",
+    "/evidence/report.json",
+    "--db",
+    "/evidence/activegraph.sqlite3",
+  ];
+  const child = spawnSyncImpl(sandboxExecutable, args, {
+    cwd: runDirectory,
+    encoding: "utf8",
+    shell: false,
+    env: buildOfflineCanaryEnvironment(sourceEnvironment),
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: CHILD_MAX_BUFFER_BYTES,
+  });
+  if (child.error) {
+    if (child.error.code === "ETIMEDOUT") {
+      fail(
+        "canary_timeout",
+        `ActiveGraph canary exceeded its ${CHILD_TIMEOUT_MS}ms runtime budget.`,
+      );
+    }
+    fail("canary_spawn_failed", child.error.message);
+  }
+  if (child.status !== 0) {
+    fail(
+      "canary_process_failed",
+      `ActiveGraph canary exited with code ${String(child.status)}: ${String(
+        child.stderr || child.stdout || "",
+      ).trim()}`,
+    );
+  }
+  assertExactCanaryArtifacts({
+    runDirectory,
+    sourcePath: resolvedExportPath,
+    sourceBytes,
+    stagedExportPath,
+    stagedBytes,
+    reportPath,
+    dbPath,
+  });
+
+  let report;
+  try {
+    report = JSON.parse(
+      readBoundedRegularFile(reportPath, {
+        label: "ActiveGraph report",
+        maxBytes: MAX_REPORT_BYTES,
+        missingCode: "report_read_failed",
+        invalidCode: "report_read_failed",
+        tooLargeCode: "artifact_too_large",
+      }).toString("utf8"),
+    );
+  } catch (error) {
+    if (error instanceof NodeKitExportBoundaryError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    fail("report_read_failed", `Unable to read ActiveGraph report: ${detail}`);
+  }
+  assertChildReport(report, exportDoc, imageAttestation);
+  return Object.freeze({
+    runDirectory,
+    stagedExportPath,
+    reportPath,
+    dbPath,
+    sandboxImage,
+    imageAttestation,
+    report: Object.freeze(report),
+  });
+}
+
+function parseCliArgs(argv) {
+  const result = {};
+  const allowed = new Set([
+    "input",
+    "evidence-root",
+    "sandbox-image",
+    "image-attestation",
+    "docker",
+    "run-name",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      fail("cli_args_invalid", "CLI arguments must be --key value pairs.");
+    }
+    const name = key.slice(2);
+    if (!allowed.has(name) || name in result) {
+      fail("cli_args_invalid", `Unknown or duplicate CLI argument: --${name}.`);
+    }
+    result[name] = value;
+  }
+  for (const required of [
+    "input",
+    "evidence-root",
+    "sandbox-image",
+    "image-attestation",
+  ]) {
+    if (!result[required])
+      fail("cli_args_invalid", `--${required} is required.`);
+  }
+  return result;
+}
+
+function parseAttestationCliArgs(argv) {
+  const result = {};
+  const allowed = new Set(["attestation-output", "sandbox-image"]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      fail("cli_args_invalid", "CLI arguments must be --key value pairs.");
+    }
+    const name = key.slice(2);
+    if (!allowed.has(name) || name in result) {
+      fail("cli_args_invalid", `Unknown or duplicate CLI argument: --${name}.`);
+    }
+    result[name] = value;
+  }
+  for (const required of allowed) {
+    if (!result[required]) {
+      fail("cli_args_invalid", `--${required} is required.`);
+    }
+  }
+  return result;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  const cliArguments = process.argv.slice(2);
+  try {
+    if (
+      cliArguments.length === 1 &&
+      cliArguments[0] === "--print-build-metadata"
+    ) {
+      assertCommittedActiveGraphBuildInputs({});
+      const metadata = createActiveGraphBuildMetadata({
+        nodebenchCandidateCommit: readNodeBenchCandidateCommit(),
+      });
+      process.stdout.write(`${JSON.stringify(metadata)}\n`);
+    } else if (cliArguments.includes("--attestation-output")) {
+      const args = parseAttestationCliArgs(cliArguments);
+      assertCommittedActiveGraphBuildInputs({});
+      const attestation = createActiveGraphImageAttestation({
+        sandboxImage: args["sandbox-image"],
+        nodebenchCandidateCommit: readNodeBenchCandidateCommit(),
+      });
+      const outputPath = resolve(args["attestation-output"]);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, `${canonicalJson(attestation)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      process.stdout.write(
+        `${JSON.stringify({ outputPath, attestationHash: attestation.attestationHash })}\n`,
+      );
+    } else {
+      const args = parseCliArgs(cliArguments);
+      runActiveGraphCanaryFromExport({
+        exportPath: args.input,
+        evidenceRoot: args["evidence-root"],
+        runDirectoryName: args["run-name"],
+        sandboxImage: args["sandbox-image"],
+        imageAttestationPath: args["image-attestation"],
+        sandboxExecutable: args.docker,
+      })
+        .then((result) => {
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        })
+        .catch((error) => {
+          process.stderr.write(
+            `${error instanceof Error ? error.message : error}\n`,
+          );
+          process.exitCode = 1;
+        });
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/preflight-deploy.mjs
+++ b/scripts/preflight-deploy.mjs
@@ -3,9 +3,11 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveConvexTypecheckProject } from "./lib/convexProject.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = resolve(__dirname, "..");
+const CONVEX_TYPECHECK_PROJECT = resolveConvexTypecheckProject(ROOT);
 
 const args = process.argv.slice(2).reduce((acc, arg) => {
   const [rawKey, rawValue] = arg.replace(/^--/, "").split("=");
@@ -82,14 +84,24 @@ const gates = [
     id: "tsc-convex",
     name: "TypeScript Convex",
     check() {
-      const result = run("npx", ["tsc", "-p", "backend/convex", "--noEmit", "--pretty", "false"]);
+      const result = run("npx", [
+        "tsc",
+        "-p",
+        CONVEX_TYPECHECK_PROJECT,
+        "--noEmit",
+        "--pretty",
+        "false",
+      ]);
       return result.ok
-        ? { ok: true, detail: "convex typecheck passed" }
+        ? {
+            ok: true,
+            detail: `convex typecheck passed (${CONVEX_TYPECHECK_PROJECT})`,
+          }
         : {
             ok: false,
             detail: "convex typecheck failed",
             stderr: tail(result.stdout || result.stderr),
-            fix: "Run npx tsc -p backend/convex --noEmit --pretty false.",
+            fix: `Run npx tsc -p ${CONVEX_TYPECHECK_PROJECT} --noEmit --pretty false.`,
           };
     },
   },


### PR DESCRIPTION
﻿## Summary

- register the current NodeBench standard-tree/NodeKit projection without pretending the repo-local runtime has already migrated
- add an immutable, owner-scoped NodeKit run-event chain with canonical export, bounded retention, stale-run recovery, and structured failure semantics
- add a pinned ActiveGraph 1.10.0 offline observer that replays canonical exports only inside an attested Docker image with networking disabled
- add executable TypeScript/Python scenario coverage, schemas, NodeAgent evaluation bindings, documentation, and before/after evidence

## Root cause

The prior prototype proved ActiveGraph behavior but did not create a trustworthy production boundary. Runtime decisions still lived in mutable trace metadata, no canonical append-only event chain existed, retention could be starved or leave running traces unbounded, and the host-side evaluator had no immutable image/build binding or hard artifact/process limits. The brownfield NodeKit manifests also described pre-standard-tree paths and contracts, so conformance could disagree with the runtime layout.

This change fixes the cause by making the exported event chain the authority, bounding its lifecycle at admission and retention, and treating ActiveGraph as a disposable read-only observer behind a fail-closed, commit-bound container boundary.

## Implementation

- `nodeKitRunEvents.ts`: canonical SHA-256 event chain, safe payload projection, lifecycle verification, nondecreasing timestamps, terminal-status consistency, and capacity reservation for every open span plus a terminal event
- `nodeKitRunExport.ts`: authenticated owner-only terminal export; complete-chain and export-hash verification; truthful `run_history_unavailable` for absent legacy/expired/deleted history
- `nodeKitRunRetention.ts`: terminal-only expiry, whole-chain owner deletion, 1,024-row mutation bound, bounded continuations, stale-run closure/purge, and multi-batch legacy-span draining
- execution-trace mutations and MCP start path emit canonical events; daily retention is wired through the reviewed Convex cron path
- ActiveGraph is pinned to 1.10.0 and audited upstream refs; replay deep-copies payloads and writes only disposable SQLite evidence
- Docker attestation binds the immutable image, canonical build-input hash, full candidate commit, upstream record, and exact image labels
- replay runs with `--network none`, read-only root, all capabilities dropped, no-new-privileges, PID/CPU/memory limits, and only `/evidence` writable

## Agentic reliability checklist

1. **BOUND** — 256 events/run; 2 KiB stored payload; 32 KiB redacted source; 256-span stale batches; 1,024 deletion operations/mutation; bounded continuation scheduling; 1 MiB source/child-output caps; 64 KiB report; 64 MiB SQLite.
2. **HONEST_STATUS** — terminal event and payload status must agree; missing canonical history is not labeled legacy; container/CLI failures are nonzero and typed; replay passes only on exact reload parity.
3. **HONEST_SCORES** — no score floors or synthetic confidence are introduced; the canary verdict is boolean and derived from exact event equality/hash checks.
4. **TIMEOUT** — Docker child runtime is capped at 120 seconds; retention work is budgeted and continuation-based rather than an unbounded invocation.
5. **SSRF** — replay accepts no URL input and performs no fetch; the real evaluation container has networking disabled.
6. **BOUND_READ** — regular-file/no-symlink checks plus byte caps precede source, attestation, report, and SQLite reads; the SQLite verifier reads only its header.
7. **ERROR_BOUNDARY** — Convex boundary failures use structured error data; CLI top-level failures preserve typed codes; corrupt retention batches stop instead of spinning.
8. **DETERMINISTIC** — canonical sorted/JCS-compatible serialization drives content hashes, chain heads, export hashes, build-input hashes, upstream hashes, and attestation hashes.

## Verification

Final head: `2af4bfd41a1b024b8222c6c9d99d970d731c94ba`

- `npx vitest run backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts backend/convex/domains/operations/taskManager/taskManagerOwnership.auth.test.ts scripts/__tests__/nodekitActiveGraphCanary.test.ts scripts/__tests__/releaseWorkflowContracts.test.ts --reporter=dot --pool=threads --maxWorkers=1 --minWorkers=1` — **61 passed, 3 skipped**
- `.tmp/venvs/activegraph-canary/Scripts/python.exe -m pytest evals/activegraph/tests -q` — **48 passed**
- `npx tsc -p backend/convex --noEmit --pretty false` — **passed**
- `npx tsc --noEmit --pretty false` — **passed**
- `.tmp/venvs/activegraph-canary/Scripts/python.exe -m pip check` — **passed**
- `npm run build` — **passed**, 7,354 modules transformed and PWA generated
- `git diff --check` — **passed** for the PR; the unrelated local `.serena/project.yml` change was not staged or committed

### Real Docker replay

- Docker Desktop 4.78.0 / Engine 29.5.3
- image: `sha256:e6c0b90d1c3e85c8f6a2e0f7ac13b11ec978e9adc6344f809df8976f13a97224`
- build inputs: `sha256:d2b144ab0bceeb3eee05ba998a23a782227d909c6427f223385be519e6bbc105`
- upstream record: `sha256:37482a57c2a6417fa756977e0dc05e39320470dc613e4c6af93397b3db519e75`
- image attestation: `sha256:7561467e88f030abaf8d5789433f399d5678bf9f5d04b4574ded0a1abb24771f`
- canonical export: 9 events, export `sha256:cd7f691ed8c459354e51db73a8f455f8cf16548db992132740c404b4c6fb485b`
- result: **verdict pass**, `persisted_reload_parity: true`, Docker runtime, `network: none`, read-only root, only `/evidence` writable

Evidence: `evidence/activegraph-production-slice/` and `evidence/activegraph-release-hardening/`.

## Known limitations / release posture

- The three skipped ownership integration cases are blocked by existing dependency skew: `convex-test@0.0.53` requires Convex `>=1.32`, while this repository resolves `1.31.5`. The two source guards in that suite pass; focused owner/corrupt-chain/retention scenarios are executable and green.
- ActiveGraph remains an offline observer. It does not answer, approve, dual-write, or replace NodeBench state.
- The image attestation is local provenance, not a trusted signed supply-chain attestation.
- No Convex deployment, production mutation, merge, or live-site claim was performed.
