### PR TITLE
docs: close ActiveGraph coordination claim

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,20 +57,6 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-07-28 · Codex `/root/activegraph_final_audit` →**
-  `backend/convex/schema.ts#agentTaskTraces+agentTaskSpans+nodeKitRunEvents`,
-  `backend/convex/domains/operations/taskManager/{mutations,nodeKitRunEvents,nodeKitRunExport,nodeKitRunRetention}*`,
-  `backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts#nodekit-events`,
-  `backend/convex/crons.ts#nodekit-retention`,
-  `scripts/nodekit/**`, `scripts/__tests__/{nodekitActiveGraphCanary,releaseWorkflowContracts}.test.ts`,
-  `evals/activegraph/**`, `evals/nodebench-*.json`,
-  `nodekit.yaml`, `nodeagent.yaml`, `agent/**`,
-  `packs/entity-intelligence/**`, `scripts/{preflight-deploy,lib/convexProject}.mjs`,
-  `docs/architecture/{NODEKIT_ACTIVEGRAPH_CANARY,STANDARD_REPO_TREE}.md`,
-  and `evidence/activegraph-*` · PR-ready release packaging, Docker replay,
-  scoped commit/push/PR · branch `codex/activegraph-canary`. No deploy or
-  production mutation.
-
 > **STANDARD-TREE MIGRATION (2026-07-19, feat/standard-tree-migration): repo paths moved.**
 > `convex/` → `backend/convex/` (convex.json `functions` added; function identifiers unchanged),
 > `src/` + `index.html` → `apps/web/` (`@convex` alias replaces relative `../convex` imports),


### PR DESCRIPTION
## What changed

- Removes the merged ActiveGraph/NodeKit work from `AGENT_COORDINATION.md` → **Active claims**.
- Preserves the detailed ActiveGraph hand-off already recorded in the ledger.

## Why

PR #596 was squash-merged as `2a9196e9523d0a51b2136e1c664b55066bf58b09`. The ledger protocol says merged work must be moved to **Recently shipped** or deleted; leaving the claim active would falsely reserve the files and invite coordination collisions.

## Scope

One documentation file, 14 deleted lines. No runtime, schema, deployment, or production changes.

## Verification

- `git diff --check -- AGENT_COORDINATION.md`
- Asserted the ActiveGraph claim is absent specifically from the **Active claims** section.
- Asserted the permanent `Release-hardening audit complete` hand-off remains.
- Confirmed only `AGENT_COORDINATION.md` is committed; unrelated local `.serena/project.yml` remains unstaged.