### PR TITLE
feat(nodekit): bind stage-local graph runtime

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -17,7 +17,7 @@ gracefully instead of clobbering each other. This is the **single source of trut
    ScratchNode e2e specs. Scan **Active claims** below.
 2. **Claim your region** before editing: append a bullet to **Active claims** —
    `agent · file:region · intent · branch/PR`. Region matters: `home-v5.html#directory`
-   and `home-v5.html#share-moment` can run in parallel; the *same* region cannot.
+   and `home-v5.html#share-moment` can run in parallel; the _same_ region cannot.
 3. **Don't deploy backend out-of-band.** Never `npx convex deploy`/`deploy:prod` from a
    worktree to the shared prod deployment — it pushes un-reviewed schema/functions and
    breaks the other agent's next deploy. Ship via PR (CI runs `convex deploy`). If you
@@ -57,10 +57,11 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-07-29 · Codex `/root` →** `apps/web/src/features/entities/components/notebook/EntityNotebookLive.tsx`,
-  its mount/tests, and `docs/design/note-surface/*` · complete the actual Live notebook
-  Cmd/Ctrl+E capture path and rebuild the Mobbin/Mew/Roam evidence chain · branch
-  `codex/note-surface-complete` / PR #601. No backend or Convex deploy.
+- **2026-07-29 · Codex `/root` →** `backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts`,
+  `nodeKitRunExport.ts`, adjacent tests/schema, and NodeKit integration docs · add the stage-local
+  execution-graph/edge/frontier/review-context trace bindings and persistent session identity
+  references without replacing Caseflow authority · branch `codex/nodekit-stage-local-integration`.
+  No out-of-band Convex deploy.
 
 > **STANDARD-TREE MIGRATION (2026-07-19, feat/standard-tree-migration): repo paths moved.**
 > `convex/` → `backend/convex/` (convex.json `functions` added; function identifiers unchanged),
@@ -81,6 +82,21 @@ Server Error) for an unknown slug.
   that re-deploys the #494 functions the incident note describes → heals prod.
 
 ## Hand-offs (built + ready for the other agent to call)
+
+- **2026-07-29 - Codex `/root` -> execution-trace and MCP consumers** -
+  Candidate on `codex/nodekit-stage-local-integration`, not deployed:
+  `mcpStartExecutionRun({ ..., nativeIdentity?: {agentId, workspaceId,
+nativeSessionId, nativeSessionGeneration, peerId?} })` returns the immutable
+  `nodekit.native-agent-session-identity/v1` snapshot plus continuity
+  `created | reconnect | rotate`. `recordExecutionGraphEvent({traceId,
+eventType, graphId, graphHash, caseId, stageId, caseContentHash, nodeId,
+nodeRunId, ...eventSpecificFields})` appends one exact graph event and returns
+  its SHA-256 content hash. The gateway entry is secret-gated and injects the
+  service owner. Shared schema additions are optional. Caseflow remains
+  authoritative; the runtime records NodeKit-generated graph/frontier/binding
+  evidence and never derives approval or stage advancement. No out-of-band
+  Convex deploy. Local verification: root typecheck, 74 focused scenarios,
+  root production build, and MCP-local package build pass.
 
 - **2026-07-28 - Codex `/root/activegraph_final_audit` -> `/root`** -
   Release-hardening audit complete on the uncommitted
@@ -195,17 +211,17 @@ Server Error) for an unknown slug.
   `c4035256` / `fa397589`)** - authenticated
   FastAgent runs reserve budget atomically through internal
   `domains/billing/rateLimiting:reserveLlmRequestInternal({ reservationKey,
-  attemptKey, userId, model, estimatedInputTokens, estimatedOutputTokens,
-  reserveMaximumTierAllowance?, agentThreadId?, runId?, workerId? })`; the mutation
+attemptKey, userId, model, estimatedInputTokens, estimatedOutputTokens,
+reserveMaximumTierAllowance?, agentThreadId?, runId?, workerId? })`; the mutation
   atomically rechecks durable cancellation and the queue lease when those optional
   fence arguments are supplied. Keyed reconciliation is
   `recordLlmUsageInternal({ reservationKey, attemptKey, userId, ...usage })` and
   pre-provider release is `releaseLlmReservationInternal({ reservationKey,
-  attemptKey, userId, reason? })`; it releases only the exact `admitted` attempt
+attemptKey, userId, reason? })`; it releases only the exact `admitted` attempt
   and preserves any earlier settled spend. The provider boundary is closed by
   `markLlmReservationAttemptEndedInternal`, and ambiguous terminal spend is
   finalized by `finalizeAmbiguousLlmReservationInternal({ reservationKey,
-  attemptKey, userId, reason? })`, retaining the full reservation maximum rather
+attemptKey, userId, reason? })`, retaining the full reservation maximum rather
   than admitting an unreserved fallback. A scheduled exact-attempt
   `reapExpiredLlmReservationInternal` applies the same conservative rule to
   crash-stranded work. `llmUsageLog`
@@ -264,7 +280,7 @@ Server Error) for an unknown slug.
     with `e.data.code === 'join_requires_approval'` (and `e.data.requestStatus`) for
     non-approved non-members. **Open rooms are unchanged.** Handle this code in the room
     boot to show a "request to join" prompt instead of a generic error.
-  - **The LLM is ADVISORY only** — it never admits/denies. Render `llm*` as host *hints*,
+  - **The LLM is ADVISORY only** — it never admits/denies. Render `llm*` as host _hints_,
     never as an action. The host's approve/deny is the only thing that admits a guest.
 - **2026-06-03 · Claude →** PUBLIC wiki read (PR #486, additive). Frontend `/wiki/<slug>`
   reader calls:
@@ -283,6 +299,12 @@ Server Error) for an unknown slug.
   actually enters a room. The live counter + share moment both honor this.
 
 ## Recently shipped (this ScratchNode session)
+
+- **2026-07-29 · Codex `/root`** — Live notebook capture and its Mobbin/Mew/Roam evidence chain
+  merged through PR #601 at `8416106a`. Cmd/Ctrl+E now preserves underlying write authority,
+  focuses the first editable block, creates one empty block at most once, and fails closed for
+  shared/read-only/input-focused cases. CI and preview gates passed; authenticated production
+  journey proof remains separately tracked.
 
 - **2026-07-16 Codex - reproducible receipt continuation (#557 `6dd180c9`)** -
   separated fresh reruns from live-chat continuation, restored the receipt prompt,
@@ -370,8 +392,8 @@ Server Error) for an unknown slug.
   token path (`/events/:slug/private` and token consumption). Keep it gated and reviewed;
   do not expose session ids, private notes, anchors, or tokens in public links.
 - **Claude** — directory viral slice (`home-v5.html#directory`): flyer cards + "● N inside" presence cue + policy-aware action (open → "Join now"; request → "Request to join" `<button>` wired to `events:requestJoinEvent`, watching `getMyJoinRequest` for approval, on the **same `sn_session_id`** so approval carries through the `joinEvent` door gate). 18/18 chromium honesty suite; desktop + mobile verified. (This consumes the Codex 8c3a0cc9 "Request to join" label hand-off.)
-- **#481 Claude** — post-create viral *share moment* (home-v5.html landing): invite card + QR + copy + Text/Email + "Enter your room →".
-- **#480 Claude** — door-policy *backend* (`backend/convex/events.ts` + `eventsSchema.ts`): request table, gate, request/approve/deny, advisory LLM bouncer. 6/6 scenario tests.
+- **#481 Claude** — post-create viral _share moment_ (home-v5.html landing): invite card + QR + copy + Text/Email + "Enter your room →".
+- **#480 Claude** — door-policy _backend_ (`backend/convex/events.ts` + `eventsSchema.ts`): request table, gate, request/approve/deny, advisory LLM bouncer. 6/6 scenario tests.
 - **#477 Claude** — schema-drift hotfix: tolerate `lastActivityAt` so Convex deploy passed.
 - **#476 Claude** — synthesized landing (live counter + Create-first), cherry-picking Codex's index-backed "active now" + chrome-leak fix.
 - **8c3a0cc9 Codex** — public room discovery (directory + `joinPolicy` field + `listPublicRooms` + the "Request to join" label, not yet wired).

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -23,6 +23,7 @@ This directory contains append-only per-surface changelog lanes. Each lane recor
 
 - [`integrations/ai-elements.md`](integrations/ai-elements.md) — Vercel AI Elements scaffold, adapter, and governance integration.
 - [`integrations/pipeline-runtime.md`](integrations/pipeline-runtime.md) — Owner-scoped pipeline launch, activity, streaming, evaluation, schedules, and MCP bridge contracts.
+- [`integrations/nodekit-stage-local-runtime.md`](integrations/nodekit-stage-local-runtime.md) — NodeKit current-stage graph, exact edge-binding, native-session identity, MCP trace, and offline ActiveGraph contracts.
 
 ### Build and bundling
 

--- a/CHANGELOG/integrations/nodekit-stage-local-runtime.md
+++ b/CHANGELOG/integrations/nodekit-stage-local-runtime.md
@@ -1,0 +1,31 @@
+# NodeKit Stage-Local Runtime
+
+Append-only lane for NodeKit graph, exact edge-binding, native-session identity,
+run-event, export, MCP, and offline ActiveGraph compatibility. Newest entries
+first.
+
+## 2026-07-29 — Bind NodeBench traces to NodeKit's current-stage graph
+
+The pending candidate adds an owner/workspace-scoped native-agent session
+identity, records NodeKit's exact stage-local graph, frontier, edge-binding,
+artifact, barrier, and separated-review evidence, and exports the immutable
+identity snapshot with the terminal run chain. The MCP gateway exposes a
+secret-gated graph-event mutation with injected service ownership. The
+ActiveGraph canary remains offline and non-authoritative but now exercises a
+representative graph-and-identity corpus.
+
+Caseflow remains canonical. NodeBench does not compile a second graph, infer
+readiness from exit codes, approve review findings, or advance stages.
+
+**PR / canonical main commit**: PENDING PR / MAIN SHA / FINAL QA.
+
+**Evidence state**:
+
+- Source: pending on `codex/nodekit-stage-local-integration`.
+- Checks: root typecheck passed; 74 focused contract, database, export, retention, MCP, and ActiveGraph scenarios passed; the root production build and MCP-local package build passed. CI remains pending.
+- Visual proof: not applicable; this slice changes backend and tool contracts.
+- Preview: not recorded.
+- Production live: not recorded.
+
+**Author**: Homen Shum + Codex.
+**Touches**: [`../../docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md`](../../docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md) and [`../../docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md`](../../docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md).

--- a/CHANGELOG/integrations/nodekit-stage-local-runtime.md
+++ b/CHANGELOG/integrations/nodekit-stage-local-runtime.md
@@ -17,11 +17,11 @@ representative graph-and-identity corpus.
 Caseflow remains canonical. NodeBench does not compile a second graph, infer
 readiness from exit codes, approve review findings, or advance stages.
 
-**PR / canonical main commit**: PENDING PR / MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #602 / PENDING MAIN SHA / FINAL QA.
 
 **Evidence state**:
 
-- Source: pending on `codex/nodekit-stage-local-integration`.
+- Source: pending in PR #602 from `codex/nodekit-stage-local-integration`.
 - Checks: root typecheck passed; 74 focused contract, database, export, retention, MCP, and ActiveGraph scenarios passed; the root production build and MCP-local package build passed. CI remains pending.
 - Visual proof: not applicable; this slice changes backend and tool contracts.
 - Preview: not recorded.

--- a/CHANGELOG/integrations/nodekit-stage-local-runtime.md
+++ b/CHANGELOG/integrations/nodekit-stage-local-runtime.md
@@ -17,11 +17,11 @@ representative graph-and-identity corpus.
 Caseflow remains canonical. NodeBench does not compile a second graph, infer
 readiness from exit codes, approve review findings, or advance stages.
 
-**PR / canonical main commit**: #602 / PENDING MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #603 / PENDING MAIN SHA / FINAL QA.
 
 **Evidence state**:
 
-- Source: pending in PR #602 from `codex/nodekit-stage-local-integration`.
+- Source: pending in PR #603 from `feat/nodekit-stage-local-integration`.
 - Checks: root typecheck passed; 74 focused contract, database, export, retention, MCP, and ActiveGraph scenarios passed; the root production build and MCP-local package build passed. CI remains pending.
 - Visual proof: not applicable; this slice changes backend and tool contracts.
 - Preview: not recorded.

--- a/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.integration.test.ts
+++ b/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.integration.test.ts
@@ -1,0 +1,324 @@
+/// <reference types="vite/client" />
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { internal } from "../../_generated/api";
+import schema from "../../schema";
+
+const DIR_SEGMENTS = ["domains", "mcp"];
+
+function rerootGlobKey(key: string): string {
+  const parts = key.replace(/^\.\//, "").split("/");
+  const base = [...DIR_SEGMENTS];
+  while (parts[0] === "..") {
+    parts.shift();
+    base.pop();
+  }
+  return [...base, ...parts].join("/");
+}
+
+const convexModules = Object.fromEntries(
+  Object.entries(import.meta.glob("../../**/*.{ts,js}")).map(
+    ([key, loader]) => [rerootGlobKey(key), loader],
+  ),
+);
+
+let convexTest: any;
+let convexTestAvailable = false;
+try {
+  const convexTestModule =
+    process.env.NODEBENCH_CONVEX_TEST_MODULE ?? "convex-test";
+  const mod = await import(/* @vite-ignore */ convexTestModule);
+  convexTest = mod.convexTest;
+  convexTestAvailable = typeof convexTest === "function";
+} catch {
+  convexTestAvailable = false;
+}
+
+const traceEndpoints = (internal as any).domains.mcp.mcpExecutionTraceEndpoints;
+
+describe("NodeKit execution trace gateway contract", () => {
+  it("keeps graph writes secret-gated and injects the service owner", () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        "backend/convex/domains/mcp/mcpGatewayDispatcher.ts",
+      ),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /recordExecutionGraphEvent:\s*\{[\s\S]*?recordExecutionGraphEvent,[\s\S]*?type:\s*"mutation",[\s\S]*?injectUserId:\s*true,[\s\S]*?\}/,
+    );
+    expect(source).not.toMatch(
+      /PUBLIC_RESEARCH_GATEWAY_FNS[\s\S]*?recordExecutionGraphEvent/,
+    );
+  });
+});
+
+function startArgs(
+  userId: string,
+  overrides: Partial<{
+    agentId: string;
+    workspaceId: string;
+    nativeSessionId: string;
+    nativeSessionGeneration: number;
+    peerId: string;
+  }> = {},
+) {
+  return {
+    userId,
+    title: "Compile the approved build stage",
+    workflowName: "nodekit-stage-local-build",
+    type: "agent" as const,
+    visibility: "private" as const,
+    nativeIdentity: {
+      agentId: "codex.desktop",
+      workspaceId: "workspace:nodebench",
+      nativeSessionId: "session:desktop:2026-07-29",
+      nativeSessionGeneration: 4,
+      peerId: "peer:runner:codex",
+      ...overrides,
+    },
+  };
+}
+
+describe.skipIf(!convexTestAvailable)(
+  "NodeKit execution trace identity and graph persistence",
+  () => {
+    it("creates, reconnects, and explicitly rotates one owner-scoped native identity", async () => {
+      const t = convexTest(schema, convexModules);
+      const userId = await t.run((ctx: any) =>
+        ctx.db.insert("users", { email: "nodekit-identity@example.com" }),
+      );
+
+      const created = await t.mutation(
+        traceEndpoints.mcpStartExecutionRun,
+        startArgs(userId),
+      );
+      const reconnected = await t.mutation(
+        traceEndpoints.mcpStartExecutionRun,
+        startArgs(userId),
+      );
+      const rotated = await t.mutation(
+        traceEndpoints.mcpStartExecutionRun,
+        startArgs(userId, {
+          nativeSessionId: "session:desktop:2026-07-30",
+          nativeSessionGeneration: 5,
+        }),
+      );
+
+      expect([
+        created.nativeIdentityContinuity,
+        reconnected.nativeIdentityContinuity,
+        rotated.nativeIdentityContinuity,
+      ]).toEqual(["created", "reconnect", "rotate"]);
+      expect(created.nativeIdentity?.identityRef).toBe(
+        reconnected.nativeIdentity?.identityRef,
+      );
+      expect(rotated.nativeIdentity).toMatchObject({
+        nativeSessionId: "session:desktop:2026-07-30",
+        nativeSessionGeneration: 5,
+      });
+
+      const stored = await t.run(async (ctx: any) => ({
+        identities: await ctx.db.query("agentIdentities").collect(),
+        sessions: await ctx.db.query("agentTaskSessions").collect(),
+        traces: await ctx.db.query("agentTaskTraces").collect(),
+        events: await ctx.db.query("nodeKitRunEvents").collect(),
+      }));
+      expect(stored.identities).toHaveLength(1);
+      expect(stored.sessions).toHaveLength(3);
+      expect(stored.traces).toHaveLength(3);
+      expect(stored.events).toHaveLength(3);
+      expect(stored.sessions[0].nativeIdentity.snapshotHash).toBe(
+        stored.events[0].payload.fields.identitySnapshotHash,
+      );
+    });
+
+    it.each([
+      {
+        label: "stale generation",
+        overrides: { nativeSessionGeneration: 3 },
+        message: /native_session_stale/,
+      },
+      {
+        label: "same-generation session collision",
+        overrides: { nativeSessionId: "session:collision" },
+        message: /native_session_collision/,
+      },
+      {
+        label: "peer replacement during reconnect",
+        overrides: { peerId: "peer:runner:impostor" },
+        message: /native_peer_mismatch/,
+      },
+    ])(
+      "rejects $label without appending partial state",
+      async ({ overrides, message }) => {
+        const t = convexTest(schema, convexModules);
+        const userId = await t.run((ctx: any) =>
+          ctx.db.insert("users", {
+            email: `nodekit-${overrides.nativeSessionGeneration ?? 4}@example.com`,
+          }),
+        );
+        await t.mutation(
+          traceEndpoints.mcpStartExecutionRun,
+          startArgs(userId),
+        );
+
+        await expect(
+          t.mutation(
+            traceEndpoints.mcpStartExecutionRun,
+            startArgs(userId, overrides),
+          ),
+        ).rejects.toThrow(message);
+
+        const counts = await t.run(async (ctx: any) => ({
+          identities: (await ctx.db.query("agentIdentities").collect()).length,
+          sessions: (await ctx.db.query("agentTaskSessions").collect()).length,
+          traces: (await ctx.db.query("agentTaskTraces").collect()).length,
+          events: (await ctx.db.query("nodeKitRunEvents").collect()).length,
+        }));
+        expect(counts).toEqual({
+          identities: 1,
+          sessions: 1,
+          traces: 1,
+          events: 1,
+        });
+      },
+    );
+
+    it("validates the complete native identity before inserting any row", async () => {
+      const t = convexTest(schema, convexModules);
+      const userId = await t.run((ctx: any) =>
+        ctx.db.insert("users", { email: "nodekit-invalid@example.com" }),
+      );
+
+      await expect(
+        t.mutation(
+          traceEndpoints.mcpStartExecutionRun,
+          startArgs(userId, { nativeSessionId: "unsafe session id" }),
+        ),
+      ).rejects.toThrow(/native_identity_field_invalid/);
+
+      const counts = await t.run(async (ctx: any) => ({
+        identities: (await ctx.db.query("agentIdentities").collect()).length,
+        sessions: (await ctx.db.query("agentTaskSessions").collect()).length,
+      }));
+      expect(counts).toEqual({ identities: 0, sessions: 0 });
+    });
+
+    it("serializes a burst of reconnects onto one identity without duplicate rows", async () => {
+      const t = convexTest(schema, convexModules);
+      const userId = await t.run((ctx: any) =>
+        ctx.db.insert("users", { email: "nodekit-burst@example.com" }),
+      );
+
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          t.mutation(traceEndpoints.mcpStartExecutionRun, startArgs(userId)),
+        ),
+      );
+      expect(
+        results.filter(
+          (result) => result.nativeIdentityContinuity === "created",
+        ),
+      ).toHaveLength(1);
+      expect(
+        results.filter(
+          (result) => result.nativeIdentityContinuity === "reconnect",
+        ),
+      ).toHaveLength(7);
+
+      const identityCount = await t.run(
+        async (ctx: any) =>
+          (await ctx.db.query("agentIdentities").collect()).length,
+      );
+      expect(identityCount).toBe(1);
+    });
+
+    it("keeps sustained reconnect state bounded to one identity while retaining immutable run snapshots", async () => {
+      const t = convexTest(schema, convexModules);
+      const userId = await t.run((ctx: any) =>
+        ctx.db.insert("users", { email: "nodekit-sustained@example.com" }),
+      );
+
+      for (let index = 0; index < 32; index += 1) {
+        await t.mutation(
+          traceEndpoints.mcpStartExecutionRun,
+          startArgs(userId),
+        );
+      }
+
+      const stored = await t.run(async (ctx: any) => ({
+        identities: await ctx.db.query("agentIdentities").collect(),
+        sessions: await ctx.db.query("agentTaskSessions").collect(),
+        traces: await ctx.db.query("agentTaskTraces").collect(),
+        events: await ctx.db.query("nodeKitRunEvents").collect(),
+      }));
+      expect(stored.identities).toHaveLength(1);
+      expect(stored.sessions).toHaveLength(32);
+      expect(stored.traces).toHaveLength(32);
+      expect(stored.events).toHaveLength(32);
+      expect(
+        new Set(
+          stored.sessions.map(
+            (session: any) => session.nativeIdentity.snapshotHash,
+          ),
+        ),
+      ).toEqual(new Set([stored.identities[0].nativeIdentitySnapshotHash]));
+    });
+
+    it("rejects cross-tenant graph appends and stores the owner-bound exact graph event", async () => {
+      const t = convexTest(schema, convexModules);
+      const { ownerId, foreignId } = await t.run(async (ctx: any) => ({
+        ownerId: await ctx.db.insert("users", {
+          email: "nodekit-owner@example.com",
+        }),
+        foreignId: await ctx.db.insert("users", {
+          email: "nodekit-foreign@example.com",
+        }),
+      }));
+      const started = await t.mutation(
+        traceEndpoints.mcpStartExecutionRun,
+        startArgs(ownerId),
+      );
+      const graphEvent = {
+        traceId: started.traceId,
+        eventType: "node.started" as const,
+        graphId: `execution-graph:sha256:${"a".repeat(64)}`,
+        graphHash: "b".repeat(64),
+        caseId: "case:nodebench",
+        stageId: "build",
+        caseContentHash: "c".repeat(64),
+        nodeId: "node:build-ui",
+        nodeRunId: "node-run:build-ui:1",
+        nodeKind: "task",
+        frontierHash: "d".repeat(64),
+      };
+
+      await expect(
+        t.mutation(traceEndpoints.recordExecutionGraphEvent, {
+          userId: foreignId,
+          ...graphEvent,
+        }),
+      ).rejects.toThrow(/not owned/);
+      const contentHash = await t.mutation(
+        traceEndpoints.recordExecutionGraphEvent,
+        { userId: ownerId, ...graphEvent },
+      );
+      expect(contentHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+
+      const events = await t.run((ctx: any) =>
+        ctx.db.query("nodeKitRunEvents").collect(),
+      );
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({
+        eventType: "node.started",
+        runId: started.publicTraceId,
+      });
+    });
+  },
+);

--- a/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts
+++ b/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts
@@ -1,7 +1,16 @@
 import { v } from "convex/values";
-import { internalMutation } from "../../_generated/server";
+import { internalMutation, type MutationCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { appendNodeKitRunEvent } from "../operations/taskManager/nodeKitRunEvents";
+import {
+  NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION,
+  buildNodeKitNativeIdentityRef,
+  buildNodeKitNativeSessionIdentity,
+  compareNodeKitNativeSessionIdentity,
+  type NodeKitNativeSessionIdentity,
+  type NodeKitNativeSessionIdentityInput,
+  validateNodeKitNativeSessionIdentityInput,
+} from "../operations/taskManager/nodeKitRuntimeIdentity";
 
 const oracleSourceRefValidator = v.object({
   label: v.string(),
@@ -9,6 +18,103 @@ const oracleSourceRefValidator = v.object({
   note: v.optional(v.string()),
   kind: v.optional(v.string()),
 });
+
+const nativeIdentityInputValidator = v.object({
+  agentId: v.string(),
+  workspaceId: v.string(),
+  nativeSessionId: v.string(),
+  nativeSessionGeneration: v.number(),
+  peerId: v.optional(v.string()),
+});
+
+const nativeIdentitySnapshotValidator = v.object({
+  schemaVersion: v.literal(NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION),
+  identityRef: v.string(),
+  agentId: v.string(),
+  workspaceId: v.string(),
+  nativeSessionId: v.string(),
+  nativeSessionGeneration: v.number(),
+  peerId: v.optional(v.string()),
+  snapshotHash: v.string(),
+});
+
+async function resolveNativeIdentity(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  input: NodeKitNativeSessionIdentityInput,
+): Promise<{
+  snapshot: NodeKitNativeSessionIdentity;
+  continuity: "created" | "reconnect" | "rotate";
+}> {
+  validateNodeKitNativeSessionIdentityInput(input);
+  const existing = await ctx.db
+    .query("agentIdentities")
+    .withIndex("by_owner_workspace_agent", (q) =>
+      q
+        .eq("ownerUserId", userId)
+        .eq("workspaceId", input.workspaceId)
+        .eq("agentId", input.agentId),
+    )
+    .first();
+  const now = Date.now();
+  const identityId =
+    existing?._id ??
+    (await ctx.db.insert("agentIdentities", {
+      agentId: input.agentId,
+      ownerUserId: userId,
+      workspaceId: input.workspaceId,
+      identityContractVersion: NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION,
+      name: input.agentId,
+      persona: "Native NodeKit execution agent",
+      allowedTools: [],
+      allowedChannels: [],
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    }));
+  if (existing && existing.status !== "active") {
+    throw new Error(`Native agent identity is ${existing.status}.`);
+  }
+
+  const identityRef = await buildNodeKitNativeIdentityRef(String(identityId));
+  const snapshot = await buildNodeKitNativeSessionIdentity({
+    identityRef,
+    ...input,
+  });
+  let continuity: "created" | "reconnect" | "rotate" = "created";
+  if (existing) {
+    if (
+      existing.identityContractVersion !==
+        NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION ||
+      existing.nativeSessionId === undefined ||
+      existing.nativeSessionGeneration === undefined
+    ) {
+      throw new Error(
+        "Native agent identity has incomplete persisted session state.",
+      );
+    }
+    const previous = await buildNodeKitNativeSessionIdentity({
+      identityRef,
+      agentId: existing.agentId,
+      workspaceId: existing.workspaceId ?? "",
+      nativeSessionId: existing.nativeSessionId,
+      nativeSessionGeneration: existing.nativeSessionGeneration,
+      peerId: existing.nativePeerId,
+    });
+    continuity = compareNodeKitNativeSessionIdentity(previous, snapshot);
+  }
+
+  await ctx.db.patch(identityId, {
+    identityContractVersion: NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION,
+    nativeSessionId: snapshot.nativeSessionId,
+    nativeSessionGeneration: snapshot.nativeSessionGeneration,
+    nativePeerId: snapshot.peerId,
+    nativeIdentitySnapshotHash: snapshot.snapshotHash,
+    lastSeenAt: now,
+    updatedAt: now,
+  });
+  return { snapshot, continuity };
+}
 
 function generateTraceId(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -39,6 +145,7 @@ export const mcpStartExecutionRun = internalMutation({
     visionSnapshot: v.optional(v.string()),
     successCriteria: v.optional(v.array(v.string())),
     sourceRefs: v.optional(v.array(oracleSourceRefValidator)),
+    nativeIdentity: v.optional(nativeIdentityInputValidator),
     metadata: v.optional(v.any()),
   },
   returns: v.object({
@@ -46,9 +153,25 @@ export const mcpStartExecutionRun = internalMutation({
     traceId: v.id("agentTaskTraces"),
     publicTraceId: v.string(),
     status: v.string(),
+    nativeIdentity: v.optional(nativeIdentitySnapshotValidator),
+    nativeIdentityContinuity: v.optional(
+      v.union(
+        v.literal("created"),
+        v.literal("reconnect"),
+        v.literal("rotate"),
+      ),
+    ),
   }),
   handler: async (ctx, args) => {
     const now = Date.now();
+    const resolvedIdentity =
+      args.nativeIdentity === undefined
+        ? undefined
+        : await resolveNativeIdentity(
+            ctx,
+            args.userId as Id<"users">,
+            args.nativeIdentity,
+          );
     const sessionId = await ctx.db.insert("agentTaskSessions", {
       title: args.title,
       description: args.description,
@@ -61,9 +184,12 @@ export const mcpStartExecutionRun = internalMutation({
       visionSnapshot: args.visionSnapshot,
       successCriteria: args.successCriteria,
       sourceRefs: args.sourceRefs,
+      nativeIdentity: resolvedIdentity?.snapshot,
       metadata: {
         executionTraceOrigin: "mcp",
-        ...(args.metadata && typeof args.metadata === "object" ? (args.metadata as Record<string, unknown>) : {}),
+        ...(args.metadata && typeof args.metadata === "object"
+          ? (args.metadata as Record<string, unknown>)
+          : {}),
       },
     });
 
@@ -76,11 +202,14 @@ export const mcpStartExecutionRun = internalMutation({
       visionSnapshot: args.visionSnapshot,
       successCriteria: args.successCriteria,
       sourceRefs: args.sourceRefs,
+      nativeIdentity: resolvedIdentity?.snapshot,
       status: "running",
       startedAt: now,
       metadata: {
         executionTraceOrigin: "mcp",
-        ...(args.metadata && typeof args.metadata === "object" ? (args.metadata as Record<string, unknown>) : {}),
+        ...(args.metadata && typeof args.metadata === "object"
+          ? (args.metadata as Record<string, unknown>)
+          : {}),
       },
     });
 
@@ -96,6 +225,20 @@ export const mcpStartExecutionRun = internalMutation({
         origin: "mcp",
         sessionType: args.type ?? "agent",
         sessionStartedAt: now,
+        ...(resolvedIdentity === undefined
+          ? {}
+          : {
+              identityRef: resolvedIdentity.snapshot.identityRef,
+              workspaceId: resolvedIdentity.snapshot.workspaceId,
+              agentId: resolvedIdentity.snapshot.agentId,
+              nativeSessionId: resolvedIdentity.snapshot.nativeSessionId,
+              nativeSessionGeneration:
+                resolvedIdentity.snapshot.nativeSessionGeneration,
+              ...(resolvedIdentity.snapshot.peerId === undefined
+                ? {}
+                : { peerId: resolvedIdentity.snapshot.peerId }),
+              identitySnapshotHash: resolvedIdentity.snapshot.snapshotHash,
+            }),
         ...(args.goalId === undefined ? {} : { goalId: args.goalId }),
       },
       allowLegacySkip: false,
@@ -106,6 +249,82 @@ export const mcpStartExecutionRun = internalMutation({
       traceId,
       publicTraceId,
       status: "running",
+      nativeIdentity: resolvedIdentity?.snapshot,
+      nativeIdentityContinuity: resolvedIdentity?.continuity,
     };
+  },
+});
+
+const executionGraphEventTypeValidator = v.union(
+  v.literal("node.started"),
+  v.literal("edge.consumed"),
+  v.literal("artifact.produced"),
+  v.literal("node.completed"),
+  v.literal("node.failed"),
+  v.literal("barrier.opened"),
+  v.literal("barrier.blocked"),
+);
+
+export const recordExecutionGraphEvent = internalMutation({
+  args: {
+    userId: v.string(),
+    traceId: v.id("agentTaskTraces"),
+    eventType: executionGraphEventTypeValidator,
+    graphId: v.string(),
+    graphHash: v.string(),
+    caseId: v.string(),
+    stageId: v.string(),
+    caseContentHash: v.string(),
+    nodeId: v.string(),
+    nodeRunId: v.string(),
+    nodeKind: v.optional(v.string()),
+    frontierHash: v.optional(v.string()),
+    edgeId: v.optional(v.string()),
+    bindingId: v.optional(v.string()),
+    bindingHash: v.optional(v.string()),
+    artifactId: v.optional(v.string()),
+    artifactSchemaVersion: v.optional(v.string()),
+    artifactContentHash: v.optional(v.string()),
+    authorityKind: v.optional(v.string()),
+    status: v.optional(v.string()),
+    reasonCode: v.optional(v.string()),
+    blockingEdgeCount: v.optional(v.number()),
+    reviewContextRef: v.optional(v.string()),
+    reviewSeparation: v.optional(v.string()),
+    protectedEvaluator: v.optional(v.boolean()),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const trace = await ctx.db.get(args.traceId);
+    if (!trace) throw new Error("Execution trace not found.");
+    const session = await ctx.db.get(trace.sessionId);
+    if (!session || String(session.userId) !== args.userId) {
+      throw new Error("Execution trace is not owned by the service user.");
+    }
+    if (trace.status !== "running") {
+      throw new Error(`Execution trace is already ${trace.status}.`);
+    }
+
+    const {
+      userId: _userId,
+      traceId: _traceId,
+      eventType,
+      ...candidate
+    } = args;
+    const payload = Object.fromEntries(
+      Object.entries(candidate).filter(([, value]) => value !== undefined),
+    );
+    const event = await appendNodeKitRunEvent(ctx, {
+      sessionId: session._id,
+      traceId: trace._id,
+      userId: session.userId as Id<"users">,
+      runId: trace.traceId,
+      eventType,
+      recordedAt: Date.now(),
+      payload,
+      allowLegacySkip: false,
+    });
+    if (!event) throw new Error("Graph event was not stored.");
+    return event.contentHash;
   },
 });

--- a/backend/convex/domains/mcp/mcpGatewayDispatcher.ts
+++ b/backend/convex/domains/mcp/mcpGatewayDispatcher.ts
@@ -304,6 +304,11 @@ const ALLOWLIST: Record<string, AllowlistEntry> = {
     type: "mutation",
     injectUserId: true,
   },
+  recordExecutionGraphEvent: {
+    ref: internal.domains.mcp.mcpExecutionTraceEndpoints.recordExecutionGraphEvent,
+    type: "mutation",
+    injectUserId: true,
+  },
 
   // ── GROUP C: Document internal endpoints — already accept userId ─────────
 

--- a/backend/convex/domains/operations/taskManager/nodeKitGraphRunEvents.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitGraphRunEvents.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  NodeKitRunContractError,
+  buildNodeKitRunEvent,
+  verifyNodeKitRunEventChain,
+  type NodeKitRunEvent,
+} from "./nodeKitRunEvents";
+
+const RUN_ID = "trace_stage_local_graph";
+const GRAPH = {
+  graphId: `execution-graph:sha256:${"a".repeat(64)}`,
+  graphHash: `${"b".repeat(64)}`,
+  caseId: "case:nodebench",
+  stageId: "build",
+  caseContentHash: `${"c".repeat(64)}`,
+} as const;
+
+async function append(
+  events: NodeKitRunEvent[],
+  eventType: NodeKitRunEvent["eventType"],
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const previous = events.at(-1);
+  events.push(
+    await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: events.length,
+      eventType,
+      recordedAt: 1_725_000_000_000 + events.length,
+      payload,
+      previousHash: previous?.contentHash ?? NODEKIT_RUN_GENESIS_HASH,
+    }),
+  );
+}
+
+async function validGraphEvents(): Promise<NodeKitRunEvent[]> {
+  const events: NodeKitRunEvent[] = [];
+  await append(events, "run.started", {
+    workflowName: "Stage-local NodeKit consumer",
+    sessionType: "agent",
+    sessionStartedAt: 1_725_000_000_000,
+    identityRef: "nodebench:agent-identity:agent_doc_123",
+    workspaceId: "workspace:nodebench",
+    agentId: "codex.desktop",
+    nativeSessionId: "session:desktop:2026-07-29",
+    nativeSessionGeneration: 4,
+    peerId: "peer:runner:codex",
+    identitySnapshotHash: `sha256:${"d".repeat(64)}`,
+  });
+  await append(events, "node.started", {
+    ...GRAPH,
+    nodeId: "node:build-ui",
+    nodeRunId: "node-run:build-ui:1",
+    nodeKind: "task",
+    frontierHash: `${"e".repeat(64)}`,
+  });
+  await append(events, "edge.consumed", {
+    ...GRAPH,
+    nodeId: "node:build-ui",
+    nodeRunId: "node-run:build-ui:1",
+    edgeId: "edge:research-to-ui",
+    bindingId: `execution-edge-binding:sha256:${"f".repeat(64)}`,
+    bindingHash: `${"1".repeat(64)}`,
+    artifactId: "artifact:research-pack",
+    artifactSchemaVersion: "nodekit.research-pack/v1",
+    artifactContentHash: `${"2".repeat(64)}`,
+    authorityKind: "deterministic",
+  });
+  await append(events, "artifact.produced", {
+    ...GRAPH,
+    nodeId: "node:build-ui",
+    nodeRunId: "node-run:build-ui:1",
+    artifactId: "artifact:ui-candidate",
+    artifactSchemaVersion: "nodekit.ui-candidate/v1",
+    artifactContentHash: `${"3".repeat(64)}`,
+    authorityKind: "agent-produced",
+  });
+  await append(events, "node.completed", {
+    ...GRAPH,
+    nodeId: "node:build-ui",
+    nodeRunId: "node-run:build-ui:1",
+    status: "completed",
+  });
+  await append(events, "run.completed", { status: "completed" });
+  return events;
+}
+
+describe("NodeKit graph-aware run events", () => {
+  it("accepts a complete stage-local node and edge-binding lifecycle", async () => {
+    const events = await validGraphEvents();
+
+    await expect(
+      verifyNodeKitRunEventChain(events, RUN_ID),
+    ).resolves.toMatchObject({
+      eventCount: 6,
+      terminalEventType: "run.completed",
+    });
+  });
+
+  it("fails closed when a terminal run still has an open graph node", async () => {
+    const events = await validGraphEvents();
+    events.splice(4, 1);
+    const terminal = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 4,
+      eventType: "run.completed",
+      recordedAt: 1_725_000_000_004,
+      payload: { status: "completed" },
+      previousHash: events[3].contentHash,
+    });
+    events[4] = terminal;
+
+    await expect(verifyNodeKitRunEventChain(events, RUN_ID)).rejects.toEqual(
+      expect.objectContaining<NodeKitRunContractError>({
+        code: "graph_node_lifecycle_incomplete",
+      }),
+    );
+  });
+
+  it("rejects an edge consumption that is not bound to the currently running node", async () => {
+    const events = await validGraphEvents();
+    const invalidEdge = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 2,
+      eventType: "edge.consumed",
+      recordedAt: 1_725_000_000_002,
+      payload: {
+        ...GRAPH,
+        nodeId: "node:other",
+        nodeRunId: "node-run:other:1",
+        edgeId: "edge:research-to-ui",
+        bindingId: `execution-edge-binding:sha256:${"f".repeat(64)}`,
+        bindingHash: `${"1".repeat(64)}`,
+        artifactId: "artifact:research-pack",
+        artifactSchemaVersion: "nodekit.research-pack/v1",
+        artifactContentHash: `${"2".repeat(64)}`,
+        authorityKind: "deterministic",
+      },
+      previousHash: events[1].contentHash,
+    });
+    events.splice(2);
+    events.push(invalidEdge);
+    await append(events, "run.failed", { status: "error" });
+
+    await expect(verifyNodeKitRunEventChain(events, RUN_ID)).rejects.toEqual(
+      expect.objectContaining<NodeKitRunContractError>({
+        code: "graph_node_not_running",
+      }),
+    );
+  });
+});

--- a/backend/convex/domains/operations/taskManager/nodeKitGraphRunEvents.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitGraphRunEvents.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   NODEKIT_RUN_GENESIS_HASH,
-  NodeKitRunContractError,
   buildNodeKitRunEvent,
   verifyNodeKitRunEventChain,
   type NodeKitRunEvent,
@@ -113,7 +112,7 @@ describe("NodeKit graph-aware run events", () => {
     events[4] = terminal;
 
     await expect(verifyNodeKitRunEventChain(events, RUN_ID)).rejects.toEqual(
-      expect.objectContaining<NodeKitRunContractError>({
+      expect.objectContaining({
         code: "graph_node_lifecycle_incomplete",
       }),
     );
@@ -145,7 +144,7 @@ describe("NodeKit graph-aware run events", () => {
     await append(events, "run.failed", { status: "error" });
 
     await expect(verifyNodeKitRunEventChain(events, RUN_ID)).rejects.toEqual(
-      expect.objectContaining<NodeKitRunContractError>({
+      expect.objectContaining({
         code: "graph_node_not_running",
       }),
     );

--- a/backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts
@@ -20,6 +20,13 @@ export const NODEKIT_RUN_EVENT_TYPES = [
   "verification.recorded",
   "evidence.attached",
   "approval.requested",
+  "node.started",
+  "edge.consumed",
+  "artifact.produced",
+  "node.completed",
+  "node.failed",
+  "barrier.opened",
+  "barrier.blocked",
   "run.completed",
   "run.failed",
 ] as const;
@@ -72,6 +79,13 @@ const SAFE_FIELDS_BY_EVENT: Readonly<
     "goalId",
     "sessionType",
     "sessionStartedAt",
+    "identityRef",
+    "workspaceId",
+    "agentId",
+    "nativeSessionId",
+    "nativeSessionGeneration",
+    "peerId",
+    "identitySnapshotHash",
   ],
   "span.started": [
     "spanId",
@@ -94,6 +108,95 @@ const SAFE_FIELDS_BY_EVENT: Readonly<
   "verification.recorded": ["status"],
   "evidence.attached": [],
   "approval.requested": ["approvalId", "toolName", "riskLevel"],
+  "node.started": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "nodeKind",
+    "frontierHash",
+    "reviewContextRef",
+  ],
+  "edge.consumed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "edgeId",
+    "bindingId",
+    "bindingHash",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "artifact.produced": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "node.completed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+    "reviewContextRef",
+    "reviewSeparation",
+    "protectedEvaluator",
+  ],
+  "node.failed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+    "reasonCode",
+  ],
+  "barrier.opened": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+    "status",
+  ],
+  "barrier.blocked": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+    "status",
+    "reasonCode",
+    "blockingEdgeCount",
+  ],
   "run.completed": [
     "status",
     "totalDurationMs",
@@ -114,6 +217,84 @@ const REQUIRED_FIELDS_BY_EVENT: Partial<
   "run.started": ["workflowName", "sessionType", "sessionStartedAt"],
   "span.started": ["spanId"],
   "span.completed": ["spanId"],
+  "node.started": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+  ],
+  "edge.consumed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "edgeId",
+    "bindingId",
+    "bindingHash",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "artifact.produced": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "node.completed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+  ],
+  "node.failed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+  ],
+  "barrier.opened": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+  ],
+  "barrier.blocked": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+  ],
   "run.completed": ["status"],
   "run.failed": ["status"],
 };
@@ -133,6 +314,151 @@ function assertTerminalPayloadStatus(
     fail(
       "terminal_status_mismatch",
       `${label} requires status ${expectedStatus}.`,
+    );
+  }
+}
+
+const GRAPH_EVENT_TYPES = new Set<NodeKitRunEventType>([
+  "node.started",
+  "edge.consumed",
+  "artifact.produced",
+  "node.completed",
+  "node.failed",
+  "barrier.opened",
+  "barrier.blocked",
+]);
+
+function assertRawSha256(value: unknown, field: string): void {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) {
+    fail("graph_hash_invalid", `${field} must be a lowercase SHA-256 digest.`);
+  }
+}
+
+function assertGraphPayloadFields(
+  eventType: NodeKitRunEventType,
+  fields: Readonly<Record<string, unknown>>,
+  label: string,
+): void {
+  if (eventType === "run.started") {
+    const identityFields = [
+      "identityRef",
+      "workspaceId",
+      "agentId",
+      "nativeSessionId",
+      "nativeSessionGeneration",
+      "identitySnapshotHash",
+    ] as const;
+    const presentCount = identityFields.filter(
+      (field) => field in fields,
+    ).length;
+    if (presentCount !== 0 && presentCount !== identityFields.length) {
+      fail(
+        "native_identity_incomplete",
+        `${label} must bind the complete native identity snapshot.`,
+      );
+    }
+    if (presentCount === identityFields.length) {
+      if (
+        !Number.isSafeInteger(fields.nativeSessionGeneration) ||
+        (fields.nativeSessionGeneration as number) < 0
+      ) {
+        fail(
+          "native_session_generation_invalid",
+          `${label} nativeSessionGeneration must be a non-negative safe integer.`,
+        );
+      }
+      assertHash(
+        String(fields.identitySnapshotHash),
+        `${label}.identitySnapshotHash`,
+      );
+    }
+    return;
+  }
+  if (!GRAPH_EVENT_TYPES.has(eventType)) return;
+
+  if (
+    typeof fields.graphId !== "string" ||
+    !/^execution-graph:sha256:[a-f0-9]{64}$/.test(fields.graphId)
+  ) {
+    fail(
+      "graph_id_invalid",
+      `${label}.graphId is not a NodeKit execution graph ID.`,
+    );
+  }
+  assertRawSha256(fields.graphHash, `${label}.graphHash`);
+  assertRawSha256(fields.caseContentHash, `${label}.caseContentHash`);
+  if ("frontierHash" in fields) {
+    assertRawSha256(fields.frontierHash, `${label}.frontierHash`);
+  }
+  if ("bindingHash" in fields) {
+    assertRawSha256(fields.bindingHash, `${label}.bindingHash`);
+  }
+  if ("artifactContentHash" in fields) {
+    assertRawSha256(fields.artifactContentHash, `${label}.artifactContentHash`);
+  }
+  if (
+    "bindingId" in fields &&
+    (typeof fields.bindingId !== "string" ||
+      !/^execution-edge-binding:sha256:[a-f0-9]{64}$/.test(fields.bindingId))
+  ) {
+    fail(
+      "edge_binding_id_invalid",
+      `${label}.bindingId is not a NodeKit execution edge binding ID.`,
+    );
+  }
+  if (
+    "authorityKind" in fields &&
+    ![
+      "agent-produced",
+      "deterministic",
+      "human-attested",
+      "nodeproof-verified",
+    ].includes(String(fields.authorityKind))
+  ) {
+    fail("authority_kind_invalid", `${label}.authorityKind is unsupported.`);
+  }
+  if (
+    eventType === "node.started" &&
+    "nodeKind" in fields &&
+    !["task", "review", "barrier"].includes(String(fields.nodeKind))
+  ) {
+    fail("node_kind_invalid", `${label}.nodeKind is unsupported.`);
+  }
+  if (eventType === "node.completed" && fields.status !== "completed") {
+    fail("graph_status_mismatch", `${label} requires status completed.`);
+  }
+  if (
+    eventType === "node.failed" &&
+    !["failed", "error"].includes(String(fields.status))
+  ) {
+    fail("graph_status_mismatch", `${label} requires a failure status.`);
+  }
+  if (
+    eventType === "barrier.opened" &&
+    "status" in fields &&
+    fields.status !== "opened"
+  ) {
+    fail("graph_status_mismatch", `${label} requires status opened.`);
+  }
+  if (
+    eventType === "barrier.blocked" &&
+    "status" in fields &&
+    fields.status !== "blocked"
+  ) {
+    fail("graph_status_mismatch", `${label} requires status blocked.`);
+  }
+  if (
+    "reviewSeparation" in fields &&
+    ![
+      "same-context",
+      "fresh-context",
+      "independent-model",
+      "independent-human",
+    ].includes(String(fields.reviewSeparation))
+  ) {
+    fail(
+      "review_separation_invalid",
+      `${label}.reviewSeparation is unsupported.`,
     );
   }
 }
@@ -297,6 +623,7 @@ export async function projectNodeKitRunEventPayload(
     }
   }
   assertTerminalPayloadStatus(eventType, fields, eventType);
+  assertGraphPayloadFields(eventType, fields, eventType);
 
   const projection: NodeKitSafeEventPayload = {
     projectionVersion: NODEKIT_SAFE_EVENT_PAYLOAD_VERSION,
@@ -433,6 +760,7 @@ function assertSafeEventPayload(
     }
   }
   assertTerminalPayloadStatus(eventType, fields, `Event ${index}`);
+  assertGraphPayloadFields(eventType, fields, `Event ${index}`);
   if (
     new TextEncoder().encode(canonicalNodeKitJson(payload)).byteLength >
     NODEKIT_RUN_MAX_STORED_PAYLOAD_BYTES
@@ -606,6 +934,82 @@ function assertNodeKitSpanLifecycle(
   return openSpans;
 }
 
+function assertNodeKitGraphLifecycle(
+  events: readonly NodeKitRunEvent[],
+  requireClosed: boolean,
+): ReadonlySet<string> {
+  const openNodes = new Map<string, string>();
+  const closedNodeRuns = new Set<string>();
+  let graphScope:
+    | {
+        graphId: string;
+        graphHash: string;
+        caseId: string;
+        stageId: string;
+        caseContentHash: string;
+      }
+    | undefined;
+
+  for (const event of events) {
+    if (!GRAPH_EVENT_TYPES.has(event.eventType)) continue;
+    const currentScope = {
+      graphId: String(eventField(event, "graphId")),
+      graphHash: String(eventField(event, "graphHash")),
+      caseId: String(eventField(event, "caseId")),
+      stageId: String(eventField(event, "stageId")),
+      caseContentHash: String(eventField(event, "caseContentHash")),
+    };
+    if (graphScope === undefined) {
+      graphScope = currentScope;
+    } else if (
+      Object.keys(graphScope).some(
+        (key) =>
+          graphScope?.[key as keyof typeof graphScope] !==
+          currentScope[key as keyof typeof currentScope],
+      )
+    ) {
+      fail(
+        "graph_scope_mismatch",
+        "One run-event chain cannot mix execution graphs, cases, or stages.",
+      );
+    }
+
+    const nodeId = String(eventField(event, "nodeId"));
+    const nodeRunId = String(eventField(event, "nodeRunId"));
+    if (event.eventType === "node.started") {
+      if (openNodes.has(nodeRunId) || closedNodeRuns.has(nodeRunId)) {
+        fail(
+          "graph_node_duplicate_start",
+          `Node run ${nodeRunId} was started twice.`,
+        );
+      }
+      openNodes.set(nodeRunId, nodeId);
+      continue;
+    }
+    if (openNodes.get(nodeRunId) !== nodeId) {
+      fail(
+        "graph_node_not_running",
+        `${event.eventType} is not bound to the currently running node ${nodeRunId}.`,
+      );
+    }
+    if (
+      event.eventType === "node.completed" ||
+      event.eventType === "node.failed"
+    ) {
+      openNodes.delete(nodeRunId);
+      closedNodeRuns.add(nodeRunId);
+    }
+  }
+
+  if (requireClosed && openNodes.size > 0) {
+    fail(
+      "graph_node_lifecycle_incomplete",
+      `Terminal runs cannot retain ${openNodes.size} open graph node(s).`,
+    );
+  }
+  return new Set(openNodes.keys());
+}
+
 export async function verifyNodeKitRunEventPrefix(
   inputEvents: readonly NodeKitRunEvent[],
   expectedRunId: string,
@@ -614,6 +1018,7 @@ export async function verifyNodeKitRunEventPrefix(
   chainHead: string;
   terminalEventType: "run.completed" | "run.failed" | null;
   openSpanIds: readonly string[];
+  openNodeRunIds: readonly string[];
 }> {
   if (!Array.isArray(inputEvents) || inputEvents.length === 0) {
     fail("start_event_missing", "A run prefix requires run.started.");
@@ -698,6 +1103,10 @@ export async function verifyNodeKitRunEventPrefix(
     inputEvents,
     terminalEventType !== null,
   );
+  const openNodeRuns = assertNodeKitGraphLifecycle(
+    inputEvents,
+    terminalEventType !== null,
+  );
 
   const last = inputEvents[inputEvents.length - 1];
   return {
@@ -705,6 +1114,7 @@ export async function verifyNodeKitRunEventPrefix(
     chainHead: last.contentHash,
     terminalEventType,
     openSpanIds: [...openSpans].sort(),
+    openNodeRunIds: [...openNodeRuns].sort(),
   };
 }
 
@@ -838,11 +1248,12 @@ export async function appendNodeKitRunEvent(
   const prefix = await verifyNodeKitRunEventPrefix(candidateChain, args.runId);
   if (prefix.terminalEventType === null) {
     const remainingSlots = NODEKIT_RUN_MAX_EVENTS - prefix.eventCount;
-    const requiredSlots = prefix.openSpanIds.length + 1;
+    const requiredSlots =
+      prefix.openSpanIds.length + prefix.openNodeRunIds.length + 1;
     if (remainingSlots < requiredSlots) {
       fail(
         "event_capacity_reserved",
-        `The remaining ${remainingSlots} event slot(s) cannot close ${prefix.openSpanIds.length} open span(s) and terminate the run.`,
+        `The remaining ${remainingSlots} event slot(s) cannot close ${prefix.openSpanIds.length} open span(s), ${prefix.openNodeRunIds.length} open graph node(s), and terminate the run.`,
       );
     }
   }

--- a/backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts
@@ -15,6 +15,7 @@ import {
   assertNodeKitRunExport,
   buildCanonicalNodeKitRunExport,
 } from "./nodeKitRunExport";
+import { buildNodeKitNativeSessionIdentity } from "./nodeKitRuntimeIdentity";
 
 const RUN_ID = "trace_nodekit_export_contract";
 
@@ -59,6 +60,53 @@ async function validEvents(): Promise<NodeKitRunEvent[]> {
 }
 
 describe("canonical NodeKit run export", () => {
+  it("exports the event-bound native identity snapshot without consulting mutable agent state", async () => {
+    const identity = await buildNodeKitNativeSessionIdentity({
+      identityRef: "nodebench:agent-identity:agent_doc_123",
+      agentId: "codex.desktop",
+      workspaceId: "workspace:nodebench",
+      nativeSessionId: "session:desktop:2026-07-29",
+      nativeSessionGeneration: 4,
+      peerId: "peer:runner:codex",
+    });
+    const started = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 0,
+      eventType: "run.started",
+      recordedAt: 1_725_000_000_000,
+      payload: {
+        workflowName: "Identity-bound workflow",
+        sessionType: "agent",
+        sessionStartedAt: 1_724_999_999_000,
+        identityRef: identity.identityRef,
+        agentId: identity.agentId,
+        workspaceId: identity.workspaceId,
+        nativeSessionId: identity.nativeSessionId,
+        nativeSessionGeneration: identity.nativeSessionGeneration,
+        peerId: identity.peerId,
+        identitySnapshotHash: identity.snapshotHash,
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+    const completed = await buildNodeKitRunEvent({
+      runId: RUN_ID,
+      sequence: 1,
+      eventType: "run.completed",
+      recordedAt: 1_725_000_000_010,
+      payload: { status: "completed" },
+      previousHash: started.contentHash,
+    });
+
+    const exportDoc = await buildCanonicalNodeKitRunExport({
+      sessionId: "session_123",
+      traceId: "trace_record_123",
+      events: [started, completed],
+    });
+
+    expect(exportDoc.session.nativeIdentity).toEqual(identity);
+    await expect(assertNodeKitRunExport(exportDoc)).resolves.toBe(exportDoc);
+  });
+
   it("emits an immutable ordered export with per-event and whole-export hashes", async () => {
     const events = await validEvents();
     const exportDoc = await buildCanonicalNodeKitRunExport({

--- a/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
@@ -7,12 +7,17 @@ import {
   NODEKIT_RUN_EVENT_CONTRACT_VERSION,
   NODEKIT_RUN_MAX_EVENTS,
   NodeKitRunContractError,
+  canonicalNodeKitJson,
   deepFreezeNodeKitValue,
   sha256CanonicalNodeKitValue,
   verifyNodeKitRunEventChain,
   type NodeKitRunEvent,
   type NodeKitSafeEventPayload,
 } from "./nodeKitRunEvents";
+import {
+  buildNodeKitNativeSessionIdentity,
+  type NodeKitNativeSessionIdentity,
+} from "./nodeKitRuntimeIdentity";
 
 export const NODEKIT_RUN_EXPORT_SCHEMA_VERSION =
   "nodekit.run-export/v1" as const;
@@ -32,6 +37,7 @@ type SessionExport = Readonly<{
   id: string;
   typeAtRunStart: string;
   startedAt: number;
+  nativeIdentity?: NodeKitNativeSessionIdentity;
 }>;
 
 type TraceExport = Readonly<{
@@ -122,13 +128,25 @@ function assertTimestamp(
 function assertSessionExport(
   value: Record<string, unknown>,
 ): asserts value is Record<string, unknown> & SessionExport {
-  assertExactKeys(value, ["id", "typeAtRunStart", "startedAt"], "session");
+  assertExactKeys(
+    value,
+    [
+      "id",
+      "typeAtRunStart",
+      "startedAt",
+      ...("nativeIdentity" in value ? ["nativeIdentity"] : []),
+    ],
+    "session",
+  );
   assertString(value.id, "session.id", { nonEmpty: true });
   assertString(value.typeAtRunStart, "session.typeAtRunStart", {
     nonEmpty: true,
     maxLength: 256,
   });
   assertTimestamp(value.startedAt, "session.startedAt");
+  if ("nativeIdentity" in value) {
+    assertObject(value.nativeIdentity, "session.nativeIdentity");
+  }
 }
 
 function assertTraceExport(
@@ -209,10 +227,39 @@ export async function buildCanonicalNodeKitRunExport(input: {
       "run.started has an invalid event-bound session/trace snapshot.",
     );
   }
+  const identityRef = startEvent.payload.fields.identityRef;
+  const workspaceId = startEvent.payload.fields.workspaceId;
+  const agentId = startEvent.payload.fields.agentId;
+  const nativeSessionId = startEvent.payload.fields.nativeSessionId;
+  const nativeSessionGeneration =
+    startEvent.payload.fields.nativeSessionGeneration;
+  const peerId = startEvent.payload.fields.peerId;
+  const identitySnapshotHash = startEvent.payload.fields.identitySnapshotHash;
+  const nativeIdentity =
+    identityRef === undefined
+      ? undefined
+      : await buildNodeKitNativeSessionIdentity({
+          identityRef: String(identityRef),
+          workspaceId: String(workspaceId),
+          agentId: String(agentId),
+          nativeSessionId: String(nativeSessionId),
+          nativeSessionGeneration: Number(nativeSessionGeneration),
+          ...(peerId === undefined ? {} : { peerId: String(peerId) }),
+        });
+  if (
+    nativeIdentity !== undefined &&
+    nativeIdentity.snapshotHash !== identitySnapshotHash
+  ) {
+    fail(
+      "native_identity_hash_mismatch",
+      "run.started native identity fields do not match identitySnapshotHash.",
+    );
+  }
   const session: SessionExport = {
     id: input.sessionId,
     typeAtRunStart: sessionType,
     startedAt: sessionStartedAt as number,
+    ...(nativeIdentity === undefined ? {} : { nativeIdentity }),
   };
   const trace: TraceExport = {
     id: input.traceId,
@@ -346,6 +393,37 @@ export async function assertNodeKitRunExport(
       "event_snapshot_mismatch",
       "Session or trace metadata differs from the immutable event snapshots.",
     );
+  }
+  const startIdentityRef = startEvent.payload.fields.identityRef;
+  if (startIdentityRef === undefined && "nativeIdentity" in value.session) {
+    fail(
+      "native_identity_snapshot_mismatch",
+      "The export session cannot add identity absent from run.started.",
+    );
+  }
+  if (startIdentityRef !== undefined) {
+    const expectedIdentity = await buildNodeKitNativeSessionIdentity({
+      identityRef: String(startIdentityRef),
+      workspaceId: String(startEvent.payload.fields.workspaceId),
+      agentId: String(startEvent.payload.fields.agentId),
+      nativeSessionId: String(startEvent.payload.fields.nativeSessionId),
+      nativeSessionGeneration: Number(
+        startEvent.payload.fields.nativeSessionGeneration,
+      ),
+      ...(startEvent.payload.fields.peerId === undefined
+        ? {}
+        : { peerId: String(startEvent.payload.fields.peerId) }),
+    });
+    if (
+      !("nativeIdentity" in value.session) ||
+      canonicalNodeKitJson(value.session.nativeIdentity) !==
+        canonicalNodeKitJson(expectedIdentity)
+    ) {
+      fail(
+        "native_identity_snapshot_mismatch",
+        "The export session identity differs from run.started.",
+      );
+    }
   }
   if (
     value.completeness.eventChainComplete !== true ||

--- a/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
@@ -255,7 +255,24 @@ describe("NodeKit bounded retention maintenance", () => {
       payload: { spanId: "span-open" },
       previousHash: started.contentHash,
     });
-    const rows = [started, spanStarted].map((event, index) => ({
+    const nodeStarted = await buildNodeKitRunEvent({
+      runId,
+      sequence: 2,
+      eventType: "node.started",
+      recordedAt: spanStarted.recordedAt + 1,
+      payload: {
+        graphId: `execution-graph:sha256:${"a".repeat(64)}`,
+        graphHash: "b".repeat(64),
+        caseId: "case:stale",
+        stageId: "build",
+        caseContentHash: "c".repeat(64),
+        nodeId: "node:stale-build",
+        nodeRunId: "node-run:stale-build:1",
+        nodeKind: "task",
+      },
+      previousHash: spanStarted.contentHash,
+    });
+    const rows = [started, spanStarted, nodeStarted].map((event, index) => ({
       _id: `stale-event-${index}`,
       sessionId: "stale-session",
       traceId: "stale-trace",
@@ -300,6 +317,12 @@ describe("NodeKit bounded retention maintenance", () => {
     expect(result).toMatchObject({ staleClosed: 1, staleCorruptPurged: 0 });
     expect((await ctx.db.get("stale-trace"))?.status).toBe("error");
     expect((await ctx.db.get("span-open"))?.status).toBe("error");
+    expect(ctx.db.tables.nodeKitRunEvents.at(-3)?.eventType).toBe(
+      "node.failed",
+    );
+    expect(ctx.db.tables.nodeKitRunEvents.at(-2)?.eventType).toBe(
+      "span.completed",
+    );
     expect(ctx.db.tables.nodeKitRunEvents.at(-1)?.eventType).toBe("run.failed");
     expect(
       ctx.db.tables.nodeKitRunEvents.at(-1)?.retentionExpiresAt,

--- a/backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunRetention.ts
@@ -153,6 +153,42 @@ async function closeStaleTrace(
     now,
     storedEvents[storedEvents.length - 1].recordedAt,
   );
+  for (const nodeRunId of prefix.openNodeRunIds) {
+    const startedEvent = [...storedEvents]
+      .reverse()
+      .find(
+        (event: Record<string, any>) =>
+          event.eventType === "node.started" &&
+          event.payload?.fields?.nodeRunId === nodeRunId,
+      );
+    if (!startedEvent) {
+      throw new NodeKitRunContractError(
+        "graph_node_start_missing",
+        `Open graph node ${nodeRunId} has no start event.`,
+      );
+    }
+    const fields = startedEvent.payload.fields;
+    await appendNodeKitRunEvent(ctx as never, {
+      sessionId: session._id,
+      traceId: trace._id,
+      userId: session.userId,
+      runId: trace.traceId,
+      eventType: "node.failed",
+      recordedAt,
+      payload: {
+        graphId: fields.graphId,
+        graphHash: fields.graphHash,
+        caseId: fields.caseId,
+        stageId: fields.stageId,
+        caseContentHash: fields.caseContentHash,
+        nodeId: fields.nodeId,
+        nodeRunId,
+        status: "error",
+        reasonCode: "stale_run_timeout",
+      },
+      allowLegacySkip: false,
+    });
+  }
   for (const spanId of prefix.openSpanIds) {
     const span = await ctx.db.get(spanId as Id<"agentTaskSpans">);
     const durationMs =

--- a/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  NodeKitRuntimeIdentityError,
   buildNodeKitNativeIdentityRef,
   buildNodeKitNativeSessionIdentity,
   compareNodeKitNativeSessionIdentity,
@@ -88,7 +87,7 @@ describe("NodeKit native agent session identity", () => {
     },
   ])("rejects $label before persistence", ({ input, code }) => {
     expect(() => validateNodeKitNativeSessionIdentityInput(input)).toThrowError(
-      expect.objectContaining<NodeKitRuntimeIdentityError>({ code }),
+      expect.objectContaining({ code }),
     );
   });
 
@@ -120,7 +119,7 @@ describe("NodeKit native agent session identity", () => {
     expect(() =>
       compareNodeKitNativeSessionIdentity(previous, candidate),
     ).toThrowError(
-      expect.objectContaining<NodeKitRuntimeIdentityError>({ code }),
+      expect.objectContaining({ code }),
     );
   });
 });

--- a/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NodeKitRuntimeIdentityError,
+  buildNodeKitNativeIdentityRef,
+  buildNodeKitNativeSessionIdentity,
+  compareNodeKitNativeSessionIdentity,
+  validateNodeKitNativeSessionIdentityInput,
+} from "./nodeKitRuntimeIdentity";
+
+const baseIdentity = {
+  identityRef: "nodebench:agent-identity:agent_doc_123",
+  agentId: "codex.desktop",
+  workspaceId: "workspace:nodebench",
+  nativeSessionId: "session:desktop:2026-07-29",
+  nativeSessionGeneration: 4,
+  peerId: "peer:runner:codex",
+} as const;
+
+describe("NodeKit native agent session identity", () => {
+  it("derives a stable opaque reference from storage-engine-specific IDs", async () => {
+    const first = await buildNodeKitNativeIdentityRef(
+      "mock;agentIdentities:opaque/storage-id",
+    );
+    const second = await buildNodeKitNativeIdentityRef(
+      "mock;agentIdentities:opaque/storage-id",
+    );
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^nodebench:agent-identity:[a-f0-9]{64}$/);
+    expect(first).not.toContain("mock");
+  });
+
+  it("binds a persistent agent, workspace, peer, and session generation into one deterministic snapshot", async () => {
+    const first = await buildNodeKitNativeSessionIdentity(baseIdentity);
+    const reordered = await buildNodeKitNativeSessionIdentity({
+      peerId: baseIdentity.peerId,
+      nativeSessionGeneration: baseIdentity.nativeSessionGeneration,
+      nativeSessionId: baseIdentity.nativeSessionId,
+      workspaceId: baseIdentity.workspaceId,
+      agentId: baseIdentity.agentId,
+      identityRef: baseIdentity.identityRef,
+    });
+
+    expect(first).toEqual(reordered);
+    expect(first.schemaVersion).toBe(
+      "nodekit.native-agent-session-identity/v1",
+    );
+    expect(first.snapshotHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+
+  it("classifies a reconnect without rotating the native session identity", async () => {
+    const previous = await buildNodeKitNativeSessionIdentity(baseIdentity);
+    const next = await buildNodeKitNativeSessionIdentity(baseIdentity);
+
+    expect(compareNodeKitNativeSessionIdentity(previous, next)).toBe(
+      "reconnect",
+    );
+  });
+
+  it("accepts a higher generation as an explicit restart or rotation", async () => {
+    const previous = await buildNodeKitNativeSessionIdentity(baseIdentity);
+    const next = await buildNodeKitNativeSessionIdentity({
+      ...baseIdentity,
+      nativeSessionId: "session:desktop:2026-07-30",
+      nativeSessionGeneration: 5,
+    });
+
+    expect(compareNodeKitNativeSessionIdentity(previous, next)).toBe("rotate");
+  });
+
+  it.each([
+    {
+      label: "empty agent",
+      input: { ...baseIdentity, agentId: "" },
+      code: "native_identity_field_invalid",
+    },
+    {
+      label: "unsafe session identifier",
+      input: { ...baseIdentity, nativeSessionId: "session with spaces" },
+      code: "native_identity_field_invalid",
+    },
+    {
+      label: "fractional generation",
+      input: { ...baseIdentity, nativeSessionGeneration: 4.5 },
+      code: "native_session_generation_invalid",
+    },
+  ])("rejects $label before persistence", ({ input, code }) => {
+    expect(() => validateNodeKitNativeSessionIdentityInput(input)).toThrowError(
+      expect.objectContaining<NodeKitRuntimeIdentityError>({ code }),
+    );
+  });
+
+  it.each([
+    {
+      label: "stale generation",
+      next: { ...baseIdentity, nativeSessionGeneration: 3 },
+      code: "native_session_stale",
+    },
+    {
+      label: "same generation with a different session",
+      next: { ...baseIdentity, nativeSessionId: "session:spoofed" },
+      code: "native_session_collision",
+    },
+    {
+      label: "same session with a different peer",
+      next: { ...baseIdentity, peerId: "peer:runner:unknown" },
+      code: "native_peer_mismatch",
+    },
+    {
+      label: "cross-workspace replay",
+      next: { ...baseIdentity, workspaceId: "workspace:other" },
+      code: "native_identity_scope_mismatch",
+    },
+  ])("rejects $label", async ({ next, code }) => {
+    const previous = await buildNodeKitNativeSessionIdentity(baseIdentity);
+    const candidate = await buildNodeKitNativeSessionIdentity(next);
+
+    expect(() =>
+      compareNodeKitNativeSessionIdentity(previous, candidate),
+    ).toThrowError(
+      expect.objectContaining<NodeKitRuntimeIdentityError>({ code }),
+    );
+  });
+});

--- a/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.ts
@@ -1,0 +1,155 @@
+import {
+  deepFreezeNodeKitValue,
+  sha256CanonicalNodeKitValue,
+} from "./nodeKitRunEvents";
+
+export const NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION =
+  "nodekit.native-agent-session-identity/v1" as const;
+
+export type NodeKitNativeSessionIdentity = Readonly<{
+  schemaVersion: typeof NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION;
+  identityRef: string;
+  agentId: string;
+  workspaceId: string;
+  nativeSessionId: string;
+  nativeSessionGeneration: number;
+  peerId?: string;
+  snapshotHash: string;
+}>;
+
+export class NodeKitRuntimeIdentityError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "NodeKitRuntimeIdentityError";
+    this.code = code;
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new NodeKitRuntimeIdentityError(code, message);
+}
+
+function assertBoundedId(value: string, field: string, maxLength = 256): void {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(value)
+  ) {
+    fail(
+      "native_identity_field_invalid",
+      `${field} must be a non-empty bounded identifier.`,
+    );
+  }
+}
+
+export type NodeKitNativeSessionIdentityInput = Readonly<{
+  agentId: string;
+  workspaceId: string;
+  nativeSessionId: string;
+  nativeSessionGeneration: number;
+  peerId?: string;
+}>;
+
+export function validateNodeKitNativeSessionIdentityInput(
+  input: NodeKitNativeSessionIdentityInput,
+): void {
+  assertBoundedId(input.agentId, "agentId", 128);
+  assertBoundedId(input.workspaceId, "workspaceId");
+  assertBoundedId(input.nativeSessionId, "nativeSessionId");
+  if (input.peerId !== undefined) assertBoundedId(input.peerId, "peerId");
+  if (
+    !Number.isSafeInteger(input.nativeSessionGeneration) ||
+    input.nativeSessionGeneration < 0
+  ) {
+    fail(
+      "native_session_generation_invalid",
+      "nativeSessionGeneration must be a non-negative safe integer.",
+    );
+  }
+}
+
+export async function buildNodeKitNativeIdentityRef(
+  storageIdentityId: string,
+): Promise<string> {
+  if (
+    typeof storageIdentityId !== "string" ||
+    storageIdentityId.length === 0 ||
+    storageIdentityId.length > 512
+  ) {
+    fail(
+      "native_identity_storage_id_invalid",
+      "The storage identity ID must be non-empty and bounded.",
+    );
+  }
+  const digest = await sha256CanonicalNodeKitValue({ storageIdentityId });
+  return `nodebench:agent-identity:${digest.slice("sha256:".length)}`;
+}
+
+export async function buildNodeKitNativeSessionIdentity(
+  input: NodeKitNativeSessionIdentityInput & { identityRef: string },
+): Promise<NodeKitNativeSessionIdentity> {
+  assertBoundedId(input.identityRef, "identityRef");
+  validateNodeKitNativeSessionIdentityInput(input);
+
+  const body = {
+    schemaVersion: NODEKIT_NATIVE_AGENT_SESSION_IDENTITY_VERSION,
+    identityRef: input.identityRef,
+    agentId: input.agentId,
+    workspaceId: input.workspaceId,
+    nativeSessionId: input.nativeSessionId,
+    nativeSessionGeneration: input.nativeSessionGeneration,
+    ...(input.peerId === undefined ? {} : { peerId: input.peerId }),
+  } as const;
+
+  return deepFreezeNodeKitValue({
+    ...body,
+    snapshotHash: await sha256CanonicalNodeKitValue(body),
+  });
+}
+
+export function compareNodeKitNativeSessionIdentity(
+  previous: NodeKitNativeSessionIdentity,
+  next: NodeKitNativeSessionIdentity,
+): "reconnect" | "rotate" {
+  if (
+    previous.identityRef !== next.identityRef ||
+    previous.agentId !== next.agentId ||
+    previous.workspaceId !== next.workspaceId
+  ) {
+    fail(
+      "native_identity_scope_mismatch",
+      "A native session cannot cross an agent or workspace identity boundary.",
+    );
+  }
+  if (next.nativeSessionGeneration < previous.nativeSessionGeneration) {
+    fail(
+      "native_session_stale",
+      "The native session generation is older than the persisted identity state.",
+    );
+  }
+  if (
+    next.nativeSessionGeneration === previous.nativeSessionGeneration &&
+    next.nativeSessionId !== previous.nativeSessionId
+  ) {
+    fail(
+      "native_session_collision",
+      "One native session generation cannot identify two different sessions.",
+    );
+  }
+  if (
+    next.nativeSessionGeneration === previous.nativeSessionGeneration &&
+    previous.peerId !== undefined &&
+    next.peerId !== previous.peerId
+  ) {
+    fail(
+      "native_peer_mismatch",
+      "A reconnect cannot replace the peer bound to the active native session.",
+    );
+  }
+  return next.nativeSessionGeneration === previous.nativeSessionGeneration
+    ? "reconnect"
+    : "rotate";
+}

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -12850,6 +12850,18 @@ export default defineSchema({
     agentRunId: v.optional(v.id("agentRuns")),
     agentThreadId: v.optional(v.string()),
     swarmId: v.optional(v.string()),
+    nativeIdentity: v.optional(
+      v.object({
+        schemaVersion: v.literal("nodekit.native-agent-session-identity/v1"),
+        identityRef: v.string(),
+        agentId: v.string(),
+        workspaceId: v.string(),
+        nativeSessionId: v.string(),
+        nativeSessionGeneration: v.number(),
+        peerId: v.optional(v.string()),
+        snapshotHash: v.string(),
+      }),
+    ),
     goalId: v.optional(v.string()),
     visionSnapshot: v.optional(v.string()),
     successCriteria: v.optional(v.array(v.string())),
@@ -12928,6 +12940,18 @@ export default defineSchema({
     ),
     estimatedCostUsd: v.optional(v.number()),
     model: v.optional(v.string()),
+    nativeIdentity: v.optional(
+      v.object({
+        schemaVersion: v.literal("nodekit.native-agent-session-identity/v1"),
+        identityRef: v.string(),
+        agentId: v.string(),
+        workspaceId: v.string(),
+        nativeSessionId: v.string(),
+        nativeSessionGeneration: v.number(),
+        peerId: v.optional(v.string()),
+        snapshotHash: v.string(),
+      }),
+    ),
     metadata: v.optional(v.any()),
   })
     .index("by_session", ["sessionId", "startedAt"])
@@ -12997,6 +13021,13 @@ export default defineSchema({
       v.literal("verification.recorded"),
       v.literal("evidence.attached"),
       v.literal("approval.requested"),
+      v.literal("node.started"),
+      v.literal("edge.consumed"),
+      v.literal("artifact.produced"),
+      v.literal("node.completed"),
+      v.literal("node.failed"),
+      v.literal("barrier.opened"),
+      v.literal("barrier.blocked"),
       v.literal("run.completed"),
       v.literal("run.failed"),
     ),
@@ -14458,6 +14489,16 @@ export default defineSchema({
    */
   agentIdentities: defineTable({
     agentId: v.string(),
+    ownerUserId: v.optional(v.id("users")),
+    workspaceId: v.optional(v.string()),
+    identityContractVersion: v.optional(
+      v.literal("nodekit.native-agent-session-identity/v1"),
+    ),
+    nativeSessionId: v.optional(v.string()),
+    nativeSessionGeneration: v.optional(v.number()),
+    nativePeerId: v.optional(v.string()),
+    nativeIdentitySnapshotHash: v.optional(v.string()),
+    lastSeenAt: v.optional(v.number()),
     name: v.string(),
     persona: v.string(),
     allowedTools: v.array(v.string()),
@@ -14486,6 +14527,7 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_agentId", ["agentId"])
+    .index("by_owner_workspace_agent", ["ownerUserId", "workspaceId", "agentId"])
     .index("by_status", ["status", "updatedAt"])
     .index("by_name", ["name"]),
 

--- a/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
+++ b/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
@@ -58,7 +58,9 @@ append:
 - `decision.recorded`;
 - `verification.recorded`;
 - `evidence.attached`;
-- trace-bound `approval.requested`; and
+- trace-bound `approval.requested`;
+- `node.started`, `edge.consumed`, and `artifact.produced`;
+- `node.completed`, `node.failed`, `barrier.opened`, and `barrier.blocked`; and
 - exactly one `run.completed` or `run.failed`.
 
 Each event commits to:
@@ -80,10 +82,13 @@ structural scalars plus the redacted source digest and byte count. Raw
 metadata are excluded. A redacted source is capped at 32 KiB, a stored
 projection at 2 KiB, and a run at 256 events.
 
-Explicit `span.started` and `span.completed` events form a checked lifecycle:
-duplicate starts, completion without a start, and terminal runs with open spans
-fail the owning transaction. Every nonterminal append must leave enough bounded
-slots for all currently open span completions plus one terminal event.
+Explicit spans and graph nodes form checked lifecycles: duplicate starts,
+completion without a start, and terminal runs with open spans or graph nodes
+fail the owning transaction. Graph events remain bound to one current-stage
+graph, Caseflow case, and stage. Edge consumption requires the exact NodeKit
+edge-binding and artifact hashes for the currently running node. Every
+nonterminal append must leave enough bounded slots for all currently open span
+and node failures plus one terminal event.
 `run.completed` requires payload status `completed`; `run.failed` requires
 payload status `error`. `step.recorded` remains a self-contained completed step
 and is not misrepresented as an open explicit span.
@@ -239,11 +244,11 @@ The canary installs exact direct pins:
 - `pytest==9.1.1`
 - `rfc8785==0.1.4`
 
-| Reference                     | Revision                                   | Use                                      |
-| ----------------------------- | ------------------------------------------ | ---------------------------------------- |
+| Reference                      | Revision                                   | Use                                      |
+| ------------------------------ | ------------------------------------------ | ---------------------------------------- |
 | `v1.10.0` annotated tag object | `3fbcd8fc56a45ae68622d4e2b18a6d5844180527` | Release-tag provenance                   |
-| `v1.10.0` release commit      | `148e12c2969f18fa12a1a3c2e75f3affd9aa0616` | Executable dependency contract           |
-| Audited upstream `main`       | `8aedb1866cf5dce056af97529152ffd6f468a1ed` | Repository and issue inspection boundary |
+| `v1.10.0` release commit       | `148e12c2969f18fa12a1a3c2e75f3affd9aa0616` | Executable dependency contract           |
+| Audited upstream `main`        | `8aedb1866cf5dce056af97529152ffd6f468a1ed` | Repository and issue inspection boundary |
 
 The audited `main` revision and any features discussed upstream are provenance
 and research data only; they confer no NodeBench authority. The evaluator does
@@ -309,7 +314,18 @@ exact build/replay commands are in `evals/activegraph/README.md`.
 This gate does not backfill legacy traces and does not authorize production
 adoption.
 
-### Gate 3 — representative corpus: deferred
+### Gate 3a — representative graph-and-identity fixture: implemented
+
+The TypeScript boundary suite now uses a representative stage-local export
+containing an immutable native-session identity snapshot, frontier-bound node
+start, exact edge consumption, artifact production, node completion, and run
+completion. All canary tamper and isolation tests therefore exercise the new
+graph and identity fields rather than the former two-event trace fixture.
+
+This proves the boundary on one deterministic representative corpus. It does
+not satisfy the owner-authorized multi-run adoption experiment.
+
+### Gate 3b — representative owner-authorized corpus: deferred
 
 Replay roughly 20 representative owner-authorized exports. Stop if:
 

--- a/docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md
+++ b/docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md
@@ -1,0 +1,138 @@
+# NodeKit stage-local runtime integration
+
+- **Status:** Candidate; reviewed deployment required
+- **Contract date:** 2026-07-29
+- **Upstream NodeKit change:** [node-platform PR #29](https://github.com/HomenShum/node-platform/pull/29)
+- **Runtime owner:** NodeBench execution trace and MCP gateway
+
+## Decision
+
+NodeBench records and exports the exact execution evidence produced by NodeKit's
+current-stage graph contracts. It does not compile a second graph, infer a
+frontier from process status, approve findings, or advance Caseflow.
+
+The authority chain is:
+
+```text
+Canonical Caseflow
+    -> NodeKit current-stage compiled projection
+    -> verified runnable frontier
+    -> exact edge bindings
+    -> bounded NodeBench run-event evidence
+    -> owner-scoped terminal export
+    -> optional offline ActiveGraph replay
+```
+
+Only canonical Caseflow records, protected approvals, and NodeProof receipts may
+authorize a stage transition. Every later surface is derived, rebuildable, or
+evidentiary.
+
+## Compatibility matrix
+
+| NodeKit contract                           | NodeBench representation                                                                           | Enforced boundary                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `nodekit.execution-graph/v1`               | `graphId`, `graphHash`, `caseId`, `stageId`, `caseContentHash` on graph events                     | One run cannot mix graph, case, or stage scope                                 |
+| `nodekit.execution-edge-binding/v1`        | `edge.consumed` with exact binding, artifact, schema, content hash, and authority                  | No readiness from exit code; all required binding fields verify                |
+| `nodekit.runnable-frontier/v1`             | `frontierHash` on `node.started`                                                                   | NodeBench records the NodeKit-derived frontier and never derives its own       |
+| `nodekit.review-context/v1`                | Review context reference, separation class, and protected-evaluator flag on terminal node evidence | Recording a review never grants approval or stage-advance authority            |
+| `nodekit.native-agent-session-identity/v1` | Optional immutable identity snapshot on sessions, traces, and `run.started`                        | Owner/workspace scope, monotonic generation, reconnect and peer continuity     |
+| `nodekit.run-event/v1`                     | Bounded append-only hash chain                                                                     | At most 256 events, safe-field projection, lifecycle and terminal closure      |
+| `nodekit.run-export/v1`                    | Owner-scoped terminal transfer document                                                            | Identity and graph evidence derive from immutable events, not mutable profiles |
+
+## Native session identity
+
+The persistent identity contract separates four concerns:
+
+- `identityRef`: durable NodeBench identity row;
+- `agentId` and `workspaceId`: owner-scoped execution boundary;
+- `nativeSessionId` and monotonic generation: native runtime continuity;
+- optional `peerId`: reconnect binding for the active generation.
+
+Reconnect requires the same generation and session ID. Rotation requires a
+higher generation. A lower generation, same-generation session collision, or
+peer replacement fails before any session, trace, or event is inserted.
+
+The current identity snapshot is stored on the mutable identity row for future
+continuity checks. Every run also stores an immutable snapshot and commits its
+hash into `run.started`; export reads only the event-bound snapshot.
+
+## Graph event lifecycle
+
+The supported graph vocabulary is deliberately fixed:
+
+```text
+node.started
+edge.consumed
+artifact.produced
+node.completed
+node.failed
+barrier.opened
+barrier.blocked
+```
+
+Every non-start event must address a currently open `nodeRunId` and its exact
+`nodeId`. A run cannot terminate with an open node. Stale-run retention first
+appends `node.failed` for every open graph node, closes explicit spans, and then
+appends `run.failed`; it never fabricates completion.
+
+NodeBench reserves enough of the 256-event budget to close all open spans and
+graph nodes plus the run terminal. Event payloads remain sensitivity-redacted,
+event-specific, and bounded to the existing 2 KiB stored / 32 KiB redacted
+source limits.
+
+## MCP boundary
+
+`start_execution_run` may provide `nativeIdentity`. The internal
+`mcpStartExecutionRun` mutation resolves it against an owner/workspace-scoped
+identity and returns `created`, `reconnect`, or `rotate`.
+
+`record_execution_graph_event` calls the secret-gated
+`recordExecutionGraphEvent` dispatcher entry. The gateway injects the service
+owner. The mutation verifies trace ownership and running status before the
+canonical run-event projector validates all event-specific fields and appends
+the hash-chained event.
+
+This endpoint performs no external fetch. It returns a content hash only after
+the event transaction succeeds.
+
+## ActiveGraph boundary
+
+ActiveGraph receives only a validated terminal `nodekit.run-export/v1`. The
+representative fixture now contains native identity plus a real stage-local
+sequence: start, frontier-bound node start, exact edge consumption, artifact
+production, node completion, and run completion.
+
+ActiveGraph remains an offline disposable replay observer. It is not a graph
+compiler, scheduler, workflow database, or approval authority.
+
+## Reliability checklist
+
+| Gate           | Result                                                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| BOUND          | 256-event run cap, reserved lifecycle closure, bounded identity fields and payload sizes                          |
+| HONEST_STATUS  | Mutations throw on ownership, lifecycle, identity, or persistence failure                                         |
+| HONEST_SCORES  | No score or confidence is generated                                                                               |
+| TIMEOUT        | New mutations perform no network I/O; the existing offline canary retains its process timeout                     |
+| SSRF           | No caller URL is accepted or fetched                                                                              |
+| BOUND_READ     | Indexed identity lookup and bounded run-prefix reads; gateway body cap remains unchanged                          |
+| ERROR_BOUNDARY | Validation happens before persistence; a failed append aborts the owning mutation                                 |
+| DETERMINISTIC  | Canonical sorted-key SHA-256 hashes bind identities, events, chains, exports, graph references, and edge bindings |
+
+## Required verification
+
+```powershell
+npx tsc --noEmit --pretty false
+npx vitest run `
+  backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity.test.ts `
+  backend/convex/domains/operations/taskManager/nodeKitGraphRunEvents.test.ts `
+  backend/convex/domains/operations/taskManager/nodeKitRunExport.test.ts `
+  backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts `
+  backend/convex/domains/mcp/mcpExecutionTraceEndpoints.integration.test.ts `
+  packages/mcp-local/src/__tests__/executionTraceTools.test.ts `
+  scripts/__tests__/nodekitActiveGraphCanary.test.ts
+npm run build
+```
+
+Production completion additionally requires a reviewed PR merge, a fresh
+deployment tied to that merge, raw-response content evidence, and an operational
+browser journey. A local pass or Git push is not deployment proof.

--- a/evidence/nodekit-stage-local-integration/after.txt
+++ b/evidence/nodekit-stage-local-integration/after.txt
@@ -1,0 +1,25 @@
+NodeKit stage-local runtime integration — after
+Date: 2026-07-29
+
+Verified locally:
+
+- `npx tsc --noEmit --pretty false` — pass
+- focused NodeKit identity, database, graph-event, export, retention,
+  MCP-local, and ActiveGraph suites — 74/74 pass
+- MCP-local static catalog count — pass at 355 tools
+- `npm run build` — pass
+- `npm --prefix packages/mcp-local run build` — pass
+- `git diff --check` — pass
+
+The database suite covers first connection, reconnect, rotation, stale
+generation, same-generation collision, peer replacement, validation before
+persistence, an eight-request burst, 32 sustained reconnects, cross-tenant
+graph append rejection, and exact owner-bound graph event persistence.
+
+The ActiveGraph fixture now replays identity plus a representative stage-local
+node start, exact edge consumption, artifact production, node completion, and
+terminal run. It remains offline and non-authoritative.
+
+The broader repository-wide `tools.test.ts` invocation still contains unrelated
+standard-tree path assumptions (`convex/` versus `backend/convex/`) and slow
+spreadsheet/audit cases. Its direct catalog expectation was updated and passes.

--- a/evidence/nodekit-stage-local-integration/before.txt
+++ b/evidence/nodekit-stage-local-integration/before.txt
@@ -1,0 +1,13 @@
+NodeKit stage-local runtime integration — before
+Date: 2026-07-29
+
+The first contract-first test run proved the missing integration seams:
+
+- the native session identity module did not exist;
+- stage-local graph event types were rejected by the trace contract;
+- the MCP-local graph-event tool did not exist; and
+- six focused scenarios failed while two legacy assertions passed.
+
+The existing run-event/export path was trace-centric. It could not bind a
+NodeKit current-stage graph, runnable frontier, exact edge binding, verifier
+review context, or persistent owner/workspace/native-session identity.

--- a/package.json
+++ b/package.json
@@ -417,7 +417,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "agent-browser": "^0.26.0",
     "autoprefixer": "~10",
-    "convex-test": "^0.0.53",
+    "convex-test": "0.0.40",
     "critters": "^0.0.25",
     "cross-env": "^10.1.0",
     "dotenv": "^16.6.1",

--- a/package.json
+++ b/package.json
@@ -417,7 +417,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "agent-browser": "^0.26.0",
     "autoprefixer": "~10",
-    "convex-test": "0.0.40",
+    "convex-test": "^0.0.53",
     "critters": "^0.0.25",
     "cross-env": "^10.1.0",
     "dotenv": "^16.6.1",

--- a/packages/mcp-local/src/__tests__/executionTraceTools.test.ts
+++ b/packages/mcp-local/src/__tests__/executionTraceTools.test.ts
@@ -30,6 +30,7 @@ describe("executionTraceTools", () => {
       "record_execution_step",
       "record_execution_decision",
       "record_execution_verification",
+      "record_execution_graph_event",
       "attach_execution_evidence",
       "request_execution_approval",
     ]);
@@ -39,10 +40,12 @@ describe("executionTraceTools", () => {
     delete process.env.CONVEX_SITE_URL;
     delete process.env.MCP_SECRET;
 
-    const tool = executionTraceTools.find((entry) => entry.name === "start_execution_run");
+    const tool = executionTraceTools.find(
+      (entry) => entry.name === "start_execution_run",
+    );
     expect(tool).toBeDefined();
 
-    const result = await tool!.handler({ title: "Spreadsheet trace" }) as any;
+    const result = (await tool!.handler({ title: "Spreadsheet trace" })) as any;
     expect(result.error).toBe(true);
     expect(result.message).toContain("MCP_SECRET");
   });
@@ -67,13 +70,22 @@ describe("executionTraceTools", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const tool = executionTraceTools.find((entry) => entry.name === "start_execution_run");
-    const result = await tool!.handler({
+    const tool = executionTraceTools.find(
+      (entry) => entry.name === "start_execution_run",
+    );
+    const result = (await tool!.handler({
       title: "Spreadsheet trace",
       workflowName: "Spreadsheet enrichment",
       type: "agent",
       visibility: "private",
-    }) as any;
+      nativeIdentity: {
+        agentId: "codex.desktop",
+        workspaceId: "workspace:nodebench",
+        nativeSessionId: "session:desktop:2026-07-29",
+        nativeSessionGeneration: 4,
+        peerId: "peer:runner:codex",
+      },
+    })) as any;
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
@@ -92,6 +104,13 @@ describe("executionTraceTools", () => {
         visionSnapshot: undefined,
         successCriteria: undefined,
         sourceRefs: undefined,
+        nativeIdentity: {
+          agentId: "codex.desktop",
+          workspaceId: "workspace:nodebench",
+          nativeSessionId: "session:desktop:2026-07-29",
+          nativeSessionGeneration: 4,
+          peerId: "peer:runner:codex",
+        },
         metadata: undefined,
       },
     });
@@ -101,6 +120,53 @@ describe("executionTraceTools", () => {
     expect(result.publicTraceId).toBe("trace_public_789");
   });
 
+  it("records an exact NodeKit edge binding instead of inferring readiness from exit status", async () => {
+    process.env.CONVEX_SITE_URL = "https://example.convex.site/";
+    process.env.MCP_SECRET = "trace-secret";
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: "event_doc_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = executionTraceTools.find(
+      (entry) => entry.name === "record_execution_graph_event",
+    );
+    const payload = {
+      traceId: "trace_doc_456",
+      eventType: "edge.consumed",
+      graphId: `execution-graph:sha256:${"a".repeat(64)}`,
+      graphHash: "b".repeat(64),
+      caseId: "case:nodebench",
+      stageId: "build",
+      caseContentHash: "c".repeat(64),
+      nodeId: "node:build-ui",
+      nodeRunId: "node-run:build-ui:1",
+      edgeId: "edge:research-to-ui",
+      bindingId: `execution-edge-binding:sha256:${"d".repeat(64)}`,
+      bindingHash: "e".repeat(64),
+      artifactId: "artifact:research-pack",
+      artifactSchemaVersion: "nodekit.research-pack/v1",
+      artifactContentHash: "f".repeat(64),
+      authorityKind: "deterministic",
+    };
+
+    const result = (await tool!.handler(payload)) as any;
+
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).toEqual({
+      fn: "recordExecutionGraphEvent",
+      args: payload,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      eventHash: "event_doc_123",
+      eventType: "edge.consumed",
+    });
+  });
+
   it("requires an error message when completing a failed execution run", async () => {
     process.env.CONVEX_SITE_URL = "https://example.convex.site/";
     process.env.MCP_SECRET = "trace-secret";
@@ -108,12 +174,14 @@ describe("executionTraceTools", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const tool = executionTraceTools.find((entry) => entry.name === "complete_execution_run");
-    const result = await tool!.handler({
+    const tool = executionTraceTools.find(
+      (entry) => entry.name === "complete_execution_run",
+    );
+    const result = (await tool!.handler({
       sessionId: "session_123",
       traceId: "trace_doc_456",
       status: "failed",
-    }) as any;
+    })) as any;
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.error).toBe(true);

--- a/packages/mcp-local/src/__tests__/tools.test.ts
+++ b/packages/mcp-local/src/__tests__/tools.test.ts
@@ -158,9 +158,9 @@ async function getAllImplementedToolNames(): Promise<Set<string>> {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("Static: tool structure", () => {
-  it("should have 354 tools total", () => {
+  it("should have 355 tools total", () => {
     // domain tools + meta tools + progressive discovery tools, including the v3 MCP discovery surface with get_tool_graph.
-    expect(allTools.length).toBe(354);
+    expect(allTools.length).toBe(355);
   });
 
   it("every tool has name, description, inputSchema, handler", () => {

--- a/packages/mcp-local/src/tools/executionTraceTools.ts
+++ b/packages/mcp-local/src/tools/executionTraceTools.ts
@@ -19,12 +19,16 @@ function getTraceConfig(): { siteUrl: string; secret: string } | null {
   return { siteUrl: siteUrl.replace(/\/$/, ""), secret };
 }
 
-async function callGateway<T>(fn: string, args: Record<string, unknown>): Promise<GatewayResult<T>> {
+async function callGateway<T>(
+  fn: string,
+  args: Record<string, unknown>,
+): Promise<GatewayResult<T>> {
   const config = getTraceConfig();
   if (!config) {
     return {
       success: false,
-      error: "Missing CONVEX_SITE_URL (or VITE_CONVEX_URL) or MCP_SECRET. Cannot call execution trace backend.",
+      error:
+        "Missing CONVEX_SITE_URL (or VITE_CONVEX_URL) or MCP_SECRET. Cannot call execution trace backend.",
     };
   }
 
@@ -39,9 +43,10 @@ async function callGateway<T>(fn: string, args: Record<string, unknown>): Promis
 
   const payload = (await res.json()) as GatewayResult<T> & { message?: string };
   if (!res.ok) {
-    const errorMessage = ("error" in payload ? payload.error : undefined)
-      || payload.message
-      || `Execution trace backend returned HTTP ${res.status}`;
+    const errorMessage =
+      ("error" in payload ? payload.error : undefined) ||
+      payload.message ||
+      `Execution trace backend returned HTTP ${res.status}`;
     return {
       success: false,
       error: errorMessage,
@@ -64,7 +69,8 @@ export const executionTraceTools: McpTool[] = [
         },
         workflowName: {
           type: "string",
-          description: "Workflow label for the trace, e.g. 'Spreadsheet enrichment'. Defaults to title.",
+          description:
+            "Workflow label for the trace, e.g. 'Spreadsheet enrichment'. Defaults to title.",
         },
         description: {
           type: "string",
@@ -78,11 +84,13 @@ export const executionTraceTools: McpTool[] = [
         visibility: {
           type: "string",
           enum: ["public", "private"],
-          description: "Whether the run is publicly visible in shared UI surfaces (default: private).",
+          description:
+            "Whether the run is publicly visible in shared UI surfaces (default: private).",
         },
         goalId: {
           type: "string",
-          description: "Optional Oracle/mission goal ID for cross-check tracking.",
+          description:
+            "Optional Oracle/mission goal ID for cross-check tracking.",
         },
         visionSnapshot: {
           type: "string",
@@ -107,6 +115,25 @@ export const executionTraceTools: McpTool[] = [
             required: ["label"],
           },
         },
+        nativeIdentity: {
+          type: "object",
+          description:
+            "Optional persistent native-agent/workspace/session identity. Reuse the same session ID and generation on reconnect; increment the generation on restart or rotation.",
+          properties: {
+            agentId: { type: "string" },
+            workspaceId: { type: "string" },
+            nativeSessionId: { type: "string" },
+            nativeSessionGeneration: { type: "number" },
+            peerId: { type: "string" },
+          },
+          required: [
+            "agentId",
+            "workspaceId",
+            "nativeSessionId",
+            "nativeSessionGeneration",
+          ],
+          additionalProperties: false,
+        },
         metadata: {
           type: "object",
           description: "Opaque metadata stored on both the session and trace.",
@@ -124,7 +151,19 @@ export const executionTraceTools: McpTool[] = [
       goalId?: string;
       visionSnapshot?: string;
       successCriteria?: string[];
-      sourceRefs?: Array<{ label: string; href?: string; note?: string; kind?: string }>;
+      sourceRefs?: Array<{
+        label: string;
+        href?: string;
+        note?: string;
+        kind?: string;
+      }>;
+      nativeIdentity?: {
+        agentId: string;
+        workspaceId: string;
+        nativeSessionId: string;
+        nativeSessionGeneration: number;
+        peerId?: string;
+      };
       metadata?: Record<string, unknown>;
     }) => {
       const start = Date.now();
@@ -143,11 +182,16 @@ export const executionTraceTools: McpTool[] = [
         visionSnapshot: args.visionSnapshot,
         successCriteria: args.successCriteria,
         sourceRefs: args.sourceRefs,
+        nativeIdentity: args.nativeIdentity,
         metadata: args.metadata,
       });
 
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
 
       return {
@@ -198,8 +242,14 @@ export const executionTraceTools: McpTool[] = [
           type: "string",
           description: "Required when status is failed.",
         },
-        inputTokens: { type: "number", description: "Optional input token count." },
-        outputTokens: { type: "number", description: "Optional output token count." },
+        inputTokens: {
+          type: "number",
+          description: "Optional input token count.",
+        },
+        outputTokens: {
+          type: "number",
+          description: "Optional output token count.",
+        },
         toolsUsed: {
           type: "array",
           items: { type: "string" },
@@ -236,7 +286,8 @@ export const executionTraceTools: McpTool[] = [
       if (args.status === "failed" && !args.errorMessage) {
         return {
           error: true,
-          message: "errorMessage is required when completing an execution run with status='failed'.",
+          message:
+            "errorMessage is required when completing an execution run with status='failed'.",
           latencyMs: Date.now() - start,
         };
       }
@@ -259,7 +310,11 @@ export const executionTraceTools: McpTool[] = [
         });
 
         if (!metricsResult.success) {
-          return { error: true, message: metricsResult.error, latencyMs: Date.now() - start };
+          return {
+            error: true,
+            message: metricsResult.error,
+            latencyMs: Date.now() - start,
+          };
         }
       }
 
@@ -280,7 +335,11 @@ export const executionTraceTools: McpTool[] = [
       });
 
       if (!traceResult.success) {
-        return { error: true, message: traceResult.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: traceResult.error,
+          latencyMs: Date.now() - start,
+        };
       }
 
       const sessionResult = await callGateway<null>("updateSessionStatus", {
@@ -292,7 +351,11 @@ export const executionTraceTools: McpTool[] = [
       });
 
       if (!sessionResult.success) {
-        return { error: true, message: sessionResult.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: sessionResult.error,
+          latencyMs: Date.now() - start,
+        };
       }
 
       return {
@@ -312,10 +375,22 @@ export const executionTraceTools: McpTool[] = [
       type: "object",
       properties: {
         traceId: { type: "string", description: "Convex agentTaskTraces ID." },
-        parentSpanId: { type: "string", description: "Optional parent span ID." },
+        parentSpanId: {
+          type: "string",
+          description: "Optional parent span ID.",
+        },
         stage: {
           type: "string",
-          enum: ["ingest", "inspect", "research", "propose", "edit", "verify", "export", "summarize"],
+          enum: [
+            "ingest",
+            "inspect",
+            "research",
+            "propose",
+            "edit",
+            "verify",
+            "export",
+            "summarize",
+          ],
         },
         type: {
           type: "string",
@@ -351,13 +426,26 @@ export const executionTraceTools: McpTool[] = [
         endedAt: { type: "number" },
         metadata: { type: "object", additionalProperties: true },
       },
-      required: ["traceId", "stage", "type", "title", "tool", "action", "target", "resultSummary"],
+      required: [
+        "traceId",
+        "stage",
+        "type",
+        "title",
+        "tool",
+        "action",
+        "target",
+        "resultSummary",
+      ],
     },
     handler: async (args: Record<string, unknown>) => {
       const start = Date.now();
       const result = await callGateway<string>("recordStep", args);
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
       return {
         success: true,
@@ -375,9 +463,17 @@ export const executionTraceTools: McpTool[] = [
       type: "object",
       properties: {
         traceId: { type: "string", description: "Convex agentTaskTraces ID." },
-        decisionType: { type: "string", description: "Decision type, e.g. ranking, selection, rejection, escalation." },
+        decisionType: {
+          type: "string",
+          description:
+            "Decision type, e.g. ranking, selection, rejection, escalation.",
+        },
         statement: { type: "string", description: "Decision statement." },
-        basis: { type: "array", items: { type: "string" }, description: "Concise reasons supporting the choice." },
+        basis: {
+          type: "array",
+          items: { type: "string" },
+          description: "Concise reasons supporting the choice.",
+        },
         evidenceRefs: { type: "array", items: { type: "string" } },
         alternativesConsidered: { type: "array", items: { type: "string" } },
         confidence: { type: "number" },
@@ -389,7 +485,11 @@ export const executionTraceTools: McpTool[] = [
       const start = Date.now();
       const result = await callGateway<string>("recordDecision", args);
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
       return {
         success: true,
@@ -412,9 +512,16 @@ export const executionTraceTools: McpTool[] = [
           type: "string",
           enum: ["passed", "warning", "failed", "fixed"],
         },
-        details: { type: "string", description: "Human-readable verification details." },
+        details: {
+          type: "string",
+          description: "Human-readable verification details.",
+        },
         relatedArtifactIds: { type: "array", items: { type: "string" } },
-        createGuardrailSpan: { type: "boolean", description: "Whether to also create a guardrail span (default true)." },
+        createGuardrailSpan: {
+          type: "boolean",
+          description:
+            "Whether to also create a guardrail span (default true).",
+        },
       },
       required: ["traceId", "label", "status", "details"],
     },
@@ -422,7 +529,11 @@ export const executionTraceTools: McpTool[] = [
       const start = Date.now();
       const result = await callGateway<string>("recordVerification", args);
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
       return {
         success: true,
@@ -430,6 +541,100 @@ export const executionTraceTools: McpTool[] = [
         traceId: result.data,
         label: args.label,
         status: args.status,
+      };
+    },
+  },
+  {
+    name: "record_execution_graph_event",
+    description:
+      "Append one exact NodeKit stage-local graph event to a live execution trace. Use NodeKit-produced graph, frontier, edge-binding, artifact, and review-context identifiers; this tool records the evidence-bound handoff and never infers readiness from process exit status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        traceId: { type: "string" },
+        eventType: {
+          type: "string",
+          enum: [
+            "node.started",
+            "edge.consumed",
+            "artifact.produced",
+            "node.completed",
+            "node.failed",
+            "barrier.opened",
+            "barrier.blocked",
+          ],
+        },
+        graphId: { type: "string" },
+        graphHash: { type: "string" },
+        caseId: { type: "string" },
+        stageId: { type: "string" },
+        caseContentHash: { type: "string" },
+        nodeId: { type: "string" },
+        nodeRunId: { type: "string" },
+        nodeKind: { type: "string", enum: ["task", "review", "barrier"] },
+        frontierHash: { type: "string" },
+        edgeId: { type: "string" },
+        bindingId: { type: "string" },
+        bindingHash: { type: "string" },
+        artifactId: { type: "string" },
+        artifactSchemaVersion: { type: "string" },
+        artifactContentHash: { type: "string" },
+        authorityKind: {
+          type: "string",
+          enum: [
+            "agent-produced",
+            "deterministic",
+            "human-attested",
+            "nodeproof-verified",
+          ],
+        },
+        status: { type: "string" },
+        reasonCode: { type: "string" },
+        blockingEdgeCount: { type: "number" },
+        reviewContextRef: { type: "string" },
+        reviewSeparation: {
+          type: "string",
+          enum: [
+            "same-context",
+            "fresh-context",
+            "independent-model",
+            "independent-human",
+          ],
+        },
+        protectedEvaluator: { type: "boolean" },
+      },
+      required: [
+        "traceId",
+        "eventType",
+        "graphId",
+        "graphHash",
+        "caseId",
+        "stageId",
+        "caseContentHash",
+        "nodeId",
+        "nodeRunId",
+      ],
+      additionalProperties: false,
+    },
+    handler: async (args: Record<string, unknown>) => {
+      const start = Date.now();
+      const result = await callGateway<string>(
+        "recordExecutionGraphEvent",
+        args,
+      );
+      if (!result.success) {
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
+      }
+      return {
+        success: true,
+        latencyMs: Date.now() - start,
+        eventHash: result.data,
+        traceId: args.traceId,
+        eventType: args.eventType,
       };
     },
   },
@@ -442,7 +647,10 @@ export const executionTraceTools: McpTool[] = [
       properties: {
         traceId: { type: "string", description: "Convex agentTaskTraces ID." },
         title: { type: "string", description: "Evidence title." },
-        summary: { type: "string", description: "What this evidence supports or qualifies." },
+        summary: {
+          type: "string",
+          description: "What this evidence supports or qualifies.",
+        },
         sourceRefs: {
           type: "array",
           items: {
@@ -465,7 +673,11 @@ export const executionTraceTools: McpTool[] = [
       const start = Date.now();
       const result = await callGateway<string>("attachEvidence", args);
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
       return {
         success: true,
@@ -482,12 +694,29 @@ export const executionTraceTools: McpTool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        sessionId: { type: "string", description: "Convex agentTaskSessions ID." },
-        traceId: { type: "string", description: "Optional related agentTaskTraces ID." },
-        toolName: { type: "string", description: "Tool or action requiring approval." },
-        toolArgs: { type: "object", additionalProperties: true, description: "Arguments or change payload for the risky action." },
+        sessionId: {
+          type: "string",
+          description: "Convex agentTaskSessions ID.",
+        },
+        traceId: {
+          type: "string",
+          description: "Optional related agentTaskTraces ID.",
+        },
+        toolName: {
+          type: "string",
+          description: "Tool or action requiring approval.",
+        },
+        toolArgs: {
+          type: "object",
+          additionalProperties: true,
+          description: "Arguments or change payload for the risky action.",
+        },
         riskLevel: { type: "string", enum: ["low", "medium", "high"] },
-        justification: { type: "string", description: "Why approval is needed and what will happen if approved." },
+        justification: {
+          type: "string",
+          description:
+            "Why approval is needed and what will happen if approved.",
+        },
       },
       required: ["sessionId", "toolName", "riskLevel", "justification"],
     },
@@ -495,7 +724,11 @@ export const executionTraceTools: McpTool[] = [
       const start = Date.now();
       const result = await callGateway<string>("requestTraceApproval", args);
       if (!result.success) {
-        return { error: true, message: result.error, latencyMs: Date.now() - start };
+        return {
+          error: true,
+          message: result.error,
+          latencyMs: Date.now() - start,
+        };
       }
       return {
         success: true,

--- a/packages/mcp-local/src/tools/toolRegistry.ts
+++ b/packages/mcp-local/src/tools/toolRegistry.ts
@@ -1882,6 +1882,33 @@ const REGISTRY_ENTRIES = [
     complexity: "low",
   },
   {
+    name: "record_execution_graph_event",
+    category: "platform",
+    tags: [
+      "execution-trace",
+      "nodekit",
+      "execution-graph",
+      "edge-binding",
+      "runnable-frontier",
+      "review-context",
+      "barrier",
+      "traceable",
+    ],
+    quickRef: {
+      nextAction:
+        "Graph event recorded. Continue only from the current NodeKit runnable frontier and bind every consumed edge to its exact artifact hash.",
+      nextTools: [
+        "record_execution_graph_event",
+        "attach_execution_evidence",
+        "record_execution_verification",
+      ],
+      methodology: "quality_gates",
+      tip: "Record NodeKit-issued identifiers and hashes. Do not convert a successful process exit into an edge binding or stage advance.",
+    },
+    phase: "verify",
+    complexity: "medium",
+  },
+  {
     name: "attach_execution_evidence",
     category: "platform",
     tags: ["execution-trace", "evidence", "sources", "truth-boundary", "urls", "files", "support", "claims"],
@@ -5586,8 +5613,13 @@ export const TOOL_REGISTRY = new Map<string, ToolRegistryEntry>(
   REGISTRY_ENTRIES.map((e) => [e.name, e])
 );
 
-/** All registry entries as array */
-export const ALL_REGISTRY_ENTRIES = REGISTRY_ENTRIES;
+/**
+ * Mutable runtime registry entries.
+ *
+ * Keep REGISTRY_ENTRIES as the readonly literal source for RegisteredToolName,
+ * while allowing lazy toolset loaders to append truthful synthetic entries.
+ */
+export const ALL_REGISTRY_ENTRIES: ToolRegistryEntry[] = [...REGISTRY_ENTRIES];
 
 /** Get quick ref for a tool, with fallback for unregistered tools */
 export function getQuickRef(toolName: string): ToolQuickRef | null {

--- a/scripts/__tests__/nodekitActiveGraphCanary.test.ts
+++ b/scripts/__tests__/nodekitActiveGraphCanary.test.ts
@@ -27,6 +27,7 @@ import {
   canonicalNodeKitJson,
 } from "../../backend/convex/domains/operations/taskManager/nodeKitRunEvents";
 import { buildCanonicalNodeKitRunExport } from "../../backend/convex/domains/operations/taskManager/nodeKitRunExport";
+import { buildNodeKitNativeSessionIdentity } from "../../backend/convex/domains/operations/taskManager/nodeKitRuntimeIdentity";
 
 const hashBytes = (value: Buffer) =>
   createHash("sha256").update(value).digest("hex");
@@ -80,6 +81,14 @@ function listTypeScriptSources(directory: string): string[] {
 
 async function writeValidExport(path: string) {
   const runId = "trace_disposable_copy_test";
+  const nativeIdentity = await buildNodeKitNativeSessionIdentity({
+    identityRef: "nodebench:agent-identity:fixture-agent",
+    agentId: "codex.fixture",
+    workspaceId: "workspace:activegraph-canary",
+    nativeSessionId: "session:representative-stage-local-run",
+    nativeSessionGeneration: 1,
+    peerId: "peer:runner:fixture",
+  });
   const started = await buildNodeKitRunEvent({
     runId,
     sequence: 0,
@@ -89,21 +98,95 @@ async function writeValidExport(path: string) {
       workflowName: "offline-copy-test",
       sessionType: "agent",
       sessionStartedAt: 5,
+      identityRef: nativeIdentity.identityRef,
+      workspaceId: nativeIdentity.workspaceId,
+      agentId: nativeIdentity.agentId,
+      nativeSessionId: nativeIdentity.nativeSessionId,
+      nativeSessionGeneration: nativeIdentity.nativeSessionGeneration,
+      peerId: nativeIdentity.peerId,
+      identitySnapshotHash: nativeIdentity.snapshotHash,
     },
     previousHash: NODEKIT_RUN_GENESIS_HASH,
   });
-  const completed = await buildNodeKitRunEvent({
+  const graph = {
+    graphId: `execution-graph:sha256:${"a".repeat(64)}`,
+    graphHash: "b".repeat(64),
+    caseId: "case:representative-canary",
+    stageId: "build",
+    caseContentHash: "c".repeat(64),
+    nodeId: "node:build-candidate",
+    nodeRunId: "node-run:build-candidate:1",
+  };
+  const nodeStarted = await buildNodeKitRunEvent({
     runId,
     sequence: 1,
+    eventType: "node.started",
+    recordedAt: 11,
+    payload: {
+      ...graph,
+      nodeKind: "task",
+      frontierHash: "d".repeat(64),
+    },
+    previousHash: started.contentHash,
+  });
+  const edgeConsumed = await buildNodeKitRunEvent({
+    runId,
+    sequence: 2,
+    eventType: "edge.consumed",
+    recordedAt: 12,
+    payload: {
+      ...graph,
+      edgeId: "edge:research-to-build",
+      bindingId: `execution-edge-binding:sha256:${"e".repeat(64)}`,
+      bindingHash: "f".repeat(64),
+      artifactId: "artifact:research-pack",
+      artifactSchemaVersion: "nodekit.research-pack/v1",
+      artifactContentHash: "1".repeat(64),
+      authorityKind: "deterministic",
+    },
+    previousHash: nodeStarted.contentHash,
+  });
+  const artifactProduced = await buildNodeKitRunEvent({
+    runId,
+    sequence: 3,
+    eventType: "artifact.produced",
+    recordedAt: 13,
+    payload: {
+      ...graph,
+      artifactId: "artifact:build-candidate",
+      artifactSchemaVersion: "nodekit.build-candidate/v1",
+      artifactContentHash: "2".repeat(64),
+      authorityKind: "agent-produced",
+    },
+    previousHash: edgeConsumed.contentHash,
+  });
+  const nodeCompleted = await buildNodeKitRunEvent({
+    runId,
+    sequence: 4,
+    eventType: "node.completed",
+    recordedAt: 14,
+    payload: { ...graph, status: "completed" },
+    previousHash: artifactProduced.contentHash,
+  });
+  const completed = await buildNodeKitRunEvent({
+    runId,
+    sequence: 5,
     eventType: "run.completed",
     recordedAt: 20,
     payload: { status: "completed" },
-    previousHash: started.contentHash,
+    previousHash: nodeCompleted.contentHash,
   });
   const exportDoc = await buildCanonicalNodeKitRunExport({
     sessionId: "session-copy-test",
     traceId: "trace-record-copy-test",
-    events: [started, completed],
+    events: [
+      started,
+      nodeStarted,
+      edgeConsumed,
+      artifactProduced,
+      nodeCompleted,
+      completed,
+    ],
   });
   writeFileSync(path, `${JSON.stringify(exportDoc)}\n`, "utf8");
   return exportDoc;

--- a/scripts/nodekit/runActiveGraphCanary.mjs
+++ b/scripts/nodekit/runActiveGraphCanary.mjs
@@ -55,6 +55,13 @@ const EVENT_TYPES = new Set([
   "verification.recorded",
   "evidence.attached",
   "approval.requested",
+  "node.started",
+  "edge.consumed",
+  "artifact.produced",
+  "node.completed",
+  "node.failed",
+  "barrier.opened",
+  "barrier.blocked",
   "run.completed",
   "run.failed",
 ]);
@@ -68,6 +75,13 @@ const SAFE_FIELDS_BY_EVENT = {
     "goalId",
     "sessionType",
     "sessionStartedAt",
+    "identityRef",
+    "workspaceId",
+    "agentId",
+    "nativeSessionId",
+    "nativeSessionGeneration",
+    "peerId",
+    "identitySnapshotHash",
   ]),
   "span.started": new Set([
     "spanId",
@@ -90,6 +104,95 @@ const SAFE_FIELDS_BY_EVENT = {
   "verification.recorded": new Set(["status"]),
   "evidence.attached": new Set(),
   "approval.requested": new Set(["approvalId", "toolName", "riskLevel"]),
+  "node.started": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "nodeKind",
+    "frontierHash",
+    "reviewContextRef",
+  ]),
+  "edge.consumed": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "edgeId",
+    "bindingId",
+    "bindingHash",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ]),
+  "artifact.produced": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ]),
+  "node.completed": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+    "reviewContextRef",
+    "reviewSeparation",
+    "protectedEvaluator",
+  ]),
+  "node.failed": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+    "reasonCode",
+  ]),
+  "barrier.opened": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+    "status",
+  ]),
+  "barrier.blocked": new Set([
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+    "status",
+    "reasonCode",
+    "blockingEdgeCount",
+  ]),
   "run.completed": new Set([
     "status",
     "totalDurationMs",
@@ -107,6 +210,84 @@ const REQUIRED_FIELDS_BY_EVENT = {
   "run.started": ["workflowName", "sessionType", "sessionStartedAt"],
   "span.started": ["spanId"],
   "span.completed": ["spanId"],
+  "node.started": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+  ],
+  "edge.consumed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "edgeId",
+    "bindingId",
+    "bindingHash",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "artifact.produced": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "artifactId",
+    "artifactSchemaVersion",
+    "artifactContentHash",
+    "authorityKind",
+  ],
+  "node.completed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+  ],
+  "node.failed": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "status",
+  ],
+  "barrier.opened": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+  ],
+  "barrier.blocked": [
+    "graphId",
+    "graphHash",
+    "caseId",
+    "stageId",
+    "caseContentHash",
+    "nodeId",
+    "nodeRunId",
+    "frontierHash",
+  ],
   "run.completed": ["status"],
   "run.failed": ["status"],
 };
@@ -519,6 +700,78 @@ function assertSafeEventPayload(payload, eventType, label) {
       `${label} requires status ${expectedTerminalStatus}.`,
     );
   }
+  if (eventType === "run.started") {
+    const identityFields = [
+      "identityRef",
+      "workspaceId",
+      "agentId",
+      "nativeSessionId",
+      "nativeSessionGeneration",
+      "identitySnapshotHash",
+    ];
+    const present = identityFields.filter((field) => field in payload.fields);
+    if (present.length !== 0 && present.length !== identityFields.length) {
+      fail(
+        "native_identity_incomplete",
+        `${label} must bind the complete native identity snapshot.`,
+      );
+    }
+    if (present.length === identityFields.length) {
+      assertHash(
+        payload.fields.identitySnapshotHash,
+        `${label}.identitySnapshotHash`,
+      );
+      if (
+        !Number.isSafeInteger(payload.fields.nativeSessionGeneration) ||
+        payload.fields.nativeSessionGeneration < 0
+      ) {
+        fail(
+          "native_session_generation_invalid",
+          `${label}.nativeSessionGeneration is invalid.`,
+        );
+      }
+    }
+  }
+  if (
+    eventType === "node.started" ||
+    eventType === "edge.consumed" ||
+    eventType === "artifact.produced" ||
+    eventType === "node.completed" ||
+    eventType === "node.failed" ||
+    eventType === "barrier.opened" ||
+    eventType === "barrier.blocked"
+  ) {
+    if (
+      typeof payload.fields.graphId !== "string" ||
+      !/^execution-graph:sha256:[a-f0-9]{64}$/.test(payload.fields.graphId)
+    ) {
+      fail("graph_id_invalid", `${label}.graphId is invalid.`);
+    }
+    for (const field of [
+      "graphHash",
+      "caseContentHash",
+      "frontierHash",
+      "bindingHash",
+      "artifactContentHash",
+    ]) {
+      if (
+        field in payload.fields &&
+        (typeof payload.fields[field] !== "string" ||
+          !/^[a-f0-9]{64}$/.test(payload.fields[field]))
+      ) {
+        fail("graph_hash_invalid", `${label}.${field} is invalid.`);
+      }
+    }
+    if (
+      "bindingId" in payload.fields &&
+      (typeof payload.fields.bindingId !== "string" ||
+        !/^execution-edge-binding:sha256:[a-f0-9]{64}$/.test(
+          payload.fields.bindingId,
+        ))
+    ) {
+      fail("edge_binding_id_invalid", `${label}.bindingId is invalid.`);
+    }
+  }
   if (
     Buffer.byteLength(canonicalJson(payload), "utf8") > MAX_STORED_PAYLOAD_BYTES
   ) {
@@ -567,7 +820,16 @@ export function assertCanonicalNodeKitRunExport(value) {
   assertObject(value.trace, "trace");
   assertObject(value.completeness, "completeness");
   assertObject(value.hashes, "hashes");
-  exactKeys(value.session, ["id", "typeAtRunStart", "startedAt"], "session");
+  exactKeys(
+    value.session,
+    [
+      "id",
+      "typeAtRunStart",
+      "startedAt",
+      ...("nativeIdentity" in value.session ? ["nativeIdentity"] : []),
+    ],
+    "session",
+  );
   exactKeys(
     value.trace,
     ["id", "runId", "workflowName", "status", "startedAt", "endedAt"],
@@ -593,6 +855,23 @@ export function assertCanonicalNodeKitRunExport(value) {
     maxLength: 256,
   });
   assertTimestamp(value.session.startedAt, "session.startedAt");
+  if ("nativeIdentity" in value.session) {
+    assertObject(value.session.nativeIdentity, "session.nativeIdentity");
+    exactKeys(
+      value.session.nativeIdentity,
+      [
+        "schemaVersion",
+        "identityRef",
+        "agentId",
+        "workspaceId",
+        "nativeSessionId",
+        "nativeSessionGeneration",
+        ...("peerId" in value.session.nativeIdentity ? ["peerId"] : []),
+        "snapshotHash",
+      ],
+      "session.nativeIdentity",
+    );
+  }
   assertString(value.trace.id, "trace.id", { nonEmpty: true });
   assertString(value.trace.runId, "trace.runId", {
     nonEmpty: true,
@@ -626,6 +905,9 @@ export function assertCanonicalNodeKitRunExport(value) {
   let terminalIndex = -1;
   const openSpans = new Set();
   const completedSpans = new Set();
+  const openNodes = new Map();
+  const closedNodeRuns = new Set();
+  let graphScope;
   for (let index = 0; index < value.events.length; index += 1) {
     const event = value.events[index];
     assertObject(event, `events[${index}]`);
@@ -716,6 +998,53 @@ export function assertCanonicalNodeKitRunExport(value) {
       openSpans.delete(spanId);
       completedSpans.add(spanId);
     }
+    if (
+      event.eventType === "node.started" ||
+      event.eventType === "edge.consumed" ||
+      event.eventType === "artifact.produced" ||
+      event.eventType === "node.completed" ||
+      event.eventType === "node.failed" ||
+      event.eventType === "barrier.opened" ||
+      event.eventType === "barrier.blocked"
+    ) {
+      const fields = event.payload.fields;
+      const currentScope = [
+        fields.graphId,
+        fields.graphHash,
+        fields.caseId,
+        fields.stageId,
+        fields.caseContentHash,
+      ].join("|");
+      graphScope ??= currentScope;
+      if (currentScope !== graphScope) {
+        fail(
+          "graph_scope_mismatch",
+          "One export cannot mix execution graphs, cases, or stages.",
+        );
+      }
+      const nodeRunId = fields.nodeRunId;
+      const nodeId = fields.nodeId;
+      if (event.eventType === "node.started") {
+        if (openNodes.has(nodeRunId) || closedNodeRuns.has(nodeRunId)) {
+          fail("graph_node_duplicate_start", `Invalid start for ${nodeRunId}.`);
+        }
+        openNodes.set(nodeRunId, nodeId);
+      } else {
+        if (openNodes.get(nodeRunId) !== nodeId) {
+          fail(
+            "graph_node_not_running",
+            `${event.eventType} is not bound to ${nodeRunId}.`,
+          );
+        }
+        if (
+          event.eventType === "node.completed" ||
+          event.eventType === "node.failed"
+        ) {
+          openNodes.delete(nodeRunId);
+          closedNodeRuns.add(nodeRunId);
+        }
+      }
+    }
     previousHash = event.contentHash;
   }
   if (value.events[0].eventType !== "run.started") {
@@ -737,6 +1066,12 @@ export function assertCanonicalNodeKitRunExport(value) {
     fail(
       "span_lifecycle_incomplete",
       `Terminal run retains ${openSpans.size} open span(s).`,
+    );
+  }
+  if (openNodes.size > 0) {
+    fail(
+      "graph_node_lifecycle_incomplete",
+      `Terminal run retains ${openNodes.size} open graph node(s).`,
     );
   }
 
@@ -762,6 +1097,43 @@ export function assertCanonicalNodeKitRunExport(value) {
       "event_snapshot_mismatch",
       "Session or trace metadata differs from immutable event snapshots.",
     );
+  }
+  if (
+    startFields.identityRef === undefined &&
+    "nativeIdentity" in value.session
+  ) {
+    fail(
+      "native_identity_snapshot_mismatch",
+      "Session identity is absent from run.started.",
+    );
+  }
+  if (startFields.identityRef !== undefined) {
+    const expectedIdentityBody = {
+      schemaVersion: "nodekit.native-agent-session-identity/v1",
+      identityRef: startFields.identityRef,
+      agentId: startFields.agentId,
+      workspaceId: startFields.workspaceId,
+      nativeSessionId: startFields.nativeSessionId,
+      nativeSessionGeneration: startFields.nativeSessionGeneration,
+      ...(startFields.peerId === undefined
+        ? {}
+        : { peerId: startFields.peerId }),
+    };
+    const expectedIdentity = {
+      ...expectedIdentityBody,
+      snapshotHash: canonicalHash(expectedIdentityBody),
+    };
+    if (
+      !("nativeIdentity" in value.session) ||
+      canonicalJson(value.session.nativeIdentity) !==
+        canonicalJson(expectedIdentity) ||
+      startFields.identitySnapshotHash !== expectedIdentity.snapshotHash
+    ) {
+      fail(
+        "native_identity_snapshot_mismatch",
+        "Session identity differs from immutable run.started fields.",
+      );
+    }
   }
   if (
     value.completeness.eventChainComplete !== true ||


### PR DESCRIPTION
## Why
NodeBench's execution trace was trace-centric and could not preserve NodeKit's latest current-stage execution graph, exact edge bindings, runnable frontier, review separation, or persistent native-agent session identity.

## What changed
- adds `nodekit.native-agent-session-identity/v1` with owner/workspace scope, reconnect, monotonic rotation, peer continuity, opaque storage-derived identity refs, and validation before persistence
- records the fixed NodeKit graph vocabulary in the bounded hash-chained `nodekit.run-event/v1` lifecycle
- requires exact graph/case/stage, frontier, edge-binding, artifact, authority, and review-context evidence
- closes stale graph nodes with `node.failed` before terminal run failure
- exports the immutable event-bound identity snapshot
- exposes secret-gated `recordExecutionGraphEvent` plus MCP-local `record_execution_graph_event`
- upgrades the ActiveGraph fixture to a representative identity + stage-local graph sequence while keeping ActiveGraph offline and non-authoritative
- separates the literal static tool registry from its mutable runtime synthetic-entry copy

## Authority boundary
Canonical Caseflow remains authoritative. NodeBench records NodeKit-generated projections and evidence; it does not compile a second graph, infer readiness from exit status, approve findings, or advance stages. ActiveGraph remains a disposable offline observer.

## Runtime change

```text
MCP LOCAL / GATEWAY
  start run + graph event tools
          |
          v
CONVEX BACKEND
  owner-scoped identity continuity
  bounded hash-chained graph events
          |
          v
CONVEX DATA
  optional identity fields + immutable trace events
          |
          v
OFFLINE AGENT EVAL
  terminal export -> ActiveGraph canary
  no writes back; no lifecycle authority
```
## Verification
- `npx tsc --noEmit --pretty false`
- 74/74 focused identity, database, graph-event, export, retention, MCP, and ActiveGraph scenarios
- MCP-local catalog count contract: 355 tools
- `npm run build`
- `npm --prefix packages/mcp-local run build`
- `git diff --check`

Evidence: `evidence/nodekit-stage-local-integration/{before,after}.txt`

## Known unrelated broad-suite failures
A repository-wide `tools.test.ts` invocation still exposes pre-existing standard-tree assumptions (`convex/` versus `backend/convex/`) and slow spreadsheet/audit cases. The direct catalog-count contract affected by this PR was updated and passes.

## Deployment
No out-of-band Convex deploy was performed. Production proof remains gated on reviewed merge, CI deployment, raw-response signal, and operational browser verification.