### PR TITLE
docs(nodekit): record production graph proof

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,12 +57,6 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-07-29 · Codex `/root` →** `backend/convex/domains/operations/taskManager/nodeKitRunEvents.ts`,
-  `nodeKitRunExport.ts`, adjacent tests/schema, and NodeKit integration docs · add the stage-local
-  execution-graph/edge/frontier/review-context trace bindings and persistent session identity
-  references without replacing Caseflow authority · branch `codex/nodekit-stage-local-integration`.
-  No out-of-band Convex deploy.
-
 > **STANDARD-TREE MIGRATION (2026-07-19, feat/standard-tree-migration): repo paths moved.**
 > `convex/` → `backend/convex/` (convex.json `functions` added; function identifiers unchanged),
 > `src/` + `index.html` → `apps/web/` (`@convex` alias replaces relative `../convex` imports),
@@ -84,7 +78,7 @@ Server Error) for an unknown slug.
 ## Hand-offs (built + ready for the other agent to call)
 
 - **2026-07-29 - Codex `/root` -> execution-trace and MCP consumers** -
-  Candidate on `codex/nodekit-stage-local-integration`, not deployed:
+  Shipped through PR #603 at `1e034f5fd3bf109f6283669c2c24774c78962b86`:
   `mcpStartExecutionRun({ ..., nativeIdentity?: {agentId, workspaceId,
 nativeSessionId, nativeSessionGeneration, peerId?} })` returns the immutable
   `nodekit.native-agent-session-identity/v1` snapshot plus continuity
@@ -95,8 +89,10 @@ nodeRunId, ...eventSpecificFields})` appends one exact graph event and returns
   service owner. Shared schema additions are optional. Caseflow remains
   authoritative; the runtime records NodeKit-generated graph/frontier/binding
   evidence and never derives approval or stage advancement. No out-of-band
-  Convex deploy. Local verification: root typecheck, 74 focused scenarios,
-  root production build, and MCP-local package build pass.
+  Convex deploy. Production verification: main CI and Convex deploy passed;
+  the owner-scoped gateway verified create/reconnect/rotate and stale-generation
+  rejection; the graph lifecycle stored exact frontier, edge, artifact, barrier,
+  and review-context evidence in one valid terminal hash chain.
 
 - **2026-07-28 - Codex `/root/activegraph_final_audit` -> `/root`** -
   Release-hardening audit complete on the uncommitted
@@ -299,6 +295,14 @@ attemptKey, userId, reason? })`, retaining the full reservation maximum rather
   actually enters a room. The live counter + share moment both honor this.
 
 ## Recently shipped (this ScratchNode session)
+
+- **2026-07-29 · Codex `/root`** — Stage-local NodeKit execution-graph and
+  persistent native-agent identity contracts merged through PR #603 at
+  `1e034f5f`. Main CI, Convex deploy, Vercel deployment
+  `dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW`, raw production HTML, and secret-gated
+  production identity/graph lifecycle probes passed. The service-user binding
+  was restored before the live gateway proof; every proof trace was
+  terminalized.
 
 - **2026-07-29 · Codex `/root`** — Live notebook capture and its Mobbin/Mew/Roam evidence chain
   merged through PR #601 at `8416106a`. Cmd/Ctrl+E now preserves underlying write authority,

--- a/CHANGELOG/components/entity-notebook-live.md
+++ b/CHANGELOG/components/entity-notebook-live.md
@@ -9,14 +9,14 @@ Make Cmd/Ctrl+E enter edit mode and focus the first editable Live block. Empty
 notebooks create exactly one block, while active text inputs, repeated shortcuts,
 shared routes, and notebooks containing only read-only blocks remain protected.
 
-**PR / canonical main commit**: PENDING #601 MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #601 / `8416106a42729967b4ba3a6a397a95fc0e539bfa`.
 
 **Evidence state**:
-- Source: pending on PR #601.
-- Checks: TypeScript passed; the focused EntityNotebookSurface and EntityNotebookLive scenario pack passed 15/15; production build passed; the NodeKit reference corpus gate passed 10/10 records with 21 facts and 53 citations.
+- Source: merged to `main` through PR #601.
+- Checks: TypeScript passed; the focused EntityNotebookSurface and EntityNotebookLive scenario pack passed 15/15; production build passed; the NodeKit reference corpus gate passed 10/10 records with 21 facts and 53 citations; required PR and main-branch checks passed.
 - Visual proof: pending authenticated Chrome capture; failing-before and passing-after behavior receipts are in `evidence/note-surface-live-capture/`.
-- Preview: pending exact-head deployment after this update.
-- Production live: not recorded.
+- Preview: PR preview and post-deploy verification passed.
+- Production live: commit `8416106a` is contained in production deployment `dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW`; authenticated state-matrix proof remains pending and must not be inferred from deployment alone.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`entity-notebook-surface.md`](entity-notebook-surface.md).

--- a/CHANGELOG/components/entity-notebook-surface.md
+++ b/CHANGELOG/components/entity-notebook-surface.md
@@ -11,14 +11,14 @@ discarding it when the route renders in read mode. The Live component now owns
 the temporary read-only mask, allowing an authorized reader to use the capture
 shortcut without granting write access to shared or read-only notebooks.
 
-**PR / canonical main commit**: PENDING #601 MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #601 / `8416106a42729967b4ba3a6a397a95fc0e539bfa`.
 
 **Evidence state**:
-- Source: pending on PR #601.
-- Checks: TypeScript passed; the focused EntityNotebookSurface and EntityNotebookLive scenario pack passed 15/15; production build passed.
+- Source: merged to `main` through PR #601.
+- Checks: TypeScript passed; the focused EntityNotebookSurface and EntityNotebookLive scenario pack passed 15/15; production build passed; required PR and main-branch checks passed.
 - Visual proof: pending authenticated Chrome capture; component focus behavior is recorded in `evidence/note-surface-live-capture/after.txt`.
-- Preview: pending exact-head deployment after this update.
-- Production live: not recorded.
+- Preview: PR preview and post-deploy verification passed.
+- Production live: commit `8416106a` is contained in production deployment `dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW`; authenticated state-matrix proof remains pending and must not be inferred from deployment alone.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`entity-notebook-live.md`](entity-notebook-live.md).

--- a/CHANGELOG/integrations/nodekit-stage-local-runtime.md
+++ b/CHANGELOG/integrations/nodekit-stage-local-runtime.md
@@ -6,7 +6,7 @@ first.
 
 ## 2026-07-29 — Bind NodeBench traces to NodeKit's current-stage graph
 
-The pending candidate adds an owner/workspace-scoped native-agent session
+The shipped integration adds an owner/workspace-scoped native-agent session
 identity, records NodeKit's exact stage-local graph, frontier, edge-binding,
 artifact, barrier, and separated-review evidence, and exports the immutable
 identity snapshot with the terminal run chain. The MCP gateway exposes a
@@ -17,15 +17,15 @@ representative graph-and-identity corpus.
 Caseflow remains canonical. NodeBench does not compile a second graph, infer
 readiness from exit codes, approve review findings, or advance stages.
 
-**PR / canonical main commit**: #603 / PENDING MAIN SHA / FINAL QA.
+**PR / canonical main commit**: #603 / `1e034f5fd3bf109f6283669c2c24774c78962b86`.
 
 **Evidence state**:
 
-- Source: pending in PR #603 from `feat/nodekit-stage-local-integration`.
-- Checks: root typecheck passed; 74 focused contract, database, export, retention, MCP, and ActiveGraph scenarios passed; the root production build and MCP-local package build passed. CI remains pending.
+- Source: merged to `main` through PR #603 from `feat/nodekit-stage-local-integration`.
+- Checks: root typecheck passed; 74 focused contract, database, export, retention, MCP, and ActiveGraph scenarios passed; the 370-scenario runtime smoke pack, root production build, MCP-local package build, and required main-branch CI passed.
 - Visual proof: not applicable; this slice changes backend and tool contracts.
-- Preview: not recorded.
-- Production live: not recorded.
+- Preview: PR preview and post-deploy verification passed.
+- Production live: Vercel deployment `dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW` reached `READY` from commit `1e034f5`; `https://www.nodebenchai.com/` returned HTTP 200 with the production app shell. Convex Deploy run `30509168208` passed. The secret-gated production gateway verified native identity `created`, `reconnect`, and `rotate`, rejected a stale generation, stored an eight-event graph lifecycle with a valid hash chain, bound the current frontier and review context, exercised blocked/opened barriers plus an exact edge binding, and terminalized every proof trace. Production configuration now includes the required owner-scoped `MCP_SERVICE_USER_ID`.
 
 **Author**: Homen Shum + Codex.
 **Touches**: [`../../docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md`](../../docs/architecture/NODEKIT_STAGE_LOCAL_RUNTIME_INTEGRATION.md) and [`../../docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md`](../../docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md).

--- a/evidence/nodekit-stage-local-production-proof/receipt.json
+++ b/evidence/nodekit-stage-local-production-proof/receipt.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "nodebench.production-proof/v1",
+  "recordedAt": "2026-07-30T03:05:13Z",
+  "source": {
+    "repository": "https://github.com/HomenShum/NodeBenchAI",
+    "pullRequest": 603,
+    "commitSha": "1e034f5fd3bf109f6283669c2c24774c78962b86"
+  },
+  "deployment": {
+    "provider": "vercel",
+    "deploymentId": "dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW",
+    "deploymentUrl": "https://nodebench-iqpmgy3lv-hshum2018-gmailcoms-projects.vercel.app",
+    "canonicalUrl": "https://www.nodebenchai.com/",
+    "state": "READY",
+    "buildCommitPrefix": "1e034f5",
+    "rawHtml": {
+      "status": 200,
+      "title": "NodeBench AI — Entity Intelligence for Any Company, Market, or Question",
+      "rootElementPresent": true,
+      "productionAssetPresent": true
+    }
+  },
+  "ci": {
+    "mainCiRun": 30509168252,
+    "convexDeployRun": 30509168208,
+    "postDeployVerifyRun": 30509288895,
+    "mainCiPassed": true,
+    "convexDeployPassed": true,
+    "postDeployVerifyPassed": true
+  },
+  "productionConfiguration": {
+    "ownerScopedServiceUserConfigured": true,
+    "serviceUserIdentifierRecorded": false
+  },
+  "nativeIdentityScenarios": {
+    "created": "passed",
+    "reconnect": "passed",
+    "rotate": "passed",
+    "staleGenerationRejected": true,
+    "staleGenerationHttpStatus": 500,
+    "snapshotHashesPresent": true,
+    "identityRefStableAcrossReconnectAndRotation": true,
+    "successfulProofTracesTerminalized": true
+  },
+  "graphLifecycleScenario": {
+    "recordedGraphEventCount": 6,
+    "storedChainEventCount": 8,
+    "eventContentHashesPresent": true,
+    "hashChainValid": true,
+    "eventTypes": [
+      "run.started",
+      "node.started",
+      "artifact.produced",
+      "edge.consumed",
+      "barrier.blocked",
+      "barrier.opened",
+      "node.completed",
+      "run.completed"
+    ],
+    "frontierHashBound": true,
+    "edgeBindingBound": true,
+    "artifactContentHashBound": true,
+    "reviewContextBound": true,
+    "reviewSeparation": "fresh-context",
+    "protectedEvaluator": false,
+    "traceStatus": "completed",
+    "sessionStatus": "completed"
+  },
+  "authority": {
+    "caseflowRemainsCanonical": true,
+    "graphIsProjectionOnly": true,
+    "callerSuppliedStageAdvancementAccepted": false,
+    "reviewerIssuedNodeProofVerdict": false
+  },
+  "redaction": {
+    "secretsStored": false,
+    "serviceUserIdStored": false,
+    "sessionIdsStored": false,
+    "traceIdsStored": false
+  }
+}


### PR DESCRIPTION
## Summary
- close PR #603's changelog and coordination records with the canonical main SHA
- record the READY Vercel deployment, main CI, Convex deploy, and raw-HTML proof
- capture sanitized live gateway evidence for native identity continuity and the stage-local graph lifecycle
- close PR #601's stale source/preview placeholders without overstating its still-pending authenticated state matrix

## Production evidence
- deployment `dpl_BhEFBRrSuUg2MszCZLwa9fbkMQqW` cloned main commit `1e034f5`
- `https://www.nodebenchai.com/` returned HTTP 200 with the production title, root element, and production asset
- native identity: created, reconnect, rotate; stale generation rejected
- graph chain: 8 stored events, valid previous/content hash linkage, frontier/edge/artifact/barrier/review-context fields bound
- all proof sessions and traces terminalized

## Verification
- parsed `evidence/nodekit-stage-local-production-proof/receipt.json`
- `git diff --check`

## Limitations
- PR #601's authenticated 48-render state matrix is still pending and is explicitly left pending in its component changelogs.