### PR TITLE
feat(nodekit): close ActiveGraph owner export gate

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -57,6 +57,13 @@ Server Error) for an unknown slug.
 
 ## Active claims (who is editing what RIGHT NOW)
 
+- **2026-07-29 · Codex `/root` →** `backend/convex/domains/operations/taskManager/nodeKitRunExport.ts`,
+  `backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts`,
+  `backend/convex/domains/mcp/mcpGatewayDispatcher.ts`, and
+  `scripts/nodekit/*ActiveGraph*` · close Gate 3b with a bounded owner-scoped
+  export/corpus path while keeping ActiveGraph offline and non-authoritative ·
+  branch `codex/activegraph-nodekit-exports`.
+
 > **STANDARD-TREE MIGRATION (2026-07-19, feat/standard-tree-migration): repo paths moved.**
 > `convex/` → `backend/convex/` (convex.json `functions` added; function identifiers unchanged),
 > `src/` + `index.html` → `apps/web/` (`@convex` alias replaces relative `../convex` imports),

--- a/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.integration.test.ts
+++ b/backend/convex/domains/mcp/mcpExecutionTraceEndpoints.integration.test.ts
@@ -55,6 +55,12 @@ describe("NodeKit execution trace gateway contract", () => {
     expect(source).not.toMatch(
       /PUBLIC_RESEARCH_GATEWAY_FNS[\s\S]*?recordExecutionGraphEvent/,
     );
+    expect(source).toMatch(
+      /exportNodeKitRun:\s*\{[\s\S]*?mcpExportNodeKitRun,[\s\S]*?type:\s*"query",[\s\S]*?injectUserId:\s*true,[\s\S]*?\}/,
+    );
+    expect(source).not.toMatch(
+      /PUBLIC_RESEARCH_GATEWAY_FNS[\s\S]*?exportNodeKitRun/,
+    );
   });
 });
 

--- a/backend/convex/domains/mcp/mcpGatewayDispatcher.ts
+++ b/backend/convex/domains/mcp/mcpGatewayDispatcher.ts
@@ -309,6 +309,11 @@ const ALLOWLIST: Record<string, AllowlistEntry> = {
     type: "mutation",
     injectUserId: true,
   },
+  exportNodeKitRun: {
+    ref: internal.domains.operations.taskManager.nodeKitRunExport.mcpExportNodeKitRun,
+    type: "query",
+    injectUserId: true,
+  },
 
   // ── GROUP C: Document internal endpoints — already accept userId ─────────
 

--- a/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunExport.ts
@@ -2,7 +2,11 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 
 import type { Id } from "../../../_generated/dataModel";
-import { query } from "../../../_generated/server";
+import {
+  internalQuery,
+  query,
+  type QueryCtx,
+} from "../../../_generated/server";
 import {
   NODEKIT_RUN_EVENT_CONTRACT_VERSION,
   NODEKIT_RUN_MAX_EVENTS,
@@ -486,6 +490,74 @@ function throwConvexBoundaryError(error: unknown): never {
   throw error;
 }
 
+async function exportNodeKitRunForOwner(
+  ctx: Pick<QueryCtx, "db">,
+  traceId: Id<"agentTaskTraces">,
+  ownerId: Id<"users">,
+): Promise<CanonicalNodeKitRunExport> {
+  const trace = await ctx.db.get(traceId);
+  if (!trace) fail("trace_not_found", "Trace not found or unauthorized.");
+  const session = await ctx.db.get(trace.sessionId);
+  if (!session || session.userId !== ownerId) {
+    fail("trace_not_found", "Trace not found or unauthorized.");
+  }
+  if (trace.status === "running") {
+    fail("run_not_terminal", "A running trace cannot be exported.");
+  }
+  const storedEvents = await ctx.db
+    .query("nodeKitRunEvents")
+    .withIndex("by_trace_sequence", (q) => q.eq("traceId", traceId))
+    .order("asc")
+    .take(NODEKIT_RUN_MAX_EVENTS + 1);
+  if (storedEvents.length === 0) {
+    fail(
+      "run_history_unavailable",
+      "Canonical run history is unavailable because it is legacy, expired, or deleted.",
+    );
+  }
+  if (storedEvents.length > NODEKIT_RUN_MAX_EVENTS) {
+    fail(
+      "event_limit_exceeded",
+      `Run exceeds the ${NODEKIT_RUN_MAX_EVENTS}-event export bound.`,
+    );
+  }
+  if (
+    storedEvents.some(
+      (event) =>
+        event.userId !== ownerId ||
+        event.sessionId !== session._id ||
+        event.runId !== trace.traceId,
+    )
+  ) {
+    fail(
+      "event_ownership_mismatch",
+      "Stored event ownership does not match the trace.",
+    );
+  }
+
+  const exportDoc = await buildCanonicalNodeKitRunExport({
+    sessionId: String(session._id),
+    traceId: String(trace._id),
+    events: storedEvents.map((event) => ({
+      contractVersion: event.contractVersion,
+      runId: event.runId,
+      sequence: event.sequence,
+      eventType: event.eventType,
+      recordedAt: event.recordedAt,
+      payload: event.payload as NodeKitSafeEventPayload,
+      previousHash: event.previousHash,
+      contentHash: event.contentHash,
+    })),
+  });
+  if (trace.status !== exportDoc.trace.status) {
+    fail(
+      "trace_state_mismatch",
+      "Stored trace status differs from the terminal event snapshot.",
+    );
+  }
+  return exportDoc;
+}
+
 export const exportNodeKitRun = query({
   args: {
     traceId: v.id("agentTaskTraces"),
@@ -493,67 +565,27 @@ export const exportNodeKitRun = query({
   handler: async (ctx, args) => {
     try {
       const ownerId = await requireOwnerId(ctx);
-      const trace = await ctx.db.get(args.traceId);
-      if (!trace) fail("trace_not_found", "Trace not found or unauthorized.");
-      const session = await ctx.db.get(trace.sessionId);
-      if (!session || session.userId !== ownerId) {
-        fail("trace_not_found", "Trace not found or unauthorized.");
-      }
-      if (trace.status === "running") {
-        fail("run_not_terminal", "A running trace cannot be exported.");
-      }
-      const storedEvents = await ctx.db
-        .query("nodeKitRunEvents")
-        .withIndex("by_trace_sequence", (q) => q.eq("traceId", args.traceId))
-        .order("asc")
-        .take(NODEKIT_RUN_MAX_EVENTS + 1);
-      if (storedEvents.length === 0) {
-        fail(
-          "run_history_unavailable",
-          "Canonical run history is unavailable because it is legacy, expired, or deleted.",
-        );
-      }
-      if (storedEvents.length > NODEKIT_RUN_MAX_EVENTS) {
-        fail(
-          "event_limit_exceeded",
-          `Run exceeds the ${NODEKIT_RUN_MAX_EVENTS}-event export bound.`,
-        );
-      }
-      if (
-        storedEvents.some(
-          (event) =>
-            event.userId !== ownerId ||
-            event.sessionId !== session._id ||
-            event.runId !== trace.traceId,
-        )
-      ) {
-        fail(
-          "event_ownership_mismatch",
-          "Stored event ownership does not match the trace.",
-        );
-      }
+      return await exportNodeKitRunForOwner(ctx, args.traceId, ownerId);
+    } catch (error) {
+      throwConvexBoundaryError(error);
+    }
+  },
+});
 
-      const exportDoc = await buildCanonicalNodeKitRunExport({
-        sessionId: String(session._id),
-        traceId: String(trace._id),
-        events: storedEvents.map((event) => ({
-          contractVersion: event.contractVersion,
-          runId: event.runId,
-          sequence: event.sequence,
-          eventType: event.eventType,
-          recordedAt: event.recordedAt,
-          payload: event.payload as NodeKitSafeEventPayload,
-          previousHash: event.previousHash,
-          contentHash: event.contentHash,
-        })),
-      });
-      if (trace.status !== exportDoc.trace.status) {
-        fail(
-          "trace_state_mismatch",
-          "Stored trace status differs from the terminal event snapshot.",
-        );
-      }
-      return exportDoc;
+// Secret-gated callers receive their owner from the MCP dispatcher. The public
+// API never accepts a caller-controlled owner identifier.
+export const mcpExportNodeKitRun = internalQuery({
+  args: {
+    userId: v.string(),
+    traceId: v.id("agentTaskTraces"),
+  },
+  handler: async (ctx, args) => {
+    try {
+      return await exportNodeKitRunForOwner(
+        ctx,
+        args.traceId,
+        args.userId as Id<"users">,
+      );
     } catch (error) {
       throwConvexBoundaryError(error);
     }

--- a/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
+++ b/backend/convex/domains/operations/taskManager/nodeKitRunRetention.test.ts
@@ -5,7 +5,7 @@ import {
   buildNodeKitRunEvent,
   type NodeKitRunEvent,
 } from "./nodeKitRunEvents";
-import { exportNodeKitRun } from "./nodeKitRunExport";
+import { exportNodeKitRun, mcpExportNodeKitRun } from "./nodeKitRunExport";
 import {
   deleteOwnedNodeKitRunHistory,
   purgeExpiredNodeKitRunEvents,
@@ -176,6 +176,57 @@ function terminalHistory(overrides: Partial<Row> = {}): Tables {
   };
 }
 
+async function exportableTerminalHistory(): Promise<Tables> {
+  const started = await buildNodeKitRunEvent({
+    runId: "run-a",
+    sequence: 0,
+    eventType: "run.started",
+    recordedAt: 1,
+    payload: {
+      workflowName: "Owner workflow",
+      sessionType: "agent",
+      sessionStartedAt: 1,
+    },
+    previousHash: NODEKIT_RUN_GENESIS_HASH,
+  });
+  const completed = await buildNodeKitRunEvent({
+    runId: "run-a",
+    sequence: 1,
+    eventType: "run.completed",
+    recordedAt: 2,
+    payload: { status: "completed" },
+    previousHash: started.contentHash,
+  });
+  return {
+    agentTaskSessions: [
+      {
+        _id: "session-a",
+        userId: "owner-a",
+        type: "agent",
+        startedAt: 1,
+      },
+    ],
+    agentTaskTraces: [
+      {
+        _id: "trace-a",
+        sessionId: "session-a",
+        traceId: "run-a",
+        workflowName: "Owner workflow",
+        status: "completed",
+        startedAt: 1,
+        endedAt: 2,
+      },
+    ],
+    nodeKitRunEvents: [started, completed].map((event, index) => ({
+      _id: `event-a-${index}`,
+      traceId: "trace-a",
+      sessionId: "session-a",
+      userId: "owner-a",
+      ...event,
+    })),
+  };
+}
+
 describe("NodeKit owner-scoped deletion", () => {
   it("rejects anonymous and cross-owner deletion without removing rows", async () => {
     for (const [subject, code] of [
@@ -227,6 +278,31 @@ describe("NodeKit owner-scoped deletion", () => {
       (exportNodeKitRun as any)._handler(ctx, { traceId: "trace-a" }),
     ).rejects.toMatchObject({
       data: { code: "run_history_unavailable" },
+    });
+  });
+});
+
+describe("NodeKit secret-gated service export", () => {
+  it("exports only a terminal canonical chain owned by the gateway-injected user", async () => {
+    const tables = await exportableTerminalHistory();
+    const ownerCtx = createCtx(tables, null);
+    const exported = await (mcpExportNodeKitRun as any)._handler(ownerCtx, {
+      userId: "owner-a",
+      traceId: "trace-a",
+    });
+
+    expect(exported.runId).toBe("run-a");
+    expect(exported.completeness.eventCount).toBe(2);
+    expect(exported.hashes.exportHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+
+    const otherOwnerCtx = createCtx(tables, null);
+    await expect(
+      (mcpExportNodeKitRun as any)._handler(otherOwnerCtx, {
+        userId: "owner-b",
+        traceId: "trace-a",
+      }),
+    ).rejects.toMatchObject({
+      data: { code: "trace_not_found" },
     });
   });
 });

--- a/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
+++ b/docs/architecture/NODEKIT_ACTIVEGRAPH_CANARY.md
@@ -131,6 +131,13 @@ reconstructs events from mutable trace metadata. Boundary errors use Convex's
 structured error protocol, while not-found and unauthorized traces remain
 deliberately indistinguishable.
 
+The secret-gated MCP dispatcher also exposes `exportNodeKitRun` through the
+internal `mcpExportNodeKitRun` query. The dispatcher injects the configured
+service owner; the request cannot supply or override `userId`. This read-only
+path exists to collect an owner-scoped offline evaluation corpus. It is not in
+the anonymous public-research function set and does not grant ActiveGraph any
+application authority.
+
 ## Offline process boundary
 
 The supported evaluator entrypoint is:
@@ -325,16 +332,45 @@ graph and identity fields rather than the former two-event trace fixture.
 This proves the boundary on one deterministic representative corpus. It does
 not satisfy the owner-authorized multi-run adoption experiment.
 
-### Gate 3b — representative owner-authorized corpus: deferred
+### Gate 3b — representative owner-authorized corpus: implemented, live result required
 
-Replay roughly 20 representative owner-authorized exports. Stop if:
+The repository now provides a fixed 20-scenario collector and bounded corpus
+runner:
+
+```powershell
+$env:NODEBENCH_MCP_GATEWAY_URL = "https://<deployment>.convex.site/api/mcpGateway"
+$env:MCP_SECRET = "<secret>"
+npm run nodekit:activegraph:collect -- .tmp/activegraph-owner-corpus
+
+npm run nodekit:activegraph:corpus -- `
+  --manifest .tmp/activegraph-owner-corpus/manifest.json `
+  --evidence-root .tmp/activegraph-owner-corpus-evidence `
+  --sandbox-image $SandboxImage `
+  --image-attestation $ImageAttestation
+```
+
+The collector creates private service-owner traces spanning context, decision,
+build, check, review, browser, agent-eval, aggregate, repair, delivery, human
+gate, barrier recovery, and fail-safe behavior. It terminalizes partial runs
+on failure, exports only through the gateway-injected owner boundary, validates
+every canonical export before writing, and emits no owner identifier or secret
+in the manifest.
+
+The runner requires 20–24 unique complete exports, rejects path escape,
+symlinks, oversized files, duplicate run/export identities, or a false source
+claim, and launches the existing locked offline canary once per export. It
+writes one content-addressed corpus report and applies the original stop rules.
+
+Stop and record `adoptionVerdict: "reject"` if:
 
 - any export is incomplete or cannot be represented without reconstruction;
 - persistence/reload parity differs;
 - median end-to-end latency exceeds 2× the equivalent existing harness; or
 - the resulting graph/diff evidence adds no material explanatory value.
 
-Passing Gate 3 authorizes only a separate adoption-or-rejection ADR.
+Passing all stop rules yields only `eligible-for-adr`; it does not adopt
+ActiveGraph. A reject result closes this adoption experiment while preserving
+the offline diagnostic canary.
 
 ### Gate 4 — production bridge: not authorized
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "start:voice": "node dist/workers/node/index.js",
     "lint": "node scripts/ui/agentNativeUiLinter.mjs && tsc -p backend/convex -noEmit --pretty false && tsc -p . -noEmit --pretty false && convex dev --once --typecheck=enable && vite build",
     "notebook:health": "node scripts/ops/hourlyHealthCheck.mjs",
+    "nodekit:activegraph:collect": "node scripts/nodekit/collectActiveGraphCorpus.mjs",
+    "nodekit:activegraph:corpus": "node scripts/nodekit/runActiveGraphCorpus.mjs",
     "repo:augment:check": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/repo/checkAugmentUploadScope.ps1",
     "repo:history:map": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/repo/mapReduceLocalHistory.ps1",
     "repo:housekeeping": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/repo/runWorkspaceHousekeeping.ps1",

--- a/scripts/__tests__/collectActiveGraphCorpus.test.ts
+++ b/scripts/__tests__/collectActiveGraphCorpus.test.ts
@@ -1,0 +1,139 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  buildNodeKitRunEvent,
+} from "../../backend/convex/domains/operations/taskManager/nodeKitRunEvents";
+import { buildCanonicalNodeKitRunExport } from "../../backend/convex/domains/operations/taskManager/nodeKitRunExport";
+import {
+  ACTIVEGRAPH_CORPUS_SCENARIOS,
+  callNodeBenchGateway,
+  collectActiveGraphCorpus,
+} from "../nodekit/collectActiveGraphCorpus.mjs";
+import { loadActiveGraphCorpus } from "../nodekit/runActiveGraphCorpus.mjs";
+
+describe("ActiveGraph owner-export corpus collector", () => {
+  it("collects exactly 20 distinct owner-scoped terminal exports", async () => {
+    const root = mkdtempSync(join(tmpdir(), "activegraph-corpus-collector-"));
+    const sessions = new Map<string, any>();
+    let next = 0;
+    const calls: string[] = [];
+    const gatewayCall = async ({ fn, args }: any) => {
+      calls.push(fn);
+      if (fn === "mcpStartExecutionRun") {
+        const id = next++;
+        const session = {
+          sessionId: `session-${id}`,
+          traceId: `trace-${id}`,
+          publicTraceId: `run-${id}`,
+          status: "running",
+          startArgs: args,
+        };
+        sessions.set(session.traceId, session);
+        return session;
+      }
+      if (fn === "exportNodeKitRun") {
+        const session = sessions.get(args.traceId);
+        const index = Number(session.traceId.split("-")[1]);
+        const failed =
+          ACTIVEGRAPH_CORPUS_SCENARIOS[index].graphMode === "failed";
+        const started = await buildNodeKitRunEvent({
+          runId: session.publicTraceId,
+          sequence: 0,
+          eventType: "run.started",
+          recordedAt: 100 + index * 10,
+          payload: {
+            workflowName: session.startArgs.workflowName,
+            sessionType: session.startArgs.type,
+            sessionStartedAt: 100 + index * 10,
+          },
+          previousHash: NODEKIT_RUN_GENESIS_HASH,
+        });
+        const terminal = await buildNodeKitRunEvent({
+          runId: session.publicTraceId,
+          sequence: 1,
+          eventType: failed ? "run.failed" : "run.completed",
+          recordedAt: 101 + index * 10,
+          payload: { status: failed ? "error" : "completed" },
+          previousHash: started.contentHash,
+        });
+        return buildCanonicalNodeKitRunExport({
+          sessionId: session.sessionId,
+          traceId: session.traceId,
+          events: [started, terminal],
+        });
+      }
+      return null;
+    };
+
+    const result = await collectActiveGraphCorpus({
+      gatewayUrl: "https://example.convex.site/api/mcpGateway",
+      mcpSecret: "not-used-by-injected-test-gateway",
+      outputDirectory: join(root, "corpus"),
+      gatewayCall,
+    });
+
+    expect(result.corpusSize).toBe(20);
+    expect(calls.filter((name) => name === "exportNodeKitRun")).toHaveLength(
+      20,
+    );
+    expect(
+      calls.filter((name) => name === "mcpStartExecutionRun"),
+    ).toHaveLength(20);
+    expect(loadActiveGraphCorpus(result.manifestPath).entries).toHaveLength(20);
+    const manifest = JSON.parse(readFileSync(result.manifestPath, "utf8"));
+    expect(
+      new Set(manifest.exports.map((entry: any) => entry.label)).size,
+    ).toBe(20);
+  });
+
+  it("rejects non-allowlisted gateway hosts before fetch", async () => {
+    let called = false;
+    await expect(
+      callNodeBenchGateway({
+        gatewayUrl: "https://169.254.169.254/api/mcpGateway",
+        mcpSecret: "a".repeat(32),
+        fn: "exportNodeKitRun",
+        args: { traceId: "trace" },
+        fetchImpl: async () => {
+          called = true;
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow(/gateway_url_invalid/);
+    expect(called).toBe(false);
+  });
+
+  it("terminalizes a partially created run when collection fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "activegraph-corpus-failure-"));
+    const calls: string[] = [];
+    const gatewayCall = async ({ fn }: any) => {
+      calls.push(fn);
+      if (fn === "mcpStartExecutionRun") {
+        return {
+          sessionId: "session-partial",
+          traceId: "trace-partial",
+          publicTraceId: "run-partial",
+          status: "running",
+        };
+      }
+      if (fn === "recordStep") throw new Error("synthetic failure");
+      return null;
+    };
+
+    await expect(
+      collectActiveGraphCorpus({
+        gatewayUrl: "https://example.convex.site/api/mcpGateway",
+        mcpSecret: "not-used-by-injected-test-gateway",
+        outputDirectory: join(root, "corpus"),
+        gatewayCall,
+      }),
+    ).rejects.toThrow(/synthetic failure/);
+    expect(calls).toContain("completeTrace");
+    expect(calls).toContain("updateSessionStatus");
+    expect(calls).not.toContain("exportNodeKitRun");
+  });
+});

--- a/scripts/__tests__/nodekitActiveGraphCorpus.test.ts
+++ b/scripts/__tests__/nodekitActiveGraphCorpus.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  NODEKIT_RUN_GENESIS_HASH,
+  buildNodeKitRunEvent,
+} from "../../backend/convex/domains/operations/taskManager/nodeKitRunEvents";
+import { buildCanonicalNodeKitRunExport } from "../../backend/convex/domains/operations/taskManager/nodeKitRunExport";
+import {
+  ACTIVEGRAPH_CORPUS_SCHEMA,
+  loadActiveGraphCorpus,
+  runActiveGraphCorpus,
+} from "../nodekit/runActiveGraphCorpus.mjs";
+
+async function writeCorpus(count = 20) {
+  const root = mkdtempSync(join(tmpdir(), "nodekit-activegraph-corpus-"));
+  const inputs = join(root, "inputs");
+  mkdirSync(inputs);
+  const exports = [];
+  for (let index = 0; index < count; index += 1) {
+    const runId = `run-corpus-${index}`;
+    const started = await buildNodeKitRunEvent({
+      runId,
+      sequence: 0,
+      eventType: "run.started",
+      recordedAt: 100 + index * 10,
+      payload: {
+        workflowName: `Corpus workflow ${index}`,
+        sessionType: "agent",
+        sessionStartedAt: 100 + index * 10,
+      },
+      previousHash: NODEKIT_RUN_GENESIS_HASH,
+    });
+    const completed = await buildNodeKitRunEvent({
+      runId,
+      sequence: 1,
+      eventType: "run.completed",
+      recordedAt: 101 + index * 10,
+      payload: { status: "completed" },
+      previousHash: started.contentHash,
+    });
+    const document = await buildCanonicalNodeKitRunExport({
+      sessionId: `session-${index}`,
+      traceId: `trace-${index}`,
+      events: [started, completed],
+    });
+    const inputFile = `inputs/export-${index}.json`;
+    writeFileSync(join(root, inputFile), JSON.stringify(document));
+    exports.push({
+      label: `scenario-${String(index).padStart(2, "0")}`,
+      inputFile,
+      workflowClass: "scenario",
+      terminalStatus: "completed",
+    });
+  }
+  const manifestPath = join(root, "manifest.json");
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      schemaVersion: ACTIVEGRAPH_CORPUS_SCHEMA,
+      collectedAt: "2026-07-29T20:00:00.000Z",
+      source: {
+        kind: "nodebench-production",
+        gatewayFunction: "exportNodeKitRun",
+        authorization: "gateway-injected-owner",
+      },
+      exports,
+    }),
+  );
+  return { root, manifestPath };
+}
+
+describe("ActiveGraph owner-export corpus", () => {
+  it("runs the exact bounded 20-export corpus and rejects adoption when replay adds no explanation", async () => {
+    const { root, manifestPath } = await writeCorpus();
+    const evidenceRoot = join(root, "evidence");
+    const report = await runActiveGraphCorpus({
+      manifestPath,
+      evidenceRoot,
+      sandboxImage: `sha256:${"a".repeat(64)}`,
+      imageAttestationPath: join(root, "unused-attestation.json"),
+      baselineIterations: 2,
+      canaryRunner: async ({ runDirectoryName }: any) => {
+        const runDirectory = join(evidenceRoot, runDirectoryName);
+        mkdirSync(runDirectory, { recursive: true });
+        return {
+          runDirectory,
+          report: {
+            verdict: "pass",
+            persisted_reload_parity: true,
+          },
+        };
+      },
+    });
+
+    expect(report.corpusSize).toBe(20);
+    expect(report.allPersistenceReloadParity).toBe(true);
+    expect(report.materialExplanatoryValueObserved).toBe(false);
+    expect(report.stopConditions).toContain("no_material_explanatory_value");
+    expect(report.adoptionVerdict).toBe("reject");
+    expect(report.reportHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("fails closed for an undersized corpus or duplicate export", async () => {
+    const undersized = await writeCorpus(19);
+    expect(() => loadActiveGraphCorpus(undersized.manifestPath)).toThrow(
+      /corpus_size_invalid/,
+    );
+
+    const duplicated = await writeCorpus();
+    const manifest = JSON.parse(readFileSync(duplicated.manifestPath, "utf8"));
+    manifest.exports[19].inputFile = manifest.exports[0].inputFile;
+    writeFileSync(duplicated.manifestPath, JSON.stringify(manifest));
+    expect(() => loadActiveGraphCorpus(duplicated.manifestPath)).toThrow(
+      /corpus_duplicate/,
+    );
+  });
+
+  it("rejects an input path that escapes the authorized corpus directory", async () => {
+    const { manifestPath } = await writeCorpus();
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.exports[0].inputFile = "../outside.json";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => loadActiveGraphCorpus(manifestPath)).toThrow(/path_escape/);
+  });
+});

--- a/scripts/nodekit/collectActiveGraphCorpus.mjs
+++ b/scripts/nodekit/collectActiveGraphCorpus.mjs
@@ -1,0 +1,489 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { assertCanonicalNodeKitRunExport } from "./runActiveGraphCanary.mjs";
+import { ACTIVEGRAPH_CORPUS_SCHEMA } from "./runActiveGraphCorpus.mjs";
+
+const REQUEST_TIMEOUT_MS = 20_000;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+export const ACTIVEGRAPH_CORPUS_SCENARIOS = Object.freeze(
+  [
+    ["context-repository", "context", "step", "complete"],
+    ["context-mobbin", "context", "evidence", "complete"],
+    ["decision-direction", "decision", "decision", "complete"],
+    ["build-ui", "build", "step", "complete"],
+    ["build-backend", "build", "step", "complete"],
+    ["check-types", "check", "verification", "complete"],
+    ["check-schema", "check", "verification", "complete"],
+    ["review-code", "review", "decision", "review"],
+    ["review-simplification", "review", "decision", "review"],
+    ["review-design-reference", "review", "evidence", "review"],
+    ["review-authority-trust", "review", "verification", "review"],
+    ["review-data-truth", "review", "verification", "review"],
+    ["browser-live-proof", "browser", "evidence", "complete"],
+    ["agent-eval", "agent-eval", "verification", "complete"],
+    ["aggregate-findings", "aggregate", "decision", "complete"],
+    ["repair-approved", "repair", "step", "complete"],
+    ["deliver-evidence-pack", "deliver", "evidence", "complete"],
+    ["human-gate-blocked", "human-gate", "approval", "barrier"],
+    ["barrier-recovered", "barrier", "verification", "barrier"],
+    ["failed-safely", "build", "verification", "failed"],
+  ].map(([label, workflowClass, auxiliary, graphMode]) =>
+    Object.freeze({ label, workflowClass, auxiliary, graphMode }),
+  ),
+);
+
+export class ActiveGraphCorpusCollectionError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    this.name = "ActiveGraphCorpusCollectionError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new ActiveGraphCorpusCollectionError(code, message);
+}
+
+function rawHash(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function assertGatewayUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail("gateway_url_invalid", "Gateway URL is invalid.");
+  }
+  const loopback = ["127.0.0.1", "localhost", "::1"].includes(url.hostname);
+  const hosted =
+    url.hostname.endsWith(".convex.site") ||
+    url.hostname === "nodebenchai.com" ||
+    url.hostname.endsWith(".nodebenchai.com");
+  if (
+    (url.protocol !== "https:" && !(loopback && url.protocol === "http:")) ||
+    (!hosted && !loopback) ||
+    url.pathname !== "/api/mcpGateway" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    fail(
+      "gateway_url_invalid",
+      "Gateway URL must be the HTTPS NodeBench/Convex MCP endpoint or loopback.",
+    );
+  }
+  return url;
+}
+
+async function readBoundedJsonResponse(response, controller) {
+  if (!response.body)
+    fail("gateway_response_invalid", "Gateway returned no body.");
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        controller.abort();
+        fail("gateway_response_too_large", "Gateway response exceeded 4 MiB.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  let parsed;
+  try {
+    const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail("gateway_response_invalid", "Gateway response was not valid JSON.");
+  }
+  return parsed;
+}
+
+export async function callNodeBenchGateway({
+  gatewayUrl,
+  mcpSecret,
+  fn,
+  args,
+  fetchImpl = fetch,
+}) {
+  const url = assertGatewayUrl(gatewayUrl);
+  if (typeof mcpSecret !== "string" || mcpSecret.length < 16) {
+    fail("gateway_secret_missing", "MCP_SECRET is missing or too short.");
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      redirect: "error",
+      signal: controller.signal,
+      headers: {
+        "content-type": "application/json",
+        "x-mcp-secret": mcpSecret,
+      },
+      body: JSON.stringify({
+        fn,
+        args,
+        meta: {
+          client: "nodebench-activegraph-owner-corpus",
+          purpose: "offline-adoption-gate",
+        },
+      }),
+    });
+    const payload = await readBoundedJsonResponse(response, controller);
+    if (!response.ok || payload?.success !== true || !("data" in payload)) {
+      fail("gateway_call_failed", `${fn} failed with HTTP ${response.status}.`);
+    }
+    return payload.data;
+  } catch (error) {
+    if (error instanceof ActiveGraphCorpusCollectionError) throw error;
+    if (error?.name === "AbortError") {
+      fail("gateway_timeout", `${fn} exceeded ${REQUEST_TIMEOUT_MS}ms.`);
+    }
+    fail("gateway_call_failed", `${fn} failed.`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function graphFields(scenario, index) {
+  const seed = `${scenario.label}:${index}`;
+  const graphHash = rawHash(`graph:${seed}`);
+  const caseContentHash = rawHash(`case:${seed}`);
+  const frontierHash = rawHash(`frontier:${seed}`);
+  return {
+    graphId: `execution-graph:sha256:${graphHash}`,
+    graphHash,
+    caseId: `case:activegraph-corpus:${index}`,
+    stageId: scenario.workflowClass,
+    caseContentHash,
+    nodeId: `node:${scenario.label}`,
+    nodeRunId: `node-run:${scenario.label}:1`,
+    nodeKind:
+      scenario.graphMode === "review"
+        ? "review"
+        : scenario.graphMode === "barrier"
+          ? "barrier"
+          : "task",
+    frontierHash,
+  };
+}
+
+async function recordAuxiliary(call, scenario, session, index) {
+  const shared = {
+    traceId: session.traceId,
+  };
+  if (scenario.auxiliary === "step") {
+    await call("recordStep", {
+      ...shared,
+      stage: scenario.workflowClass === "repair" ? "edit" : "inspect",
+      type: "task_started",
+      title: `Exercise ${scenario.label}`,
+      tool: "nodekit-corpus",
+      action: "observe representative workflow",
+      target: scenario.label,
+      resultSummary: "Synthetic owner-scoped corpus event completed.",
+      evidenceRefs: [`corpus:${index}`],
+      verification: ["bounded synthetic production probe"],
+      confidence: 1,
+    });
+  } else if (scenario.auxiliary === "decision") {
+    await call("recordDecision", {
+      ...shared,
+      decisionType: "corpus_probe",
+      statement: `Record representative ${scenario.label} decision.`,
+      basis: ["bounded production probe", "offline export experiment"],
+      evidenceRefs: [`corpus:${index}`],
+      alternativesConsidered: ["do not adopt ActiveGraph"],
+      confidence: 1,
+      limitations: ["Synthetic probe; not a user claim."],
+    });
+  } else if (scenario.auxiliary === "verification") {
+    await call("recordVerification", {
+      ...shared,
+      label: scenario.label,
+      status: scenario.graphMode === "failed" ? "failed" : "passed",
+      details: "Deterministic corpus verification event.",
+      relatedArtifactIds: [`corpus-artifact:${index}`],
+      createGuardrailSpan: false,
+    });
+  } else if (scenario.auxiliary === "evidence") {
+    await call("attachEvidence", {
+      ...shared,
+      title: `Corpus evidence ${scenario.label}`,
+      summary: "Bounded synthetic evidence for offline replay coverage.",
+      sourceRefs: [
+        {
+          label: "NodeKit ActiveGraph corpus probe",
+          kind: "synthetic-production-probe",
+        },
+      ],
+      supportedClaims: ["The canonical export retained this event."],
+      unsupportedClaims: ["ActiveGraph should become production authority."],
+    });
+  } else if (scenario.auxiliary === "approval") {
+    await call("requestTraceApproval", {
+      sessionId: session.sessionId,
+      traceId: session.traceId,
+      toolName: "activegraph_offline_adoption",
+      riskLevel: "high",
+      justification:
+        "Record a protected human gate without granting or simulating approval.",
+    });
+  }
+}
+
+async function recordGraphLifecycle(call, scenario, session, index) {
+  const graph = graphFields(scenario, index);
+  await call("recordExecutionGraphEvent", {
+    traceId: session.traceId,
+    eventType: "node.started",
+    ...graph,
+    reviewContextRef:
+      scenario.graphMode === "review"
+        ? `review-context:${scenario.label}`
+        : undefined,
+  });
+  if (scenario.graphMode === "barrier") {
+    await call("recordExecutionGraphEvent", {
+      traceId: session.traceId,
+      eventType: "barrier.blocked",
+      ...graph,
+      status: "blocked",
+      reasonCode: "owner_approval_required",
+      blockingEdgeCount: 1,
+    });
+    await call("recordExecutionGraphEvent", {
+      traceId: session.traceId,
+      eventType: "barrier.opened",
+      ...graph,
+      status: "opened",
+    });
+  }
+  if (scenario.graphMode !== "failed") {
+    const artifactHash = rawHash(`artifact:${scenario.label}:${index}`);
+    await call("recordExecutionGraphEvent", {
+      traceId: session.traceId,
+      eventType: "artifact.produced",
+      ...graph,
+      artifactId: `artifact:${scenario.label}`,
+      artifactSchemaVersion: "nodekit.corpus-artifact/v1",
+      artifactContentHash: artifactHash,
+      authorityKind:
+        scenario.workflowClass === "check" ? "deterministic" : "agent-produced",
+    });
+    await call("recordExecutionGraphEvent", {
+      traceId: session.traceId,
+      eventType: "node.completed",
+      ...graph,
+      status: "completed",
+      reviewContextRef:
+        scenario.graphMode === "review"
+          ? `review-context:${scenario.label}`
+          : undefined,
+      reviewSeparation:
+        scenario.graphMode === "review" ? "fresh-context" : undefined,
+      protectedEvaluator: false,
+    });
+  } else {
+    await call("recordExecutionGraphEvent", {
+      traceId: session.traceId,
+      eventType: "node.failed",
+      ...graph,
+      status: "failed",
+      reasonCode: "synthetic_failure_probe",
+    });
+  }
+}
+
+async function bestEffortTerminalize(call, session, errorMessage) {
+  if (!session) return;
+  try {
+    await call("completeTrace", {
+      traceId: session.traceId,
+      status: "error",
+      crossCheckStatus: "violated",
+      deltaFromVision: errorMessage.slice(0, 240),
+    });
+  } catch {
+    // The original failure remains authoritative.
+  }
+  try {
+    await call("updateSessionStatus", {
+      sessionId: session.sessionId,
+      status: "failed",
+      errorMessage: errorMessage.slice(0, 240),
+      crossCheckStatus: "violated",
+      deltaFromVision: errorMessage.slice(0, 240),
+    });
+  } catch {
+    // The original failure remains authoritative.
+  }
+}
+
+export async function collectActiveGraphCorpus({
+  gatewayUrl,
+  mcpSecret,
+  outputDirectory,
+  gatewayCall = callNodeBenchGateway,
+}) {
+  const resolvedOutput = resolve(outputDirectory);
+  if (existsSync(resolvedOutput)) {
+    fail("output_exists", "Corpus output directory must not already exist.");
+  }
+  mkdirSync(dirname(resolvedOutput), { recursive: true });
+  mkdirSync(resolvedOutput);
+  const exportsDirectory = resolve(resolvedOutput, "exports");
+  mkdirSync(exportsDirectory);
+
+  const call = (fn, args) => gatewayCall({ gatewayUrl, mcpSecret, fn, args });
+  const manifestEntries = [];
+  for (const [index, scenario] of ACTIVEGRAPH_CORPUS_SCENARIOS.entries()) {
+    let session;
+    try {
+      session = await call("mcpStartExecutionRun", {
+        title: `ActiveGraph corpus: ${scenario.label}`,
+        workflowName: `activegraph-corpus-${scenario.label}`,
+        description:
+          "Bounded owner-scoped synthetic production trace for the offline ActiveGraph adoption gate.",
+        type:
+          index % 5 === 0
+            ? "manual"
+            : index % 5 === 1
+              ? "cron"
+              : index % 5 === 2
+                ? "scheduled"
+                : index % 5 === 3
+                  ? "agent"
+                  : "swarm",
+        visibility: "private",
+        nativeIdentity: {
+          agentId: `activegraph.corpus.${index}`,
+          workspaceId: "workspace:nodebench-activegraph-corpus",
+          nativeSessionId: `session:activegraph-corpus:${index}:1`,
+          nativeSessionGeneration: 1,
+          peerId: "peer:nodekit-offline-evaluator",
+        },
+        metadata: {
+          corpusSchemaVersion: ACTIVEGRAPH_CORPUS_SCHEMA,
+          corpusScenario: scenario.label,
+          nonAuthoritative: true,
+        },
+      });
+      await recordAuxiliary(call, scenario, session, index);
+      await recordGraphLifecycle(call, scenario, session, index);
+      const failed = scenario.graphMode === "failed";
+      await call("completeTrace", {
+        traceId: session.traceId,
+        status: failed ? "error" : "completed",
+        crossCheckStatus: failed ? "violated" : "aligned",
+        deltaFromVision: failed
+          ? "Synthetic failure scenario remained fail-closed."
+          : "Synthetic corpus scenario matched its bounded plan.",
+      });
+      await call("updateSessionStatus", {
+        sessionId: session.sessionId,
+        status: failed ? "failed" : "completed",
+        errorMessage: failed
+          ? "Synthetic failure scenario for offline replay coverage."
+          : undefined,
+        crossCheckStatus: failed ? "violated" : "aligned",
+        deltaFromVision: failed
+          ? "Synthetic failure scenario remained fail-closed."
+          : "Synthetic corpus scenario matched its bounded plan.",
+      });
+      const exportDocument = await call("exportNodeKitRun", {
+        traceId: session.traceId,
+      });
+      assertCanonicalNodeKitRunExport(exportDocument);
+      const terminalStatus = failed ? "error" : "completed";
+      if (exportDocument.trace.status !== terminalStatus) {
+        fail(
+          "export_status_mismatch",
+          `${scenario.label} export did not preserve terminal status.`,
+        );
+      }
+      const fileName = `${String(index + 1).padStart(2, "0")}-${scenario.label}.json`;
+      const exportPath = resolve(exportsDirectory, fileName);
+      writeFileSync(
+        exportPath,
+        `${JSON.stringify(exportDocument, null, 2)}\n`,
+        {
+          encoding: "utf8",
+          flag: "wx",
+        },
+      );
+      manifestEntries.push({
+        label: scenario.label,
+        inputFile: relative(resolvedOutput, exportPath).replaceAll("\\", "/"),
+        workflowClass: scenario.workflowClass,
+        terminalStatus,
+      });
+    } catch (error) {
+      await bestEffortTerminalize(
+        call,
+        session,
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
+  }
+
+  const manifest = {
+    schemaVersion: ACTIVEGRAPH_CORPUS_SCHEMA,
+    collectedAt: new Date().toISOString(),
+    source: {
+      kind: "nodebench-production",
+      gatewayFunction: "exportNodeKitRun",
+      authorization: "gateway-injected-owner",
+    },
+    exports: manifestEntries,
+  };
+  const manifestPath = resolve(resolvedOutput, "manifest.json");
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  return Object.freeze({
+    manifestPath,
+    corpusSize: manifestEntries.length,
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    const outputDirectory = process.argv[2];
+    if (!outputDirectory || process.argv.length !== 3) {
+      fail(
+        "cli_args_invalid",
+        "Usage: node collectActiveGraphCorpus.mjs <new-output-directory>",
+      );
+    }
+    const result = await collectActiveGraphCorpus({
+      gatewayUrl: process.env.NODEBENCH_MCP_GATEWAY_URL,
+      mcpSecret: process.env.MCP_SECRET,
+      outputDirectory,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/nodekit/runActiveGraphCorpus.mjs
+++ b/scripts/nodekit/runActiveGraphCorpus.mjs
@@ -1,0 +1,464 @@
+import { createHash } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+
+import {
+  assertCanonicalNodeKitRunExport,
+  runActiveGraphCanaryFromExport,
+} from "./runActiveGraphCanary.mjs";
+
+export const ACTIVEGRAPH_CORPUS_SCHEMA =
+  "nodebench.activegraph.owner-export-corpus/v1";
+export const ACTIVEGRAPH_CORPUS_REPORT_SCHEMA =
+  "nodebench.activegraph.owner-export-corpus-report/v1";
+export const ACTIVEGRAPH_CORPUS_MIN_EXPORTS = 20;
+export const ACTIVEGRAPH_CORPUS_MAX_EXPORTS = 24;
+
+const MAX_MANIFEST_BYTES = 256 * 1024;
+const MAX_EXPORT_BYTES = 4 * 1024 * 1024;
+const MAX_TOTAL_EXPORT_BYTES = 64 * 1024 * 1024;
+const DEFAULT_BASELINE_ITERATIONS = 20;
+
+export class ActiveGraphCorpusError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    this.name = "ActiveGraphCorpusError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new ActiveGraphCorpusError(code, message);
+}
+
+function assertObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail("manifest_invalid", `${label} must be an object.`);
+  }
+}
+
+function exactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    fail(
+      "manifest_invalid",
+      `${label} keys differ: expected ${wanted.join(", ")}; got ${actual.join(", ")}.`,
+    );
+  }
+}
+
+function boundedRegularFile(path, maxBytes, label) {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    fail("file_unavailable", `${label} is unavailable.`);
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    fail("file_invalid", `${label} must be a regular non-symlink file.`);
+  }
+  if (stat.size <= 0 || stat.size > maxBytes) {
+    fail("file_size_invalid", `${label} exceeds its byte bound.`);
+  }
+  return readFileSync(path);
+}
+
+function resolveCorpusFile(manifestDirectory, relativePath, label) {
+  if (
+    typeof relativePath !== "string" ||
+    relativePath.length === 0 ||
+    relativePath.length > 240 ||
+    isAbsolute(relativePath)
+  ) {
+    fail("manifest_invalid", `${label} must be a bounded relative path.`);
+  }
+  const candidate = resolve(manifestDirectory, relativePath);
+  const rel = relative(manifestDirectory, candidate);
+  if (
+    !rel ||
+    rel === ".." ||
+    rel.startsWith("../") ||
+    rel.startsWith("..\\") ||
+    isAbsolute(rel)
+  ) {
+    fail("path_escape", `${label} escapes the corpus directory.`);
+  }
+  const realDirectory = realpathSync(manifestDirectory);
+  const realCandidate = realpathSync(candidate);
+  const realRelative = relative(realDirectory, realCandidate);
+  if (
+    !realRelative ||
+    realRelative === ".." ||
+    realRelative.startsWith("../") ||
+    realRelative.startsWith("..\\") ||
+    isAbsolute(realRelative)
+  ) {
+    fail("path_escape", `${label} resolves outside the corpus directory.`);
+  }
+  return realCandidate;
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function parseManifest(manifestPath) {
+  const resolvedManifest = resolve(manifestPath);
+  const bytes = boundedRegularFile(
+    resolvedManifest,
+    MAX_MANIFEST_BYTES,
+    "corpus manifest",
+  );
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail("manifest_invalid", "Corpus manifest must be valid JSON.");
+  }
+  assertObject(manifest, "corpus manifest");
+  exactKeys(
+    manifest,
+    ["schemaVersion", "collectedAt", "source", "exports"],
+    "corpus manifest",
+  );
+  if (manifest.schemaVersion !== ACTIVEGRAPH_CORPUS_SCHEMA) {
+    fail("manifest_schema_mismatch", "Unsupported corpus manifest schema.");
+  }
+  if (
+    typeof manifest.collectedAt !== "string" ||
+    Number.isNaN(Date.parse(manifest.collectedAt))
+  ) {
+    fail("manifest_invalid", "collectedAt must be an RFC 3339 timestamp.");
+  }
+  assertObject(manifest.source, "corpus source");
+  exactKeys(
+    manifest.source,
+    ["kind", "gatewayFunction", "authorization"],
+    "corpus source",
+  );
+  if (
+    manifest.source.kind !== "nodebench-production" ||
+    manifest.source.gatewayFunction !== "exportNodeKitRun" ||
+    manifest.source.authorization !== "gateway-injected-owner"
+  ) {
+    fail(
+      "authorization_unproven",
+      "Corpus source must name the owner-injected production export boundary.",
+    );
+  }
+  if (
+    !Array.isArray(manifest.exports) ||
+    manifest.exports.length < ACTIVEGRAPH_CORPUS_MIN_EXPORTS ||
+    manifest.exports.length > ACTIVEGRAPH_CORPUS_MAX_EXPORTS
+  ) {
+    fail(
+      "corpus_size_invalid",
+      `Corpus must contain ${ACTIVEGRAPH_CORPUS_MIN_EXPORTS}-${ACTIVEGRAPH_CORPUS_MAX_EXPORTS} exports.`,
+    );
+  }
+  return { manifest, resolvedManifest };
+}
+
+export function loadActiveGraphCorpus(manifestPath) {
+  const { manifest, resolvedManifest } = parseManifest(manifestPath);
+  const manifestDirectory = dirname(resolvedManifest);
+  const labels = new Set();
+  const exportHashes = new Set();
+  const runIds = new Set();
+  let totalBytes = 0;
+  const entries = manifest.exports.map((entry, index) => {
+    assertObject(entry, `exports[${index}]`);
+    exactKeys(
+      entry,
+      ["label", "inputFile", "workflowClass", "terminalStatus"],
+      `exports[${index}]`,
+    );
+    if (
+      typeof entry.label !== "string" ||
+      !/^[a-z0-9][a-z0-9._-]{0,79}$/.test(entry.label) ||
+      labels.has(entry.label)
+    ) {
+      fail(
+        "manifest_invalid",
+        `exports[${index}].label is invalid or duplicated.`,
+      );
+    }
+    labels.add(entry.label);
+    if (
+      typeof entry.workflowClass !== "string" ||
+      entry.workflowClass.length === 0 ||
+      entry.workflowClass.length > 120
+    ) {
+      fail("manifest_invalid", `exports[${index}].workflowClass is invalid.`);
+    }
+    if (!["completed", "error"].includes(entry.terminalStatus)) {
+      fail("manifest_invalid", `exports[${index}].terminalStatus is invalid.`);
+    }
+    const exportPath = resolveCorpusFile(
+      manifestDirectory,
+      entry.inputFile,
+      `exports[${index}].inputFile`,
+    );
+    const bytes = boundedRegularFile(exportPath, MAX_EXPORT_BYTES, entry.label);
+    totalBytes += bytes.byteLength;
+    if (totalBytes > MAX_TOTAL_EXPORT_BYTES) {
+      fail("corpus_too_large", "Corpus exceeds its aggregate byte bound.");
+    }
+    let document;
+    try {
+      document = JSON.parse(bytes.toString("utf8"));
+    } catch {
+      fail("export_invalid", `${entry.label} is not valid JSON.`);
+    }
+    assertCanonicalNodeKitRunExport(document);
+    if (document.trace.status !== entry.terminalStatus) {
+      fail(
+        "manifest_export_mismatch",
+        `${entry.label} terminal status differs from its canonical export.`,
+      );
+    }
+    if (
+      exportHashes.has(document.hashes.exportHash) ||
+      runIds.has(document.runId)
+    ) {
+      fail(
+        "corpus_duplicate",
+        `${entry.label} duplicates a run or export hash.`,
+      );
+    }
+    exportHashes.add(document.hashes.exportHash);
+    runIds.add(document.runId);
+    return Object.freeze({
+      ...entry,
+      exportPath,
+      document,
+    });
+  });
+  return Object.freeze({
+    collectedAt: manifest.collectedAt,
+    source: Object.freeze({ ...manifest.source }),
+    manifestPath: resolvedManifest,
+    entries: Object.freeze(entries),
+  });
+}
+
+function hasMaterialExplanation(report) {
+  const explanatoryKeys = [
+    "causal_paths",
+    "diff",
+    "findings",
+    "graph_explanation",
+    "topology",
+    "why",
+  ];
+  return explanatoryKeys.some((key) => Object.hasOwn(report, key));
+}
+
+export async function runActiveGraphCorpus({
+  manifestPath,
+  evidenceRoot,
+  sandboxImage,
+  imageAttestationPath,
+  sandboxExecutable = "docker",
+  baselineIterations = DEFAULT_BASELINE_ITERATIONS,
+  canaryRunner = runActiveGraphCanaryFromExport,
+  sourceEnvironment = process.env,
+}) {
+  if (
+    !Number.isSafeInteger(baselineIterations) ||
+    baselineIterations < 1 ||
+    baselineIterations > 100
+  ) {
+    fail("baseline_iterations_invalid", "baselineIterations must be 1-100.");
+  }
+  const corpus = loadActiveGraphCorpus(manifestPath);
+  const resolvedEvidenceRoot = resolve(evidenceRoot);
+  mkdirSync(resolvedEvidenceRoot, { recursive: true });
+  const runs = [];
+
+  for (const [index, entry] of corpus.entries.entries()) {
+    const baselineSamples = [];
+    for (let sample = 0; sample < baselineIterations; sample += 1) {
+      const started = performance.now();
+      assertCanonicalNodeKitRunExport(entry.document);
+      baselineSamples.push(performance.now() - started);
+    }
+    const canaryStarted = performance.now();
+    const result = await canaryRunner({
+      exportPath: entry.exportPath,
+      evidenceRoot: resolvedEvidenceRoot,
+      runDirectoryName: `${String(index + 1).padStart(2, "0")}-${entry.label}`,
+      sandboxExecutable,
+      sandboxImage,
+      imageAttestationPath,
+      sourceEnvironment,
+    });
+    const canaryMs = performance.now() - canaryStarted;
+    if (
+      result.report?.verdict !== "pass" ||
+      result.report?.persisted_reload_parity !== true
+    ) {
+      fail("canary_parity_failed", `${entry.label} failed replay parity.`);
+    }
+    runs.push({
+      label: entry.label,
+      workflowClass: entry.workflowClass,
+      terminalStatus: entry.terminalStatus,
+      runId: entry.document.runId,
+      exportHash: entry.document.hashes.exportHash,
+      chainHead: entry.document.hashes.chainHead,
+      eventCount: entry.document.events.length,
+      eventTypes: [
+        ...new Set(entry.document.events.map((event) => event.eventType)),
+      ],
+      baselineValidationMedianMs: median(baselineSamples),
+      activeGraphCanaryMs: canaryMs,
+      persistedReloadParity: true,
+      materialExplanationObserved: hasMaterialExplanation(result.report),
+      evidenceDirectory: relative(resolvedEvidenceRoot, result.runDirectory),
+    });
+  }
+
+  const baselineMedianMs = median(
+    runs.map((run) => run.baselineValidationMedianMs),
+  );
+  const activeGraphMedianMs = median(
+    runs.map((run) => run.activeGraphCanaryMs),
+  );
+  const latencyRatio =
+    baselineMedianMs === 0 ? null : activeGraphMedianMs / baselineMedianMs;
+  const allParity = runs.every((run) => run.persistedReloadParity);
+  const materialExplanationObserved = runs.some(
+    (run) => run.materialExplanationObserved,
+  );
+  const latencyWithinThreshold = latencyRatio !== null && latencyRatio <= 2;
+  const stopConditions = [
+    ...(allParity ? [] : ["persistence_reload_parity_failed"]),
+    ...(latencyWithinThreshold ? [] : ["median_latency_exceeded_2x"]),
+    ...(materialExplanationObserved ? [] : ["no_material_explanatory_value"]),
+  ];
+  const reportBody = {
+    schemaVersion: ACTIVEGRAPH_CORPUS_REPORT_SCHEMA,
+    collectedAt: corpus.collectedAt,
+    evaluatedAt: new Date().toISOString(),
+    source: corpus.source,
+    corpusSize: runs.length,
+    allExportsComplete: true,
+    allPersistenceReloadParity: allParity,
+    baselineValidationMedianMs: baselineMedianMs,
+    activeGraphCanaryMedianMs: activeGraphMedianMs,
+    latencyRatio,
+    latencyThreshold: 2,
+    materialExplanatoryValueObserved: materialExplanationObserved,
+    stopConditions,
+    adoptionVerdict:
+      stopConditions.length === 0 ? "eligible-for-adr" : "reject",
+    authority:
+      "offline evaluation evidence only; cannot answer, approve, mutate, schedule, or replace NodeBench state",
+    limitations: [
+      "Gateway-injected ownership is enforced by NodeBench, not cryptographically signed into each exported file.",
+      "The baseline is canonical NodeKit validation; it does not include an alternative graph database.",
+      "A reject verdict closes this adoption experiment but does not delete the offline canary.",
+    ],
+    runs,
+  };
+  const report = {
+    ...reportBody,
+    reportHash: sha256(canonicalJson(reportBody)),
+  };
+  writeFileSync(
+    resolve(resolvedEvidenceRoot, "corpus-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+    { encoding: "utf8", flag: "wx" },
+  );
+  return Object.freeze(report);
+}
+
+function parseCliArgs(argv) {
+  const result = {};
+  const allowed = new Set([
+    "manifest",
+    "evidence-root",
+    "sandbox-image",
+    "image-attestation",
+    "docker",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      fail("cli_args_invalid", "CLI arguments must be --key value pairs.");
+    }
+    const name = key.slice(2);
+    if (!allowed.has(name) || name in result) {
+      fail("cli_args_invalid", `Unknown or duplicate CLI argument: --${name}.`);
+    }
+    result[name] = value;
+  }
+  for (const required of [
+    "manifest",
+    "evidence-root",
+    "sandbox-image",
+    "image-attestation",
+  ]) {
+    if (!result[required]) {
+      fail("cli_args_invalid", `--${required} is required.`);
+    }
+  }
+  return result;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    const args = parseCliArgs(process.argv.slice(2));
+    const report = await runActiveGraphCorpus({
+      manifestPath: args.manifest,
+      evidenceRoot: args["evidence-root"],
+      sandboxImage: args["sandbox-image"],
+      imageAttestationPath: args["image-attestation"],
+      sandboxExecutable: args.docker ?? "docker",
+    });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## What changed

- adds a secret-gated, gateway-owner-injected canonical NodeKit run export endpoint
- keeps the export query read-only, owner-scoped, and outside the anonymous public-research surface
- adds a fixed 20-scenario production corpus collector spanning context, decision, build, check, review, browser, agent-eval, aggregate, repair, delivery, human-gate, barrier, and fail-safe traces
- terminalizes partially created traces when collection fails
- adds a bounded offline corpus runner that rejects undersized, duplicate, escaped, symlinked, oversized, incomplete, or non-canonical inputs
- applies the original persistence parity, 2x latency, and material explanatory-value stop rules without biasing toward ActiveGraph adoption
- documents that ActiveGraph remains offline, advisory, and non-authoritative

## Root cause

The existing ActiveGraph canary had a safe single-export boundary, but Gate 3b remained deferred because there was no repeatable way to obtain a representative owner-authorized corpus through the service boundary or evaluate the complete corpus without manual cherry-picking.

## Validation

- 54 targeted ActiveGraph/export/gateway tests passed; 8 optional convex-test cases skipped in this local environment
- `npx tsc -p backend/convex --noEmit --pretty false`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`

## After merge

CI should deploy the additive Convex query and gateway allowlist entry. The follow-up operational proof will collect 20 private service-owner exports from production, rebuild/attest the pinned offline image against the merged commit, replay every export with Docker networking disabled, and record the resulting pass/reject corpus report. No ActiveGraph production bridge or application authority is introduced.
