### PR TITLE
refactor(nodekit): retire legacy native identity fields

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -66,8 +66,9 @@ Server Error) for an unknown slug.
   `scripts/nodekit/*ActiveGraph*` · migrate the obsolete combined
   native-session snapshot/generation contract to Caseflow-canonical
   workspace/session/checkpoint artifact refs and digests while preserving the
-  offline, non-authoritative ActiveGraph boundary · branch
-  `codex/nodekit-native-canonical-artifacts`.
+  offline, non-authoritative ActiveGraph boundary; phase-one migration is
+  production-verified at zero legacy matches and phase two is retiring the
+  emptied schema fields · branch `refactor/nodekit-retire-native-identity`.
 
 - **2026-07-29 · Codex `/root` →** `backend/convex/domains/operations/taskManager/nodeKitRunExport.ts`,
   `backend/convex/domains/mcp/mcpExecutionTraceEndpoints.ts`,

--- a/CHANGELOG/integrations/nodekit-stage-local-runtime.md
+++ b/CHANGELOG/integrations/nodekit-stage-local-runtime.md
@@ -18,6 +18,17 @@ and native lifecycle fields before their schema fields are retired. ActiveGraph
 remains a disposable offline observer and receives only the verified terminal
 export.
 
+**Phase-one production evidence**:
+
+- PR #609 merged as `0819733518e6ea2aaa0208ea15229fb2c24b64f8`.
+- Convex Deploy run `30540283599` passed for that exact merge commit.
+- The full production dry-run scanned 152 sessions, 37 traces, and 22 identity
+  rows; it matched 24, 24, and 22 legacy records respectively.
+- Apply patched those same 70 records without deleting rows.
+- A complete post-apply scan returned zero matches in all three tables.
+- Phase two removes the now-empty legacy schema fields; the internal migration
+  remains non-public maintenance code.
+
 ## 2026-07-29 — Bind NodeBench traces to NodeKit's current-stage graph
 
 The shipped integration adds an owner/workspace-scoped native-agent session

--- a/backend/convex/schema.ts
+++ b/backend/convex/schema.ts
@@ -12850,18 +12850,6 @@ export default defineSchema({
     agentRunId: v.optional(v.id("agentRuns")),
     agentThreadId: v.optional(v.string()),
     swarmId: v.optional(v.string()),
-    nativeIdentity: v.optional(
-      v.object({
-        schemaVersion: v.literal("nodekit.native-agent-session-identity/v1"),
-        identityRef: v.string(),
-        agentId: v.string(),
-        workspaceId: v.string(),
-        nativeSessionId: v.string(),
-        nativeSessionGeneration: v.number(),
-        peerId: v.optional(v.string()),
-        snapshotHash: v.string(),
-      }),
-    ),
     nativeSessionReference: v.optional(
       v.object({
         schemaVersion: v.literal("nodekit.native-session-reference/v1"),
@@ -12954,18 +12942,6 @@ export default defineSchema({
     ),
     estimatedCostUsd: v.optional(v.number()),
     model: v.optional(v.string()),
-    nativeIdentity: v.optional(
-      v.object({
-        schemaVersion: v.literal("nodekit.native-agent-session-identity/v1"),
-        identityRef: v.string(),
-        agentId: v.string(),
-        workspaceId: v.string(),
-        nativeSessionId: v.string(),
-        nativeSessionGeneration: v.number(),
-        peerId: v.optional(v.string()),
-        snapshotHash: v.string(),
-      }),
-    ),
     nativeSessionReference: v.optional(
       v.object({
         schemaVersion: v.literal("nodekit.native-session-reference/v1"),
@@ -14519,13 +14495,6 @@ export default defineSchema({
     agentId: v.string(),
     ownerUserId: v.optional(v.id("users")),
     workspaceId: v.optional(v.string()),
-    identityContractVersion: v.optional(
-      v.literal("nodekit.native-agent-session-identity/v1"),
-    ),
-    nativeSessionId: v.optional(v.string()),
-    nativeSessionGeneration: v.optional(v.number()),
-    nativePeerId: v.optional(v.string()),
-    nativeIdentitySnapshotHash: v.optional(v.string()),
     lastSeenAt: v.optional(v.number()),
     name: v.string(),
     persona: v.string(),


### PR DESCRIPTION
## Decision

Retire the legacy combined native-identity schema after the bounded production
migration completed and a full verification scan found zero remaining records.

## Production migration evidence

- Phase-one merge: `0819733518e6ea2aaa0208ea15229fb2c24b64f8`
- Convex Deploy: `30540283599`
- Dry run: 24 session snapshots, 24 trace snapshots, 22 identity lifecycle rows
- Apply: all 70 matched rows patched in place; no rows deleted
- Verify: zero matches across 152 sessions, 37 traces, and 22 identity rows

## Verification

- root TypeScript typecheck
- Convex TypeScript typecheck
- 56 focused scenarios passed; 6 database integration scenarios remain skipped
  locally because `convex-test` is unavailable
- production build passed
- legacy identifiers remain only in the internal migration and its tests
